### PR TITLE
feat(container): add getScopeByInstanceOrFail to locate the owning scope

### DIFF
--- a/__tests__/container/IContainer.spec.ts
+++ b/__tests__/container/IContainer.spec.ts
@@ -3,6 +3,7 @@ import {
   appendArgs,
   bindTo,
   Container,
+  ContainerNotFoundError,
   type IContainer,
   Provider,
   register,
@@ -65,5 +66,42 @@ describe('IContainer', function () {
 
     const instance = ILoggerToken.resolve(child1);
     expect(instance).toBe(ILoggerGroupToken.resolve(child1)[0]);
+  });
+
+  describe('getScopeByInstanceOrFail', () => {
+    class FileLogger {}
+
+    it('should return the scope that owns the instance', () => {
+      const root = new Container({ tags: ['root'] });
+      const child = root.createScope({ tags: ['child'] });
+
+      const logger = child.resolve(FileLogger);
+
+      expect(root.getScopeByInstanceOrFail(logger)).toBe(child);
+    });
+
+    it('should return itself when it owns the instance', () => {
+      const root = new Container({ tags: ['root'] });
+
+      const logger = root.resolve(FileLogger);
+
+      expect(root.getScopeByInstanceOrFail(logger)).toBe(root);
+    });
+
+    it('should find the instance in a deeply nested scope', () => {
+      const root = new Container({ tags: ['root'] });
+      const child = root.createScope({ tags: ['child'] });
+      const grandChild = child.createScope({ tags: ['grandChild'] });
+
+      const logger = grandChild.resolve(FileLogger);
+
+      expect(root.getScopeByInstanceOrFail(logger)).toBe(grandChild);
+    });
+
+    it('should throw ContainerNotFoundError when no scope owns the instance', () => {
+      const root = new Container({ tags: ['root'] });
+
+      expect(() => root.getScopeByInstanceOrFail(new FileLogger())).toThrow(ContainerNotFoundError);
+    });
   });
 });

--- a/__tests__/container/IContainer.spec.ts
+++ b/__tests__/container/IContainer.spec.ts
@@ -68,6 +68,34 @@ describe('IContainer', function () {
     expect(instance).toBe(ILoggerGroupToken.resolve(child1)[0]);
   });
 
+  describe('hasInstance', () => {
+    class FileLogger {}
+
+    it('should return true for an instance the scope owns', () => {
+      const root = new Container({ tags: ['root'] });
+
+      const logger = root.resolve(FileLogger);
+
+      expect(root.hasInstance(logger)).toBe(true);
+    });
+
+    it('should return false for an instance owned by another scope', () => {
+      const root = new Container({ tags: ['root'] });
+      const child = root.createScope({ tags: ['child'] });
+
+      const logger = child.resolve(FileLogger);
+
+      expect(root.hasInstance(logger)).toBe(false);
+      expect(child.hasInstance(logger)).toBe(true);
+    });
+
+    it('should return false for an unknown instance', () => {
+      const root = new Container({ tags: ['root'] });
+
+      expect(root.hasInstance(new FileLogger())).toBe(false);
+    });
+  });
+
   describe('getScopeByInstanceOrFail', () => {
     class FileLogger {}
 

--- a/lib/container/Container.ts
+++ b/lib/container/Container.ts
@@ -184,10 +184,14 @@ export class Container implements IContainer {
     return [...this.scopes];
   }
 
+  hasInstance(instance: object): boolean {
+    return this.instances.includes(instance as Instance);
+  }
+
   getScopeByInstanceOrFail(instance: object): IContainer {
     this.validateContainer();
 
-    if (this.instances.includes(instance as Instance)) {
+    if (this.hasInstance(instance)) {
       return this;
     }
 
@@ -246,7 +250,7 @@ export class Container implements IContainer {
 }
 
 function findScopeByInstance(container: IContainer, instance: object): IContainer | undefined {
-  if (container.getInstances(false).includes(instance as Instance)) {
+  if (container.hasInstance(instance)) {
     return container;
   }
 

--- a/lib/container/Container.ts
+++ b/lib/container/Container.ts
@@ -16,6 +16,7 @@ import { ContainerDisposedError } from '../errors/ContainerDisposedError';
 import { MetadataInjector } from '../injector/MetadataInjector';
 import { AliasMap } from './AliasMap';
 import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
+import { ContainerNotFoundError } from '../errors/ContainerNotFoundError';
 import { OnConstructHook } from '../hooks/onConstruct';
 import { OnDisposeHook } from '../hooks/onDispose';
 import { constructor, Instance, Is } from '../utils/basic';
@@ -183,6 +184,23 @@ export class Container implements IContainer {
     return [...this.scopes];
   }
 
+  getScopeByInstanceOrFail(instance: object): IContainer {
+    this.validateContainer();
+
+    if (this.instances.includes(instance as Instance)) {
+      return this;
+    }
+
+    for (const scope of this.scopes) {
+      const found = findScopeByInstance(scope, instance);
+      if (found) {
+        return found;
+      }
+    }
+
+    throw new ContainerNotFoundError('Cannot find scope for the given instance');
+  }
+
   removeScope(child: IContainer): void {
     this.scopes = this.scopes.filter((s) => s !== child);
   }
@@ -225,4 +243,19 @@ export class Container implements IContainer {
     }
     return this.providers.get(key)!;
   }
+}
+
+function findScopeByInstance(container: IContainer, instance: object): IContainer | undefined {
+  if (container.getInstances(false).includes(instance as Instance)) {
+    return container;
+  }
+
+  for (const scope of container.getScopes()) {
+    const found = findScopeByInstance(scope, instance);
+    if (found) {
+      return found;
+    }
+  }
+
+  return undefined;
 }

--- a/lib/container/Container.ts
+++ b/lib/container/Container.ts
@@ -191,15 +191,13 @@ export class Container implements IContainer {
   getScopeByInstanceOrFail(instance: object): IContainer {
     this.validateContainer();
 
-    if (this.hasInstance(instance)) {
-      return this;
-    }
-
-    for (const scope of this.scopes) {
-      const found = findScopeByInstance(scope, instance);
-      if (found) {
-        return found;
+    const queue: IContainer[] = [this];
+    while (queue.length > 0) {
+      const scope = queue.shift()!;
+      if (scope.hasInstance(instance)) {
+        return scope;
       }
+      queue.push(...scope.getScopes());
     }
 
     throw new ContainerNotFoundError('Cannot find scope for the given instance');
@@ -247,19 +245,4 @@ export class Container implements IContainer {
     }
     return this.providers.get(key)!;
   }
-}
-
-function findScopeByInstance(container: IContainer, instance: object): IContainer | undefined {
-  if (container.hasInstance(instance)) {
-    return container;
-  }
-
-  for (const scope of container.getScopes()) {
-    const found = findScopeByInstance(scope, instance);
-    if (found) {
-      return found;
-    }
-  }
-
-  return undefined;
 }

--- a/lib/container/EmptyContainer.ts
+++ b/lib/container/EmptyContainer.ts
@@ -38,6 +38,10 @@ export class EmptyContainer implements IContainer {
     return [];
   }
 
+  hasInstance(instance: object): boolean {
+    return false;
+  }
+
   createScope(): IContainer {
     throw new MethodNotImplementedError();
   }

--- a/lib/container/EmptyContainer.ts
+++ b/lib/container/EmptyContainer.ts
@@ -8,6 +8,7 @@ import {
 } from './IContainer';
 import { MethodNotImplementedError } from '../errors/MethodNotImplementedError';
 import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
+import { ContainerNotFoundError } from '../errors/ContainerNotFoundError';
 import { type IProvider } from '../provider/IProvider';
 import { type IRegistration } from '../registration/IRegistration';
 import { OnDisposeHook } from '../hooks/onDispose';
@@ -27,6 +28,10 @@ export class EmptyContainer implements IContainer {
 
   getScopes() {
     return [];
+  }
+
+  getScopeByInstanceOrFail(instance: object): IContainer {
+    throw new ContainerNotFoundError('Cannot find scope for the given instance');
   }
 
   getInstances() {

--- a/lib/container/IContainer.ts
+++ b/lib/container/IContainer.ts
@@ -65,6 +65,8 @@ export interface IContainer extends Tagged {
 
   getInstances(cascade?: boolean): Instance[];
 
+  hasInstance(instance: object): boolean;
+
   dispose(): void;
 
   addInstance(instance: Instance): void;

--- a/lib/container/IContainer.ts
+++ b/lib/container/IContainer.ts
@@ -55,6 +55,8 @@ export interface IContainer extends Tagged {
 
   getScopes(): IContainer[];
 
+  getScopeByInstanceOrFail(instance: object): IContainer;
+
   removeScope(child: IContainer): void;
 
   useModule(module: IContainerModule): this;

--- a/lib/errors/ContainerNotFoundError.ts
+++ b/lib/errors/ContainerNotFoundError.ts
@@ -1,0 +1,11 @@
+import { ContainerError } from './ContainerError';
+
+export class ContainerNotFoundError extends ContainerError {
+  name = 'ContainerNotFoundError';
+
+  constructor(message: string) {
+    super(message);
+
+    Object.setPrototypeOf(this, ContainerNotFoundError.prototype);
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -52,6 +52,7 @@ export { Registration } from './registration/Registration';
 
 // Errors
 export { DependencyNotFoundError } from './errors/DependencyNotFoundError';
+export { ContainerNotFoundError } from './errors/ContainerNotFoundError';
 export { DependencyMissingKeyError } from './errors/DependencyMissingKeyError';
 export { MethodNotImplementedError } from './errors/MethodNotImplementedError';
 export { ContainerDisposedError } from './errors/ContainerDisposedError';


### PR DESCRIPTION
Adds `IContainer.getScopeByInstanceOrFail(instance: object): IContainer`, which walks the container subtree (self then descendant scopes) to find the scope that owns a given resolved instance. When no scope owns the instance it throws the new `ContainerNotFoundError` (exported from the public API and implemented by `EmptyContainer` as the chain terminator). Covered by BDD specs for self-owned, child-scope, deeply nested, and not-found cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)