### PR TITLE
fix(hooks): run hooks declared on parent (extended-from) classes

### DIFF
--- a/__tests__/hooks/hook.spec.ts
+++ b/__tests__/hooks/hook.spec.ts
@@ -89,6 +89,91 @@ describe('hooks', () => {
     expect(hasHooks(instance, 'onStart')).toBe(true);
   });
 
+  it('should run hooks declared on a parent (extended-from) class', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+
+    class Base {
+      baseStarted = false;
+
+      @hook('onStart', execute)
+      startBase() {
+        this.baseStarted = true;
+      }
+    }
+
+    class Derived extends Base {
+      derivedStarted = false;
+
+      @hook('onStart', execute)
+      startDerived() {
+        this.derivedStarted = true;
+      }
+    }
+
+    const root = new Container({ tags: ['root'] });
+    const instance = root.resolve(Derived);
+
+    onStartHooksRunner.execute(instance, { scope: root });
+
+    expect(instance.baseStarted).toBe(true);
+    expect(instance.derivedStarted).toBe(true);
+  });
+
+  it('should run parent hooks before child hooks', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+    const invoked: string[] = [];
+
+    class Base {
+      @hook('onStart', (ctx) => {
+        invoked.push('startBase');
+        ctx.invokeMethod();
+      })
+      startBase() {}
+    }
+
+    class Derived extends Base {
+      @hook('onStart', (ctx) => {
+        invoked.push('startDerived');
+        ctx.invokeMethod();
+      })
+      startDerived() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+
+    onStartHooksRunner.execute(root.resolve(Derived), { scope: root });
+
+    expect(invoked).toEqual(['startBase', 'startDerived']);
+  });
+
+  it('should not leak child hooks into parent instances', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+    const invoked: string[] = [];
+
+    class Base {
+      @hook('onStart', (ctx) => {
+        invoked.push('startBase');
+        ctx.invokeMethod();
+      })
+      startBase() {}
+    }
+
+    class Derived extends Base {
+      @hook('onStart', (ctx) => {
+        invoked.push('startDerived');
+        ctx.invokeMethod();
+      })
+      startDerived() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+
+    onStartHooksRunner.execute(root.resolve(Base), { scope: root });
+
+    expect(invoked).toEqual(['startBase']);
+    expect(Derived).toBeDefined();
+  });
+
   it('should execute plugin hooks for lazily injected plugins', () => {
     const onPluginStartHooksRunner = new HooksRunner('onPluginStart');
     const PluginToken = new GroupAliasToken<Plugin>('Plugin');

--- a/lib/hooks/hook.ts
+++ b/lib/hooks/hook.ts
@@ -30,25 +30,45 @@ const getReflectionTarget = (target: object) => {
   return isProxy(target) ? getProxyTarget(target) : target;
 };
 
-// Get hooks metadata
+// Walk the constructor's prototype chain (most-derived first) collecting each class.
+const getConstructorChain = (ctor: unknown): object[] => {
+  const chain: object[] = [];
+  let current = ctor;
+  while (typeof current === 'function' && current !== Function.prototype) {
+    chain.push(current);
+    current = Object.getPrototypeOf(current);
+  }
+  return chain;
+};
+
+// Get hooks metadata, merging hooks declared on parent (extended-from) classes.
+// Hooks are collected from base to derived so a derived class's hooks for the same
+// method name take precedence over (replace) the parent's.
 export function getHooks(target: object, key: string | symbol): HooksOfClass {
   const reflectionTarget = getReflectionTarget(target);
-  return Reflect.hasMetadata(key, reflectionTarget.constructor)
-    ? Reflect.getMetadata(key, reflectionTarget.constructor)
-    : new Map();
+  const merged: HooksOfClass = new Map();
+  for (const ctor of getConstructorChain(reflectionTarget.constructor).reverse()) {
+    const ownHooks: HooksOfClass | undefined = Reflect.getOwnMetadata(key, ctor);
+    if (ownHooks) {
+      for (const [methodName, fns] of ownHooks) {
+        merged.set(methodName, fns);
+      }
+    }
+  }
+  return merged;
 }
 
 export function hasHooks(target: object, key: string | symbol): boolean {
   const reflectionTarget = getReflectionTarget(target);
-  return Reflect.hasMetadata(key, reflectionTarget.constructor);
+  return getConstructorChain(reflectionTarget.constructor).some((ctor) => Reflect.hasOwnMetadata(key, ctor));
 }
 
 // Hook decorator
 export const hook =
   (key: string | symbol, ...fns: (HookFn | constructor<HookClass>)[]) =>
   (target: object, propertyKey: string | symbol) => {
-    const hooks: HooksOfClass = Reflect.hasMetadata(key, target.constructor)
-      ? Reflect.getMetadata(key, target.constructor)
+    const hooks: HooksOfClass = Reflect.hasOwnMetadata(key, target.constructor)
+      ? Reflect.getOwnMetadata(key, target.constructor)
       : new Map();
     hooks.set(propertyKey as string, (hooks.get(propertyKey as string) ?? []).concat(fns));
     Reflect.defineMetadata(key, hooks, target.constructor);


### PR DESCRIPTION
`HooksRunner` previously only ran hooks declared on the most-derived class: `getHooks` returned a single metadata map and the `@hook` decorator chain-walked `Reflect.getMetadata`, causing a child class to mutate its parent's hook map (so parent instances could try to invoke child-only methods). This change collects each class's *own* hook metadata across the constructor prototype chain and merges it base→derived, so parent hooks now run (before child hooks) and child hooks no longer leak into parent instances. Added tests covering parent-hook execution, parent-before-child ordering, and the no-leak guarantee. All 314 tests and type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)