### PR TITLE
feat(hooks): add mapContext option to HooksRunner execute/executeAsync

### DIFF
--- a/__tests__/hooks/hook.spec.ts
+++ b/__tests__/hooks/hook.spec.ts
@@ -58,6 +58,56 @@ describe('hooks', () => {
     expect(instance.receivedArgs).toEqual(['initial', 'injected', undefined]);
   });
 
+  it('should map the hook context with mapContext when running execute', () => {
+    const beforeHooksRunner = new HooksRunner('syncBefore');
+
+    class MyClass {
+      receivedArgs: unknown[] = [];
+
+      @hook('syncBefore', (ctx) => {
+        ctx.invokeMethod();
+      })
+      start(@inject(args(0)) firstArg: string, @inject('suffix') suffix: string) {
+        this.receivedArgs = [firstArg, suffix];
+      }
+    }
+
+    const root = new Container({ tags: ['root'] }).addRegistration(R.fromValue('injected').bindTo('suffix'));
+    const instance = root.resolve(MyClass);
+
+    beforeHooksRunner.execute(instance, {
+      scope: root,
+      mapContext: (context) => context.setInitialArgs('mapped'),
+    });
+
+    expect(instance.receivedArgs).toEqual(['mapped', 'injected']);
+  });
+
+  it('should map the hook context with mapContext when running executeAsync', async () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+
+    class MyClass {
+      receivedArgs: unknown[] = [];
+
+      @hook('onStart', async (ctx) => {
+        await ctx.invokeMethod();
+      })
+      async start(@inject(args(0)) firstArg: string) {
+        this.receivedArgs = [firstArg];
+      }
+    }
+
+    const root = new Container({ tags: ['root'] });
+    const instance = root.resolve(MyClass);
+
+    await onStartHooksRunner.executeAsync(instance, {
+      scope: root,
+      mapContext: (context) => context.setInitialArgs('mapped'),
+    });
+
+    expect(instance.receivedArgs).toEqual(['mapped']);
+  });
+
   it('should run executeAsync for async hooks', async () => {
     const onStartHooksRunner = new HooksRunner('onStart');
 

--- a/docs/src/pages/hooks.mdx
+++ b/docs/src/pages/hooks.mdx
@@ -155,6 +155,17 @@ beforeHooksRunner.execute(instance, {
 
 In this example, `firstArg` receives `'initial'` and `suffix` is still resolved from the container.
 
+Alternatively, pass `mapContext` to transform the context the runner already created. This keeps the default `createContext` factory in place while letting you tweak the context per run — for example to preload arguments:
+
+```typescript
+beforeHooksRunner.execute(instance, {
+  scope: root,
+  mapContext: (context) => context.setInitialArgs('initial'),
+});
+```
+
+`mapContext` works the same way for both `execute` and `executeAsync`, and runs once per hooked method, after `createContext`.
+
 ## Best Practices
 
 <div class="callout callout-important">

--- a/lib/hooks/HooksRunner.ts
+++ b/lib/hooks/HooksRunner.ts
@@ -1,24 +1,35 @@
-import { createHookContext, type CreateHookContext } from './HookContext';
+import { createHookContext, type CreateHookContext, type IHookContext } from './HookContext';
 import type { IContainer } from '../container/IContainer';
 import { getHooks, HookFn, toHookFn } from './hook';
 import { UnexpectedHookResultError } from '../errors/UnexpectedHookResultError';
 
 import { promisify } from '../utils/promise';
 
+export type MapHookContext = (context: IHookContext) => IHookContext;
+
 export type HooksRunnerContext = {
   scope: IContainer;
   createContext?: CreateHookContext;
+  mapContext?: MapHookContext;
   predicate?: (methodName: string) => boolean;
 };
 
 export class HooksRunner {
   constructor(private readonly key: string | symbol) {}
 
-  execute(target: object, { scope, createContext = createHookContext, predicate = () => true }: HooksRunnerContext) {
+  execute(
+    target: object,
+    {
+      scope,
+      createContext = createHookContext,
+      mapContext = (context) => context,
+      predicate = () => true,
+    }: HooksRunnerContext,
+  ) {
     const hooks = Array.from(getHooks(target, this.key).entries()).filter(([methodName]) => predicate(methodName));
 
     const runMethodHooks = (methodName: string, executions: HookFn[]) => {
-      const context = createContext(target, scope, methodName);
+      const context = mapContext(createContext(target, scope, methodName));
       for (const execute of executions) {
         const result = execute(context);
         if (result instanceof Promise) {
@@ -37,17 +48,14 @@ export class HooksRunner {
     {
       scope,
       createContext = createHookContext,
+      mapContext = (context) => context,
       predicate = () => true,
-    }: {
-      scope: IContainer;
-      createContext?: typeof createHookContext;
-      predicate?: (methodName: string) => boolean;
-    },
+    }: HooksRunnerContext,
   ) {
     const hooks = Array.from(getHooks(target, this.key).entries()).filter(([methodName]) => predicate(methodName));
 
     const runMethodHooks = async (methodName: string, executions: HookFn[]) => {
-      const context = createContext(target, scope, methodName);
+      const context = mapContext(createContext(target, scope, methodName));
       for (const execute of executions) {
         await promisify(execute(context));
       }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -66,7 +66,7 @@ export { HookContext, createHookContextFactory, createHookContext, type IHookCon
 export { injectProp } from './hooks/injectProp';
 export { onConstructHooksRunner, onConstruct, AddOnConstructHookModule } from './hooks/onConstruct';
 export { onDisposeHooksRunner, onDispose, AddOnDisposeHookModule } from './hooks/onDispose';
-export { HooksRunner, type HooksRunnerContext } from './hooks/HooksRunner';
+export { HooksRunner, type HooksRunnerContext, type MapHookContext } from './hooks/HooksRunner';
 
 // Tokens
 export { InjectionToken } from './token/InjectionToken';


### PR DESCRIPTION
## Summary

Adds a `mapContext` option to both `HooksRunner.execute` and `HooksRunner.executeAsync`. It lets callers transform the `IHookContext` the runner already creates — without having to replace the whole `createContext` factory — making preloading arguments ergonomic:

```typescript
beforeHooksRunner.execute(instance, {
  scope: root,
  mapContext: (c) => c.setInitialArgs(smth),
});
```

`mapContext` runs once per hooked method, right after `createContext`, and defaults to an identity function so existing behavior is unchanged.

## Changes

- `lib/hooks/HooksRunner.ts`: add `MapHookContext` type and `mapContext` option to `HooksRunnerContext`; apply it in `execute` and `executeAsync`. Also unify `executeAsync`'s inline options type to reuse `HooksRunnerContext`.
- `lib/index.ts`: export the new `MapHookContext` type.
- `__tests__/hooks/hook.spec.ts`: add tests covering `mapContext` for both sync and async runs.
- `docs/src/pages/hooks.mdx`: document the new option.

## Testing

- `pnpm run type-check` ✅
- `pnpm test` — 323 tests passing ✅
- `eslint` on changed files — clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrCrnBfNUaEsrpbzngy6iU)_