### PR TITLE
refactor(metadata): rename metadata decorators with add prefix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,10 @@ EntityManagerToken.args(UserRepositoryToken).resolve(container);
 - Backend: `application`, `request`, `transaction`
 - Frontend: `application`, `page`, `widget`
 
+## Git Conventions
+
+- **The main branch is `main`, not `master`.** Target `main` as the base for pull requests.
+
 ## Commit Message Conventions
 
 ### Scopes that prevent package releases (use these when no API change)

--- a/__tests__/metadata/class.spec.ts
+++ b/__tests__/metadata/class.spec.ts
@@ -1,15 +1,15 @@
-import { classLabel, getClassLabels, classTag, getClassTags, getClassMeta, classMeta } from '../../lib';
+import { addClassLabel, getClassLabels, addClassTag, getClassTags, getClassMeta, addClassMeta } from '../../lib';
 
 describe('getClassMeta', () => {
   it('should resolve metadata from a constructor', () => {
-    @classMeta('role', () => 'service')
+    @addClassMeta('role', () => 'service')
     class MyService {}
 
     expect(getClassMeta(MyService, 'role')).toBe('service');
   });
 
   it('should resolve metadata from an instance', () => {
-    @classMeta('role', () => 'service')
+    @addClassMeta('role', () => 'service')
     class MyService {}
 
     expect(getClassMeta(new MyService(), 'role')).toBe('service');
@@ -23,9 +23,9 @@ describe('getClassMeta', () => {
 });
 
 describe('class metadata', () => {
-  describe('classLabel / getClassLabels', () => {
+  describe('addClassLabel / getClassLabels', () => {
     it('should add a label and retrieve it', () => {
-      @classLabel('env', 'production')
+      @addClassLabel('env', 'production')
       class MyService {}
 
       const labels = getClassLabels(MyService);
@@ -33,8 +33,8 @@ describe('class metadata', () => {
     });
 
     it('should support multiple labels', () => {
-      @classLabel('region', 'us-east')
-      @classLabel('env', 'staging')
+      @addClassLabel('region', 'us-east')
+      @addClassLabel('env', 'staging')
       class MyService {}
 
       const labels = getClassLabels(MyService);
@@ -49,15 +49,15 @@ describe('class metadata', () => {
     });
 
     it('should retrieve labels from an instance', () => {
-      @classLabel('env', 'production')
+      @addClassLabel('env', 'production')
       class MyService {}
 
       expect(getClassLabels(new MyService()).get('env')).toBe('production');
     });
 
     it('should overwrite label with same key', () => {
-      @classLabel('env', 'production')
-      @classLabel('env', 'staging')
+      @addClassLabel('env', 'production')
+      @addClassLabel('env', 'staging')
       class MyService {}
 
       const labels = getClassLabels(MyService);
@@ -65,17 +65,17 @@ describe('class metadata', () => {
     });
   });
 
-  describe('classTag / getTags', () => {
+  describe('addClassTag / getTags', () => {
     it('should add a tag and retrieve it', () => {
-      @classTag('singleton')
+      @addClassTag('singleton')
       class MyService {}
 
       expect(getClassTags(MyService).has('singleton')).toBe(true);
     });
 
     it('should support multiple tags', () => {
-      @classTag('singleton')
-      @classTag('service')
+      @addClassTag('singleton')
+      @addClassTag('service')
       class MyService {}
 
       const tags = getClassTags(MyService);
@@ -90,15 +90,15 @@ describe('class metadata', () => {
     });
 
     it('should retrieve tags from an instance', () => {
-      @classTag('singleton')
+      @addClassTag('singleton')
       class MyService {}
 
       expect(getClassTags(new MyService()).has('singleton')).toBe(true);
     });
 
     it('should not duplicate tags', () => {
-      @classTag('singleton')
-      @classTag('singleton')
+      @addClassTag('singleton')
+      @addClassTag('singleton')
       class MyService {}
 
       expect(getClassTags(MyService).size).toBe(1);

--- a/__tests__/metadata/method.spec.ts
+++ b/__tests__/metadata/method.spec.ts
@@ -1,10 +1,10 @@
-import { methodLabel, getMethodLabels, methodTag, getMethodTags } from '../../lib';
+import { addMethodLabel, getMethodLabels, addMethodTag, getMethodTags } from '../../lib';
 
 describe('method metadata', () => {
-  describe('methodLabel / getMethodLabels', () => {
+  describe('addMethodLabel / getMethodLabels', () => {
     it('should add a label and retrieve it by constructor', () => {
       class MyService {
-        @methodLabel('env', 'production')
+        @addMethodLabel('env', 'production')
         start() {}
       }
 
@@ -13,7 +13,7 @@ describe('method metadata', () => {
 
     it('should add a label and retrieve it by instance', () => {
       class MyService {
-        @methodLabel('env', 'production')
+        @addMethodLabel('env', 'production')
         start() {}
       }
 
@@ -22,8 +22,8 @@ describe('method metadata', () => {
 
     it('should support multiple labels on the same method', () => {
       class MyService {
-        @methodLabel('region', 'us-east')
-        @methodLabel('env', 'staging')
+        @addMethodLabel('region', 'us-east')
+        @addMethodLabel('env', 'staging')
         start() {}
       }
 
@@ -42,7 +42,7 @@ describe('method metadata', () => {
 
     it('should not bleed across methods', () => {
       class MyService {
-        @methodLabel('env', 'production')
+        @addMethodLabel('env', 'production')
         start() {}
         stop() {}
       }
@@ -51,10 +51,10 @@ describe('method metadata', () => {
     });
   });
 
-  describe('methodTag / getMethodTags', () => {
+  describe('addMethodTag / getMethodTags', () => {
     it('should add a tag and retrieve it by constructor', () => {
       class MyService {
-        @methodTag('deprecated')
+        @addMethodTag('deprecated')
         start() {}
       }
 
@@ -63,7 +63,7 @@ describe('method metadata', () => {
 
     it('should add a tag and retrieve it by instance', () => {
       class MyService {
-        @methodTag('deprecated')
+        @addMethodTag('deprecated')
         start() {}
       }
 
@@ -72,8 +72,8 @@ describe('method metadata', () => {
 
     it('should support multiple tags', () => {
       class MyService {
-        @methodTag('deprecated')
-        @methodTag('public')
+        @addMethodTag('deprecated')
+        @addMethodTag('public')
         start() {}
       }
 
@@ -92,8 +92,8 @@ describe('method metadata', () => {
 
     it('should not duplicate tags', () => {
       class MyService {
-        @methodTag('deprecated')
-        @methodTag('deprecated')
+        @addMethodTag('deprecated')
+        @addMethodTag('deprecated')
         start() {}
       }
 
@@ -102,7 +102,7 @@ describe('method metadata', () => {
 
     it('should not bleed across methods', () => {
       class MyService {
-        @methodTag('deprecated')
+        @addMethodTag('deprecated')
         start() {}
         stop() {}
       }

--- a/__tests__/metadata/parameter.spec.ts
+++ b/__tests__/metadata/parameter.spec.ts
@@ -1,9 +1,9 @@
-import { paramLabel, getParamLabels, paramTag, getParamTags, getParamMeta, paramMeta } from '../../lib';
+import { addParamLabel, getParamLabels, addParamTag, getParamTags, getParamMeta, addParamMeta } from '../../lib';
 
 describe('getParamMeta', () => {
   it('should resolve metadata from a constructor', () => {
     class MyService {
-      constructor(@paramMeta('role', () => 'db') _db: unknown) {}
+      constructor(@addParamMeta('role', () => 'db') _db: unknown) {}
     }
 
     expect(getParamMeta('role', MyService)[0]).toBe('db');
@@ -11,7 +11,7 @@ describe('getParamMeta', () => {
 
   it('should resolve metadata from an instance', () => {
     class MyService {
-      constructor(@paramMeta('role', () => 'db') _db: unknown) {}
+      constructor(@addParamMeta('role', () => 'db') _db: unknown) {}
     }
 
     expect(getParamMeta('role', new MyService(null))[0]).toBe('db');
@@ -27,10 +27,10 @@ describe('getParamMeta', () => {
 });
 
 describe('parameter metadata', () => {
-  describe('paramLabel / getParamLabels', () => {
+  describe('addParamLabel / getParamLabels', () => {
     it('should add a label and retrieve it by constructor', () => {
       class MyService {
-        constructor(@paramLabel('env', 'production') _db: unknown) {}
+        constructor(@addParamLabel('env', 'production') _db: unknown) {}
       }
 
       expect(getParamLabels(MyService, 0).get('env')).toBe('production');
@@ -38,7 +38,7 @@ describe('parameter metadata', () => {
 
     it('should add a label and retrieve it by instance', () => {
       class MyService {
-        constructor(@paramLabel('env', 'production') _db: unknown) {}
+        constructor(@addParamLabel('env', 'production') _db: unknown) {}
       }
 
       expect(getParamLabels(new MyService(null), 0).get('env')).toBe('production');
@@ -47,8 +47,8 @@ describe('parameter metadata', () => {
     it('should support multiple labels on the same parameter', () => {
       class MyService {
         constructor(
-          @paramLabel('region', 'us-east')
-          @paramLabel('env', 'staging')
+          @addParamLabel('region', 'us-east')
+          @addParamLabel('env', 'staging')
           _db: unknown,
         ) {}
       }
@@ -68,7 +68,7 @@ describe('parameter metadata', () => {
 
     it('should not bleed across parameters', () => {
       class MyService {
-        constructor(@paramLabel('env', 'production') _db: unknown, _cache: unknown) {}
+        constructor(@addParamLabel('env', 'production') _db: unknown, _cache: unknown) {}
       }
 
       expect(getParamLabels(MyService, 1).size).toBe(0);
@@ -76,7 +76,10 @@ describe('parameter metadata', () => {
 
     it('should support labels on different parameters independently', () => {
       class MyService {
-        constructor(@paramLabel('env', 'production') _db: unknown, @paramLabel('env', 'staging') _cache: unknown) {}
+        constructor(
+          @addParamLabel('env', 'production') _db: unknown,
+          @addParamLabel('env', 'staging') _cache: unknown,
+        ) {}
       }
 
       expect(getParamLabels(MyService, 0).get('env')).toBe('production');
@@ -84,10 +87,10 @@ describe('parameter metadata', () => {
     });
   });
 
-  describe('paramTag / getParamTags', () => {
+  describe('addParamTag / getParamTags', () => {
     it('should add a tag and retrieve it by constructor', () => {
       class MyService {
-        constructor(@paramTag('inject') _db: unknown) {}
+        constructor(@addParamTag('inject') _db: unknown) {}
       }
 
       expect(getParamTags(MyService, 0).has('inject')).toBe(true);
@@ -95,7 +98,7 @@ describe('parameter metadata', () => {
 
     it('should add a tag and retrieve it by instance', () => {
       class MyService {
-        constructor(@paramTag('inject') _db: unknown) {}
+        constructor(@addParamTag('inject') _db: unknown) {}
       }
 
       expect(getParamTags(new MyService(null), 0).has('inject')).toBe(true);
@@ -104,8 +107,8 @@ describe('parameter metadata', () => {
     it('should support multiple tags on the same parameter', () => {
       class MyService {
         constructor(
-          @paramTag('inject')
-          @paramTag('optional')
+          @addParamTag('inject')
+          @addParamTag('optional')
           _db: unknown,
         ) {}
       }
@@ -126,8 +129,8 @@ describe('parameter metadata', () => {
     it('should not duplicate tags', () => {
       class MyService {
         constructor(
-          @paramTag('inject')
-          @paramTag('inject')
+          @addParamTag('inject')
+          @addParamTag('inject')
           _db: unknown,
         ) {}
       }
@@ -137,7 +140,7 @@ describe('parameter metadata', () => {
 
     it('should not bleed across parameters', () => {
       class MyService {
-        constructor(@paramTag('inject') _db: unknown, _cache: unknown) {}
+        constructor(@addParamTag('inject') _db: unknown, _cache: unknown) {}
       }
 
       expect(getParamTags(MyService, 1).size).toBe(0);

--- a/__tests__/readme/metadata.spec.ts
+++ b/__tests__/readme/metadata.spec.ts
@@ -1,11 +1,11 @@
-import { classMeta, getClassMeta, paramMeta, getParamMeta, addMethodMeta, getMethodMeta } from '../../lib';
+import { addClassMeta, getClassMeta, addParamMeta, getParamMeta, addMethodMeta, getMethodMeta } from '../../lib';
 
 describe('metadata', () => {
   describe('Class Metadata', () => {
     it('should store and retrieve class metadata', () => {
       const FEATURE_KEY = 'feature:enabled';
 
-      @classMeta(FEATURE_KEY, () => true)
+      @addClassMeta(FEATURE_KEY, () => true)
       class FeatureService {
         getName() {
           return 'feature';
@@ -19,8 +19,8 @@ describe('metadata', () => {
     it('should accumulate class metadata with multiple decorators', () => {
       const TAGS_KEY = 'tags';
 
-      @classMeta(TAGS_KEY, (prev: string[] = []) => [...prev, 'service'])
-      @classMeta(TAGS_KEY, (prev: string[] = []) => [...prev, 'api'])
+      @addClassMeta(TAGS_KEY, (prev: string[] = []) => [...prev, 'service'])
+      @addClassMeta(TAGS_KEY, (prev: string[] = []) => [...prev, 'api'])
       class ApiService {
         getName() {
           return 'api';
@@ -39,8 +39,8 @@ describe('metadata', () => {
 
       class DatabaseService {
         constructor(
-          @paramMeta(INJECT_KEY, () => 'config') config: any,
-          @paramMeta(INJECT_KEY, () => 'logger') logger: any,
+          @addParamMeta(INJECT_KEY, () => 'config') config: any,
+          @addParamMeta(INJECT_KEY, () => 'logger') logger: any,
         ) {}
       }
 
@@ -54,9 +54,9 @@ describe('metadata', () => {
       class SparseService {
         constructor(
           first: any,
-          @paramMeta(INJECT_KEY, () => 'second') second: any,
+          @addParamMeta(INJECT_KEY, () => 'second') second: any,
           third: any,
-          @paramMeta(INJECT_KEY, () => 'fourth') fourth: any,
+          @addParamMeta(INJECT_KEY, () => 'fourth') fourth: any,
         ) {}
       }
 

--- a/__tests__/readme/metadata.spec.ts
+++ b/__tests__/readme/metadata.spec.ts
@@ -1,4 +1,4 @@
-import { classMeta, getClassMeta, paramMeta, getParamMeta, methodMeta, getMethodMeta } from '../../lib';
+import { classMeta, getClassMeta, paramMeta, getParamMeta, addMethodMeta, getMethodMeta } from '../../lib';
 
 describe('metadata', () => {
   describe('Class Metadata', () => {
@@ -71,10 +71,10 @@ describe('metadata', () => {
   describe('Method Metadata', () => {
     it('should store and retrieve method metadata', () => {
       class Logger {
-        @methodMeta('logLevel', () => 'info')
+        @addMethodMeta('logLevel', () => 'info')
         info(message: string) {}
 
-        @methodMeta('logLevel', () => 'error')
+        @addMethodMeta('logLevel', () => 'error')
         error(message: string) {}
       }
 
@@ -87,8 +87,8 @@ describe('metadata', () => {
       const MIDDLEWARE_KEY = 'middleware';
 
       class Controller {
-        @methodMeta(MIDDLEWARE_KEY, (prev: string[] = []) => [...prev, 'auth'])
-        @methodMeta(MIDDLEWARE_KEY, (prev: string[] = []) => [...prev, 'validate'])
+        @addMethodMeta(MIDDLEWARE_KEY, (prev: string[] = []) => [...prev, 'auth'])
+        @addMethodMeta(MIDDLEWARE_KEY, (prev: string[] = []) => [...prev, 'validate'])
         handleRequest() {}
       }
 
@@ -104,7 +104,7 @@ describe('metadata', () => {
       const VALIDATORS_KEY = 'validators';
 
       const validate = (validator: (value: any) => boolean): MethodDecorator =>
-        methodMeta(VALIDATORS_KEY, (prev: Array<(v: any) => boolean> = []) => [...prev, validator]);
+        addMethodMeta(VALIDATORS_KEY, (prev: Array<(v: any) => boolean> = []) => [...prev, validator]);
 
       const runValidators = (instance: any, methodName: string, value: any): boolean => {
         const validators = getMethodMeta(VALIDATORS_KEY, instance, methodName) as Array<(v: any) => boolean>;

--- a/__tests__/specs/metadata-utilities.spec.ts
+++ b/__tests__/specs/metadata-utilities.spec.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
 import { afterEach, beforeEach, vi } from 'vitest';
 import {
-  classLabel,
-  classTag,
+  addClassLabel,
+  addClassTag,
   debounce,
   getClassLabels,
   getClassTags,
@@ -15,8 +15,8 @@ import {
   addMethodLabel,
   addMethodTag,
   once,
-  paramLabel,
-  paramTag,
+  addParamLabel,
+  addParamTag,
   shallowCache,
   throttle,
 } from '../../lib';
@@ -31,12 +31,12 @@ describe('Spec: metadata utilities', () => {
   });
 
   it('attaches class, parameter, and method labels and tags without bleeding between targets', () => {
-    @classLabel('role', 'service')
-    @classTag('domain')
+    @addClassLabel('role', 'service')
+    @addClassTag('domain')
     class ClassAnnotated {}
 
     class ParamAnnotated {
-      constructor(@paramLabel('source', 'request') @paramTag('tenant') tenantId: string) {}
+      constructor(@addParamLabel('source', 'request') @addParamTag('tenant') tenantId: string) {}
     }
 
     class MethodAnnotated {

--- a/__tests__/specs/metadata-utilities.spec.ts
+++ b/__tests__/specs/metadata-utilities.spec.ts
@@ -12,8 +12,8 @@ import {
   getParamTags,
   handleAsyncError,
   handleError,
-  methodLabel,
-  methodTag,
+  addMethodLabel,
+  addMethodTag,
   once,
   paramLabel,
   paramTag,
@@ -42,8 +42,8 @@ describe('Spec: metadata utilities', () => {
     class MethodAnnotated {
       run(): void {}
 
-      @methodLabel('phase', 'startup')
-      @methodTag('lifecycle')
+      @addMethodLabel('phase', 'startup')
+      @addMethodTag('lifecycle')
       start(): void {}
 
       stop(): void {}

--- a/docs/src/pages/metadata.mdx
+++ b/docs/src/pages/metadata.mdx
@@ -54,7 +54,7 @@ The metadata module exports functions organized in pairs per target type:
 
 - **Class Metadata**: `classMeta`, `getClassMeta`, `classLabel`, `getClassLabels`, `classTag`, `getClassTags`
 - **Parameter Metadata**: `paramMeta`, `getParamMeta`, `paramLabel`, `getParamLabels`, `paramTag`, `getParamTags`
-- **Method Metadata**: `methodMeta`, `getMethodMeta`, `methodLabel`, `getMethodLabels`, `methodTag`, `getMethodTags`
+- **Method Metadata**: `addMethodMeta`, `getMethodMeta`, `addMethodLabel`, `getMethodLabels`, `addMethodTag`, `getMethodTags`
 
 <h2 id="class-metadata" class="toc-link">Class Metadata</h2>
 
@@ -244,12 +244,12 @@ console.log(getParamTags(new MyService(null, null), 1).has('required')); // true
 
 Method metadata is stored per method on the class. Use this for hooks, validators, middleware, or any method-level configuration.
 
-### methodMeta
+### addMethodMeta
 
 Creates a method decorator that stores metadata for a specific method. The mapper receives the previous value for that method.
 
 ```typescript
-methodMeta<T>(
+addMethodMeta<T>(
   key: string,
   mapFn: (prev: T | undefined) => T
 ): MethodDecorator
@@ -267,12 +267,12 @@ getMethodMeta(
 ): unknown
 ```
 
-### methodLabel
+### addMethodLabel
 
 Attaches a key/value label to a method. Labels are stored as a `Map<string, string>`.
 
 ```typescript
-methodLabel(key: string, label: string): MethodDecorator
+addMethodLabel(key: string, label: string): MethodDecorator
 ```
 
 ### getMethodLabels
@@ -283,12 +283,12 @@ Retrieves all labels attached to a method. Accepts either the constructor or an 
 getMethodLabels(target: object, propertyKey: string): Map<string, string>
 ```
 
-### methodTag
+### addMethodTag
 
 Attaches a string tag to a method. Tags are stored as a `Set<string>`, so duplicates are ignored automatically.
 
 ```typescript
-methodTag(tag: string): MethodDecorator
+addMethodTag(tag: string): MethodDecorator
 ```
 
 ### getMethodTags
@@ -305,8 +305,8 @@ getMethodTags(target: object, propertyKey: string): Set<string>
   code={`const MIDDLEWARE_KEY = 'middleware';
 
 class Controller {
-  @methodMeta(MIDDLEWARE_KEY, (prev: string[] = []) => [...prev, 'auth'])
-  @methodMeta(MIDDLEWARE_KEY, (prev: string[] = []) => [...prev, 'validate'])
+  @addMethodMeta(MIDDLEWARE_KEY, (prev: string[] = []) => [...prev, 'auth'])
+  @addMethodMeta(MIDDLEWARE_KEY, (prev: string[] = []) => [...prev, 'validate'])
   handleRequest() {}
 }
 
@@ -318,13 +318,13 @@ console.log(middleware); // ['validate', 'auth']`}
 
 <CodeBlock
   code={`class UserController {
-  @methodTag('public')
-  @methodTag('deprecated')
-  @methodLabel('version', 'v1')
+  @addMethodTag('public')
+  @addMethodTag('deprecated')
+  @addMethodLabel('version', 'v1')
   getUsers() {}
 
-  @methodTag('public')
-  @methodLabel('version', 'v2')
+  @addMethodTag('public')
+  @addMethodLabel('version', 'v2')
   getUsersV2() {}
 }
 
@@ -352,7 +352,7 @@ The metadata system powers the core decorators:
 
 - **@register** - Uses `classMeta` to store registration transformers
 - **@inject** - Uses `paramMeta` to specify constructor dependencies
-- **@onConstruct/@onDispose/@hook** - Use `methodMeta` for lifecycle hooks
+- **@onConstruct/@onDispose/@hook** - Use `addMethodMeta` for lifecycle hooks
 
 <h2 id="best-practices" class="toc-link">Best Practices</h2>
 
@@ -361,8 +361,8 @@ The metadata system powers the core decorators:
 - **Use mapper functions for accumulation** - When stacking decorators, use the `prev` parameter to accumulate values
 - **Type your metadata** - Use TypeScript generics to type your metadata values
 - **Handle undefined gracefully** - Always check if metadata exists before using it
-- **Prefer labels over raw metadata for key/value data** - `classLabel` / `methodLabel` / `paramLabel` provide a typed, structured alternative to raw metadata keys
-- **Prefer tags for boolean flags** - `classTag` / `methodTag` / `paramTag` avoid duplicates automatically via `Set`
+- **Prefer labels over raw metadata for key/value data** - `classLabel` / `addMethodLabel` / `paramLabel` provide a typed, structured alternative to raw metadata keys
+- **Prefer tags for boolean flags** - `classTag` / `addMethodTag` / `paramTag` avoid duplicates automatically via `Set`
 - **Don't overuse metadata** - Prefer explicit configuration over implicit metadata when possible
 
 <h2 id="limitations" class="toc-link">Limitations</h2>

--- a/docs/src/pages/metadata.mdx
+++ b/docs/src/pages/metadata.mdx
@@ -52,20 +52,20 @@ import 'reflect-metadata';
 
 The metadata module exports functions organized in pairs per target type:
 
-- **Class Metadata**: `classMeta`, `getClassMeta`, `classLabel`, `getClassLabels`, `classTag`, `getClassTags`
-- **Parameter Metadata**: `paramMeta`, `getParamMeta`, `paramLabel`, `getParamLabels`, `paramTag`, `getParamTags`
+- **Class Metadata**: `addClassMeta`, `getClassMeta`, `addClassLabel`, `getClassLabels`, `addClassTag`, `getClassTags`
+- **Parameter Metadata**: `addParamMeta`, `getParamMeta`, `addParamLabel`, `getParamLabels`, `addParamTag`, `getParamTags`
 - **Method Metadata**: `addMethodMeta`, `getMethodMeta`, `addMethodLabel`, `getMethodLabels`, `addMethodTag`, `getMethodTags`
 
 <h2 id="class-metadata" class="toc-link">Class Metadata</h2>
 
 Class metadata is stored on the class constructor itself. Use this to attach configuration, tags, or registration information to classes.
 
-### classMeta
+### addClassMeta
 
 Creates a class decorator that stores metadata using a mapper function. The mapper receives the previous value (if any) and returns the new value.
 
 ```typescript
-classMeta<T>(
+addClassMeta<T>(
   key: string | symbol,
   mapFn: (prev: T | undefined) => T
 ): ClassDecorator
@@ -82,12 +82,12 @@ getClassMeta<T>(
 ): T | undefined
 ```
 
-### classLabel
+### addClassLabel
 
 Attaches a key/value label to a class. Labels are stored as a `Map<string, string>` and can be used to categorize or describe classes.
 
 ```typescript
-classLabel(key: string, label: string): ClassDecorator
+addClassLabel(key: string, label: string): ClassDecorator
 ```
 
 ### getClassLabels
@@ -98,12 +98,12 @@ Retrieves all labels attached to a class. Accepts either the constructor or an i
 getClassLabels(target: object): Map<string, string>
 ```
 
-### classTag
+### addClassTag
 
 Attaches a string tag to a class. Tags are stored as a `Set<string>`, so duplicates are ignored automatically.
 
 ```typescript
-classTag(tag: string): ClassDecorator
+addClassTag(tag: string): ClassDecorator
 ```
 
 ### getClassTags
@@ -119,8 +119,8 @@ getClassTags(target: object): Set<string>
 <CodeBlock
   code={`const TAGS_KEY = 'tags';
 
-@classMeta(TAGS_KEY, (prev: string[] = []) => [...prev, 'service'])
-@classMeta(TAGS_KEY, (prev: string[] = []) => [...prev, 'api'])
+@addClassMeta(TAGS_KEY, (prev: string[] = []) => [...prev, 'service'])
+@addClassMeta(TAGS_KEY, (prev: string[] = []) => [...prev, 'api'])
 class ApiService {}
 
 const tags = getClassMeta<string[]>(ApiService, TAGS_KEY);
@@ -129,10 +129,10 @@ console.log(tags); // ['api', 'service']`}
 />
 
 <CodeBlock
-  code={`@classTag('singleton')
-@classTag('service')
-@classLabel('env', 'production')
-@classLabel('region', 'us-east')
+  code={`@addClassTag('singleton')
+@addClassTag('service')
+@addClassLabel('env', 'production')
+@addClassLabel('region', 'us-east')
 class MyService {}
 
 const instance = new MyService();
@@ -149,12 +149,12 @@ console.log(getClassLabels(instance).get('region')); // 'us-east'`}
 
 Parameter metadata is stored as an array indexed by parameter position. This is crucial for constructor and method parameter injection.
 
-### paramMeta
+### addParamMeta
 
 Creates a parameter decorator that stores metadata for a specific parameter. The mapper receives the previous value for that parameter index.
 
 ```typescript
-paramMeta(
+addParamMeta(
   key: string | symbol,
   mapFn: (prev: unknown) => unknown
 ): ParameterDecorator
@@ -171,12 +171,12 @@ getParamMeta(
 ): unknown[]
 ```
 
-### paramLabel
+### addParamLabel
 
 Attaches a key/value label to a constructor parameter at the given position. Labels are stored per parameter as a `Map<string, string>`.
 
 ```typescript
-paramLabel(key: string, label: string): ParameterDecorator
+addParamLabel(key: string, label: string): ParameterDecorator
 ```
 
 ### getParamLabels
@@ -187,12 +187,12 @@ Retrieves all labels for a specific parameter by index. Accepts either the const
 getParamLabels(target: object, parameterIndex: number): Map<string, string>
 ```
 
-### paramTag
+### addParamTag
 
 Attaches a string tag to a constructor parameter. Tags are stored per parameter as a `Set<string>`.
 
 ```typescript
-paramTag(tag: string): ParameterDecorator
+addParamTag(tag: string): ParameterDecorator
 ```
 
 ### getParamTags
@@ -210,8 +210,8 @@ getParamTags(target: object, parameterIndex: number): Set<string>
 
 class DatabaseService {
   constructor(
-    @paramMeta(INJECT_KEY, () => 'config') config: any,
-    @paramMeta(INJECT_KEY, () => 'logger') logger: any,
+    @addParamMeta(INJECT_KEY, () => 'config') config: any,
+    @addParamMeta(INJECT_KEY, () => 'logger') logger: any,
   ) {}
 }
 
@@ -223,12 +223,12 @@ console.log(metadata); // ['config', 'logger']`}
 <CodeBlock
   code={`class MyService {
   constructor(
-    @paramTag('optional')
-    @paramLabel('source', 'env')
+    @addParamTag('optional')
+    @addParamLabel('source', 'env')
     _config: unknown,
 
-    @paramTag('required')
-    @paramLabel('source', 'di')
+    @addParamTag('required')
+    @addParamLabel('source', 'di')
     _db: unknown,
   ) {}
 }
@@ -350,8 +350,8 @@ The metadata system is built on top of `reflect-metadata`:
 
 The metadata system powers the core decorators:
 
-- **@register** - Uses `classMeta` to store registration transformers
-- **@inject** - Uses `paramMeta` to specify constructor dependencies
+- **@register** - Uses `addClassMeta` to store registration transformers
+- **@inject** - Uses `addParamMeta` to specify constructor dependencies
 - **@onConstruct/@onDispose/@hook** - Use `addMethodMeta` for lifecycle hooks
 
 <h2 id="best-practices" class="toc-link">Best Practices</h2>
@@ -361,8 +361,8 @@ The metadata system powers the core decorators:
 - **Use mapper functions for accumulation** - When stacking decorators, use the `prev` parameter to accumulate values
 - **Type your metadata** - Use TypeScript generics to type your metadata values
 - **Handle undefined gracefully** - Always check if metadata exists before using it
-- **Prefer labels over raw metadata for key/value data** - `classLabel` / `addMethodLabel` / `paramLabel` provide a typed, structured alternative to raw metadata keys
-- **Prefer tags for boolean flags** - `classTag` / `addMethodTag` / `paramTag` avoid duplicates automatically via `Set`
+- **Prefer labels over raw metadata for key/value data** - `addClassLabel` / `addMethodLabel` / `addParamLabel` provide a typed, structured alternative to raw metadata keys
+- **Prefer tags for boolean flags** - `addClassTag` / `addMethodTag` / `addParamTag` avoid duplicates automatically via `Set`
 - **Don't overuse metadata** - Prefer explicit configuration over implicit metadata when possible
 
 <h2 id="limitations" class="toc-link">Limitations</h2>

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -81,7 +81,14 @@ export { type InstancePredicate, GroupInstanceToken } from './token/GroupInstanc
 // Metadata
 export { classMeta, getClassMeta, classLabel, getClassLabels, classTag, getClassTags } from './metadata/class';
 export { paramMeta, getParamMeta, paramLabel, getParamLabels, paramTag, getParamTags } from './metadata/parameter';
-export { methodMeta, getMethodMeta, methodLabel, getMethodLabels, methodTag, getMethodTags } from './metadata/method';
+export {
+  addMethodMeta,
+  getMethodMeta,
+  addMethodLabel,
+  getMethodLabels,
+  addMethodTag,
+  getMethodTags,
+} from './metadata/method';
 export { handleError, handleAsyncError, type HandleErrorParams } from './utils/errorHandler';
 export { throttle } from './utils/throttle';
 export { debounce } from './utils/debounce';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -79,8 +79,15 @@ export { ConstantToken } from './token/ConstantToken';
 export { type InstancePredicate, GroupInstanceToken } from './token/GroupInstanceToken';
 
 // Metadata
-export { classMeta, getClassMeta, classLabel, getClassLabels, classTag, getClassTags } from './metadata/class';
-export { paramMeta, getParamMeta, paramLabel, getParamLabels, paramTag, getParamTags } from './metadata/parameter';
+export { addClassMeta, getClassMeta, addClassLabel, getClassLabels, addClassTag, getClassTags } from './metadata/class';
+export {
+  addParamMeta,
+  getParamMeta,
+  addParamLabel,
+  getParamLabels,
+  addParamTag,
+  getParamTags,
+} from './metadata/parameter';
 export {
   addMethodMeta,
   getMethodMeta,

--- a/lib/injector/MetadataInjector.ts
+++ b/lib/injector/MetadataInjector.ts
@@ -1,7 +1,7 @@
 import { IInjector, InjectOptions, Injector } from './IInjector';
 import type { IContainer } from '../container/IContainer';
 import { type constructor, Is } from '../utils/basic';
-import { getParamMeta, paramMeta } from '../metadata/parameter';
+import { getParamMeta, addParamMeta } from '../metadata/parameter';
 import { InjectionToken } from '../token/InjectionToken';
 import { ProviderOptions } from '../provider/IProvider';
 import { argToToken, toToken } from '../token/toToken';
@@ -19,7 +19,7 @@ const hookMetaKey = (methodName = 'constructor') => `inject:${methodName}`;
 export const inject =
   <T>(fn: InjectionToken<T> | InjectFn<T> | symbol | string | constructor<T>): ParameterDecorator =>
   (target, propertyKey, parameterIndex) => {
-    paramMeta(hookMetaKey(propertyKey as string), () => toToken(fn))(
+    addParamMeta(hookMetaKey(propertyKey as string), () => toToken(fn))(
       Is.instance(target) ? target.constructor : target,
       propertyKey,
       parameterIndex,

--- a/lib/metadata/class.ts
+++ b/lib/metadata/class.ts
@@ -1,6 +1,6 @@
 import { resolveConstructor } from '../utils/basic';
 
-export const classMeta =
+export const addClassMeta =
   <T>(key: string | symbol, mapFn: (prev: T | undefined) => T): ClassDecorator =>
   (target) => {
     const value: T | undefined = Reflect.getOwnMetadata(key, target);
@@ -11,9 +11,9 @@ export function getClassMeta<T>(target: object, key: string | symbol): T | undef
   return Reflect.getOwnMetadata(key, resolveConstructor(target));
 }
 
-export const classLabel = (key: string, label: string) =>
-  classMeta('label', (prev: Map<string, string> = new Map()) => prev.set(key, label));
+export const addClassLabel = (key: string, label: string) =>
+  addClassMeta('label', (prev: Map<string, string> = new Map()) => prev.set(key, label));
 export const getClassLabels = (target: object): Map<string, string> => getClassMeta(target, 'label') ?? new Map();
 
-export const classTag = (tag: string) => classMeta('tag', (prev: Set<string> = new Set()) => prev.add(tag));
+export const addClassTag = (tag: string) => addClassMeta('tag', (prev: Set<string> = new Set()) => prev.add(tag));
 export const getClassTags = (target: object): Set<string> => getClassMeta(target, 'tag') ?? new Set();

--- a/lib/metadata/method.ts
+++ b/lib/metadata/method.ts
@@ -1,6 +1,6 @@
 import { resolveConstructor } from '../utils/basic';
 
-export const methodMeta =
+export const addMethodMeta =
   <T>(key: string, mapFn: (prev: T | undefined) => T): MethodDecorator =>
   (target, propertyKey) => {
     const metadata: T | undefined = Reflect.getMetadata(key, target.constructor, propertyKey);
@@ -9,11 +9,11 @@ export const methodMeta =
 export const getMethodMeta = (key: string, target: object, propertyKey: string): unknown =>
   Reflect.getMetadata(key, resolveConstructor(target), propertyKey);
 
-export const methodLabel = (key: string, label: string) =>
-  methodMeta('label', (prev: Map<string, string> = new Map()) => prev.set(key, label));
+export const addMethodLabel = (key: string, label: string) =>
+  addMethodMeta('label', (prev: Map<string, string> = new Map()) => prev.set(key, label));
 export const getMethodLabels = (target: object, propertyKey: string): Map<string, string> =>
   (getMethodMeta('label', target, propertyKey) as Map<string, string> | undefined) ?? new Map();
 
-export const methodTag = (tag: string) => methodMeta('tag', (prev: Set<string> = new Set()) => prev.add(tag));
+export const addMethodTag = (tag: string) => addMethodMeta('tag', (prev: Set<string> = new Set()) => prev.add(tag));
 export const getMethodTags = (target: object, propertyKey: string): Set<string> =>
   (getMethodMeta('tag', target, propertyKey) as Set<string> | undefined) ?? new Set();

--- a/lib/metadata/parameter.ts
+++ b/lib/metadata/parameter.ts
@@ -1,6 +1,6 @@
 import { resolveConstructor } from '../utils/basic';
 
-export const paramMeta =
+export const addParamMeta =
   (key: string | symbol, mapFn: (prev: unknown) => unknown): ParameterDecorator =>
   (target, _, parameterIndex) => {
     const metadata: unknown[] = Reflect.getOwnMetadata(key, target) ?? [];
@@ -11,8 +11,8 @@ export const getParamMeta = (key: string | symbol, target: object): unknown[] =>
   return (Reflect.getOwnMetadata(key, resolveConstructor(target)) as unknown[]) ?? [];
 };
 
-export const paramLabel = (key: string, label: string) =>
-  paramMeta('label', (prev: unknown) => {
+export const addParamLabel = (key: string, label: string) =>
+  addParamMeta('label', (prev: unknown) => {
     const map = (prev as Map<string, string> | undefined) ?? new Map<string, string>();
     return map.set(key, label);
   });
@@ -21,8 +21,8 @@ export const getParamLabels = (target: object, parameterIndex: number): Map<stri
   return (all[parameterIndex] as Map<string, string> | undefined) ?? new Map();
 };
 
-export const paramTag = (tag: string) =>
-  paramMeta('tag', (prev: unknown) => {
+export const addParamTag = (tag: string) =>
+  addParamMeta('tag', (prev: unknown) => {
     const set = (prev as Set<string> | undefined) ?? new Set<string>();
     return set.add(tag);
   });

--- a/lib/registration/IRegistration.ts
+++ b/lib/registration/IRegistration.ts
@@ -3,7 +3,7 @@ import type { ArgsFn, DecorateFn, GetCacheKey, IProvider, ScopeAccessRule } from
 import { SingleToken } from '../token/SingleToken';
 import { BindToken, isBindToken } from '../token/BindToken';
 import { MapFn } from '../utils/fp';
-import { classMeta, getClassMeta } from '../metadata/class';
+import { addClassMeta, getClassMeta } from '../metadata/class';
 import { type constructor } from '../utils/basic';
 
 export type ScopeMatchRule = (s: IContainer, prev: boolean) => boolean;
@@ -43,7 +43,7 @@ export const getTransformers = (Target: constructor<unknown>) =>
   getClassMeta<MapFn<IRegistration>[]>(Target, METADATA_KEY) ?? [];
 
 export const register = (...mappers: Array<MapFn<IRegistration> | ProviderPipe>) =>
-  classMeta(METADATA_KEY, (acc: MapFn<IRegistration>[] | undefined) => {
+  addClassMeta(METADATA_KEY, (acc: MapFn<IRegistration>[] | undefined) => {
     const result = mappers.map((m) =>
       isProviderPipe(m) ? (r: IRegistration) => m.mapRegistration(r) : m,
     ) as MapFn<IRegistration>[];

--- a/specs/epics/metadata-utilities.md
+++ b/specs/epics/metadata-utilities.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0008 - Zero runtime dependencies](../../docs/adr/0008-zero-runtime-dependencies.md)
-- **Public API:** `classMeta`, `getClassMeta`, `classLabel`, `getClassLabels`, `classTag`, `getClassTags`, `paramMeta`, `getParamMeta`, `paramLabel`, `getParamLabels`, `paramTag`, `getParamTags`, `addMethodMeta`, `getMethodMeta`, `addMethodLabel`, `getMethodLabels`, `addMethodTag`, `getMethodTags`, `once`, `debounce`, `throttle`, `shallowCache`, `handleError`, `handleAsyncError`
+- **Public API:** `addClassMeta`, `getClassMeta`, `addClassLabel`, `getClassLabels`, `addClassTag`, `getClassTags`, `addParamMeta`, `getParamMeta`, `addParamLabel`, `getParamLabels`, `addParamTag`, `getParamTags`, `addMethodMeta`, `getMethodMeta`, `addMethodLabel`, `getMethodLabels`, `addMethodTag`, `getMethodTags`, `once`, `debounce`, `throttle`, `shallowCache`, `handleError`, `handleAsyncError`
 - **Executable spec:** `__tests__/specs/metadata-utilities.spec.ts`
 
 ## Intent

--- a/specs/epics/metadata-utilities.md
+++ b/specs/epics/metadata-utilities.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0008 - Zero runtime dependencies](../../docs/adr/0008-zero-runtime-dependencies.md)
-- **Public API:** `classMeta`, `getClassMeta`, `classLabel`, `getClassLabels`, `classTag`, `getClassTags`, `paramMeta`, `getParamMeta`, `paramLabel`, `getParamLabels`, `paramTag`, `getParamTags`, `methodMeta`, `getMethodMeta`, `methodLabel`, `getMethodLabels`, `methodTag`, `getMethodTags`, `once`, `debounce`, `throttle`, `shallowCache`, `handleError`, `handleAsyncError`
+- **Public API:** `classMeta`, `getClassMeta`, `classLabel`, `getClassLabels`, `classTag`, `getClassTags`, `paramMeta`, `getParamMeta`, `paramLabel`, `getParamLabels`, `paramTag`, `getParamTags`, `addMethodMeta`, `getMethodMeta`, `addMethodLabel`, `getMethodLabels`, `addMethodTag`, `getMethodTags`, `once`, `debounce`, `throttle`, `shallowCache`, `handleError`, `handleAsyncError`
 - **Executable spec:** `__tests__/specs/metadata-utilities.spec.ts`
 
 ## Intent


### PR DESCRIPTION
## Summary

Renames the mutating metadata decorators to use an `add` prefix for clearer semantics and consistency across the class / parameter / method metadata families. The getter functions are unchanged.

| Before | After |
| --- | --- |
| `classMeta` | `addClassMeta` |
| `classLabel` | `addClassLabel` |
| `classTag` | `addClassTag` |
| `paramMeta` | `addParamMeta` |
| `paramLabel` | `addParamLabel` |
| `paramTag` | `addParamTag` |
| `methodMeta` | `addMethodMeta` |
| `methodLabel` | `addMethodLabel` |
| `methodTag` | `addMethodTag` |

## Changes

- Updated source (`lib/metadata/{class,parameter,method}.ts`) and the public exports in `lib/index.ts`
- Updated internal call sites in `lib/registration/IRegistration.ts` and `lib/injector/MetadataInjector.ts`
- Updated tests, docs page, and spec epic
- `CHANGELOG.md` left untouched (historical record)

## Testing

- `pnpm run type-check` — passes
- `pnpm exec vitest run` — 321 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kyi5iFKp5KJav3JPqGqg7y

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kyi5iFKp5KJav3JPqGqg7y)_