### PR TITLE
feat(hooks): replace createContext with HookContextBuilder

### DIFF
--- a/__tests__/hooks/hook.spec.ts
+++ b/__tests__/hooks/hook.spec.ts
@@ -3,6 +3,7 @@ import {
   AddOnDisposeHookModule,
   bindTo,
   Container,
+  DefaultHookContextBuilder,
   GroupAliasToken,
   hasHooks,
   hook,
@@ -53,10 +54,8 @@ describe('hooks', () => {
 
     beforeHooksRunner.execute(instance, {
       scope: root,
-      createContext: (Target, scope, methodName) =>
-        new HookContext(Target, scope, methodName).setInitialArgs('initial'),
+      contextBuilder: new DefaultHookContextBuilder().appendArgs('initial'),
     });
-
     expect(instance.receivedArgs).toEqual(['initial', 'injected']);
   });
 

--- a/lib/hooks/HookContext.ts
+++ b/lib/hooks/HookContext.ts
@@ -53,7 +53,3 @@ export class HookContext implements IHookContext {
     return this;
   }
 }
-
-export type CreateHookContext = (Target: object, scope: IContainer, methodName?: string) => IHookContext;
-export const createHookContext: CreateHookContext = (Target, scope, methodName = 'constructor') =>
-  new HookContext(Target, scope, methodName);

--- a/lib/hooks/HookContextBuilder.ts
+++ b/lib/hooks/HookContextBuilder.ts
@@ -1,0 +1,34 @@
+import type { IContainer } from '../container/IContainer';
+import { HookContext, IHookContext } from './HookContext';
+
+export type HookContextBuilderOptions = { target: object; scope: IContainer; methodName: string };
+
+export interface IHookContextBuilder {
+  mergeOptions(context: Partial<HookContextBuilderOptions>): void;
+  build(context: Partial<HookContextBuilderOptions>): IHookContext;
+  appendArgs(...args: unknown[]): this;
+}
+
+export class DefaultHookContextBuilder implements IHookContextBuilder {
+  private options: Partial<HookContextBuilderOptions> = {};
+  private initialArgs: unknown[] = [];
+
+  build(context: Partial<HookContextBuilderOptions>): IHookContext {
+    const target = context.target ?? this.options.target;
+    const scope = context.scope ?? this.options.scope;
+    const methodName = context.methodName ?? context.methodName;
+    return new HookContext(target!, scope!, methodName).setInitialArgs(...this.initialArgs);
+  }
+
+  mergeOptions(context: Partial<HookContextBuilderOptions>): void {
+    this.options = {
+      ...this.options,
+      ...context,
+    };
+  }
+
+  appendArgs(...args: unknown[]): this {
+    this.initialArgs.push(...args);
+    return this;
+  }
+}

--- a/lib/hooks/HooksRunner.ts
+++ b/lib/hooks/HooksRunner.ts
@@ -1,24 +1,28 @@
-import { createHookContext, type CreateHookContext } from './HookContext';
 import type { IContainer } from '../container/IContainer';
 import { getHooks, HookFn, toHookFn } from './hook';
 import { UnexpectedHookResultError } from '../errors/UnexpectedHookResultError';
 
 import { promisify } from '../utils/promise';
+import { DefaultHookContextBuilder, IHookContextBuilder } from './HookContextBuilder';
 
 export type HooksRunnerContext = {
   scope: IContainer;
-  createContext?: CreateHookContext;
+  contextBuilder?: IHookContextBuilder;
   predicate?: (methodName: string) => boolean;
 };
 
 export class HooksRunner {
   constructor(private readonly key: string | symbol) {}
 
-  execute(target: object, { scope, createContext = createHookContext, predicate = () => true }: HooksRunnerContext) {
+  execute(
+    target: object,
+    { scope, contextBuilder = new DefaultHookContextBuilder(), predicate = () => true }: HooksRunnerContext,
+  ) {
     const hooks = Array.from(getHooks(target, this.key).entries()).filter(([methodName]) => predicate(methodName));
+    contextBuilder.mergeOptions({ target, scope });
 
     const runMethodHooks = (methodName: string, executions: HookFn[]) => {
-      const context = createContext(target, scope, methodName);
+      const context = contextBuilder.build({ methodName });
       for (const execute of executions) {
         const result = execute(context);
         if (result instanceof Promise) {
@@ -34,20 +38,13 @@ export class HooksRunner {
 
   async executeAsync(
     target: object,
-    {
-      scope,
-      createContext = createHookContext,
-      predicate = () => true,
-    }: {
-      scope: IContainer;
-      createContext?: typeof createHookContext;
-      predicate?: (methodName: string) => boolean;
-    },
+    { scope, contextBuilder = new DefaultHookContextBuilder(), predicate = () => true }: HooksRunnerContext,
   ) {
     const hooks = Array.from(getHooks(target, this.key).entries()).filter(([methodName]) => predicate(methodName));
+    contextBuilder.mergeOptions({ target, scope });
 
     const runMethodHooks = async (methodName: string, executions: HookFn[]) => {
-      const context = createContext(target, scope, methodName);
+      const context = contextBuilder.build({ methodName });
       for (const execute of executions) {
         await promisify(execute(context));
       }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -86,3 +86,4 @@ export { methodMeta, getMethodMeta, methodLabel, getMethodLabels, methodTag, get
 export { select } from './select';
 export { pipe, type MapFn } from './utils/fp';
 export { type constructor, type Instance, Is, resolveConstructor } from './utils/basic';
+export { type IHookContextBuilder, DefaultHookContextBuilder } from './hooks/HookContextBuilder';


### PR DESCRIPTION
Closes #58

Replaces the `createContext` callback in `HooksRunnerContext` with a `contextBuilder` (`IHookContextBuilder`) for a more composable API.