### PR TITLE
feat(hooks): add getProperty() to IHookContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -2601,6 +2601,26 @@ describe('inject property', () => {
     expect(viewModel.greetingService).toBe('Hello');
     expect(viewModel.display()).toBe('Hello User');
   });
+
+  it('should read the applied instance property via getProperty', () => {
+    const onInitHookRunner = new HooksRunner('onInit');
+
+    let injectedValue: unknown;
+
+    class UserViewModel {
+      @hook('onInit', injectProp('GreetingService'), (context) => {
+        injectedValue = context.getProperty();
+      })
+      greetingService!: string;
+    }
+
+    const container = new Container().addRegistration(Registration.fromValue('Hello').bindToKey('GreetingService'));
+
+    const viewModel = container.resolve(UserViewModel);
+    onInitHookRunner.execute(viewModel, { scope: container });
+
+    expect(injectedValue).toBe('Hello');
+  });
 });
 
 ```

--- a/__tests__/readme/injectProp.spec.ts
+++ b/__tests__/readme/injectProp.spec.ts
@@ -38,4 +38,24 @@ describe('inject property', () => {
     expect(viewModel.greetingService).toBe('Hello');
     expect(viewModel.display()).toBe('Hello User');
   });
+
+  it('should read the applied instance property via getProperty', () => {
+    const onInitHookRunner = new HooksRunner('onInit');
+
+    let injectedValue: unknown;
+
+    class UserViewModel {
+      @hook('onInit', injectProp('GreetingService'), (context) => {
+        injectedValue = context.getProperty();
+      })
+      greetingService!: string;
+    }
+
+    const container = new Container().addRegistration(Registration.fromValue('Hello').bindToKey('GreetingService'));
+
+    const viewModel = container.resolve(UserViewModel);
+    onInitHookRunner.execute(viewModel, { scope: container });
+
+    expect(injectedValue).toBe('Hello');
+  });
 });

--- a/lib/hooks/HookContext.ts
+++ b/lib/hooks/HookContext.ts
@@ -16,6 +16,8 @@ export interface IHookContext {
 
   setProperty(fn: InjectionToken): void;
 
+  getProperty(): unknown;
+
   setInitialArgs(...args: unknown[]): this;
 }
 
@@ -45,6 +47,11 @@ export class HookContext implements IHookContext {
   setProperty(fn: InjectionToken): void {
     // @ts-ignore
     this.instance[this.methodName] = fn.resolve(this.scope);
+  }
+
+  getProperty(): unknown {
+    // @ts-ignore
+    return this.instance[this.methodName];
   }
 
   setInitialArgs(...args: unknown[]): this {


### PR DESCRIPTION
## Summary

Adds a `getProperty()` method to `IHookContext` that returns the value of the applied instance property, mirroring the existing `setProperty()`.

This is useful in hooks that need to read a property after it has been injected (e.g. validation, logging, or conditional logic following property injection).

## Changes

- `lib/hooks/HookContext.ts`: add `getProperty(): unknown` to the `IHookContext` interface and implement it on `HookContext` — it returns `this.instance[this.methodName]`.
- `__tests__/readme/injectProp.spec.ts`: add a test verifying `getProperty()` reads the value applied by `injectProp` during a lifecycle hook.

## Testing

- `pnpm exec vitest run __tests__/readme/injectProp.spec.ts` — passes
- `pnpm run type-check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgLFQJgViZ7LSwUtWNitiw)_