### PR TITLE
feat(hooks): add onException handler to AddOnConstructHookModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2462,7 +2462,16 @@ Sometimes you need to invoke methods after construct or dispose of class. This i
 
 ```typescript
 import 'reflect-metadata';
-import { AddOnConstructHookModule, Container, type HookFn, inject, onConstruct, Registration as R } from 'ts-ioc-container';
+import {
+  AddOnConstructHookModule,
+  Container,
+  type ExecutionContext,
+  type HookFn,
+  type IContainer,
+  inject,
+  onConstruct,
+  Registration as R,
+} from 'ts-ioc-container';
 
 const execute: HookFn = (ctx) => {
   ctx.invokeMethod({ args: ctx.resolveArgs() });
@@ -2489,6 +2498,64 @@ describe('onConstruct', function () {
 
     expect(db.isConnected).toBe(true);
     expect(db.connectionString).toBe('postgres://localhost:5432');
+  });
+
+  it('should forward hook exceptions to the onException handler with the execution context', function () {
+    const failure = new Error('boom');
+
+    class BrokenService {
+      @onConstruct(() => {
+        throw failure;
+      })
+      init() {}
+    }
+
+    let captured: { ex: unknown; context: ExecutionContext } | undefined;
+    const container = new Container().useModule(
+      new AddOnConstructHookModule((ex, context) => {
+        captured = { ex, context };
+      }),
+    );
+
+    expect(() => container.resolve(BrokenService)).not.toThrow();
+    expect(captured?.ex).toBe(failure);
+    expect(captured?.context.scope).toBe(container);
+  });
+
+  it('should rethrow hook exceptions when no onException handler is provided', function () {
+    const failure = new Error('boom');
+
+    class BrokenService {
+      @onConstruct(() => {
+        throw failure;
+      })
+      init() {}
+    }
+
+    const container = new Container().useModule(new AddOnConstructHookModule());
+
+    expect(() => container.resolve(BrokenService)).toThrow(failure);
+  });
+
+  it('should expose the resolving scope through the execution context', function () {
+    class BrokenService {
+      @onConstruct(() => {
+        throw new Error('boom');
+      })
+      init() {}
+    }
+
+    let scope: IContainer | undefined;
+    const container = new Container().useModule(
+      new AddOnConstructHookModule((_ex, context) => {
+        scope = context.scope;
+      }),
+    );
+    const child = container.createScope();
+
+    child.resolve(BrokenService);
+
+    expect(scope).toBe(child);
   });
 });
 

--- a/__tests__/readme/onConstruct.spec.ts
+++ b/__tests__/readme/onConstruct.spec.ts
@@ -1,5 +1,14 @@
 import 'reflect-metadata';
-import { AddOnConstructHookModule, Container, type HookFn, inject, onConstruct, Registration as R } from '../../lib';
+import {
+  AddOnConstructHookModule,
+  Container,
+  type ExecutionContext,
+  type HookFn,
+  type IContainer,
+  inject,
+  onConstruct,
+  Registration as R,
+} from '../../lib';
 
 const execute: HookFn = (ctx) => {
   ctx.invokeMethod({ args: ctx.resolveArgs() });
@@ -26,5 +35,63 @@ describe('onConstruct', function () {
 
     expect(db.isConnected).toBe(true);
     expect(db.connectionString).toBe('postgres://localhost:5432');
+  });
+
+  it('should forward hook exceptions to the onException handler with the execution context', function () {
+    const failure = new Error('boom');
+
+    class BrokenService {
+      @onConstruct(() => {
+        throw failure;
+      })
+      init() {}
+    }
+
+    let captured: { ex: unknown; context: ExecutionContext } | undefined;
+    const container = new Container().useModule(
+      new AddOnConstructHookModule((ex, context) => {
+        captured = { ex, context };
+      }),
+    );
+
+    expect(() => container.resolve(BrokenService)).not.toThrow();
+    expect(captured?.ex).toBe(failure);
+    expect(captured?.context.scope).toBe(container);
+  });
+
+  it('should rethrow hook exceptions when no onException handler is provided', function () {
+    const failure = new Error('boom');
+
+    class BrokenService {
+      @onConstruct(() => {
+        throw failure;
+      })
+      init() {}
+    }
+
+    const container = new Container().useModule(new AddOnConstructHookModule());
+
+    expect(() => container.resolve(BrokenService)).toThrow(failure);
+  });
+
+  it('should expose the resolving scope through the execution context', function () {
+    class BrokenService {
+      @onConstruct(() => {
+        throw new Error('boom');
+      })
+      init() {}
+    }
+
+    let scope: IContainer | undefined;
+    const container = new Container().useModule(
+      new AddOnConstructHookModule((_ex, context) => {
+        scope = context.scope;
+      }),
+    );
+    const child = container.createScope();
+
+    child.resolve(BrokenService);
+
+    expect(scope).toBe(child);
   });
 });

--- a/lib/ExecutionContext.ts
+++ b/lib/ExecutionContext.ts
@@ -1,0 +1,6 @@
+import type { IContainer } from './container/IContainer';
+
+// General execution context passed to callbacks that run within a scope.
+export interface ExecutionContext {
+  scope: IContainer;
+}

--- a/lib/hooks/onConstruct.ts
+++ b/lib/hooks/onConstruct.ts
@@ -2,16 +2,28 @@ import { hook, HookClass, HookFn } from './hook';
 import type { IContainer, IContainerModule } from '../container/IContainer';
 import { constructor, Instance } from '../utils/basic';
 import { HooksRunner } from './HooksRunner';
+import type { ExecutionContext } from '../ExecutionContext';
 
 export const onConstructHooksRunner = new HooksRunner('onConstruct');
 export const onConstruct = (...fns: (HookFn | constructor<HookClass>)[]) => hook('onConstruct', ...fns);
 
 export type OnConstructHook = (instance: Instance, scope: IContainer) => void;
 
+export type OnExceptionHandler = (ex: unknown, context: ExecutionContext) => void;
+
 export class AddOnConstructHookModule implements IContainerModule {
+  constructor(private readonly onException?: OnExceptionHandler) {}
+
   applyTo(container: IContainer) {
     container.addOnConstructHook((instance, scope) => {
-      onConstructHooksRunner.execute(instance, { scope });
+      try {
+        onConstructHooksRunner.execute(instance, { scope });
+      } catch (ex) {
+        if (!this.onException) {
+          throw ex;
+        }
+        this.onException(ex, { scope });
+      }
     });
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -64,7 +64,12 @@ export { CannonSingletonApplyTwiceError } from './errors/CannonSingletonApplyTwi
 export { getHooks, hook, hasHooks, type HookFn, type HookClass, type InjectFn, type HooksOfClass } from './hooks/hook';
 export { HookContext, createHookContextFactory, createHookContext, type IHookContext } from './hooks/HookContext';
 export { injectProp } from './hooks/injectProp';
-export { onConstructHooksRunner, onConstruct, AddOnConstructHookModule } from './hooks/onConstruct';
+export {
+  onConstructHooksRunner,
+  onConstruct,
+  AddOnConstructHookModule,
+  type OnExceptionHandler,
+} from './hooks/onConstruct';
 export { onDisposeHooksRunner, onDispose, AddOnDisposeHookModule } from './hooks/onDispose';
 export { HooksRunner, type HooksRunnerContext, type MapHookContext } from './hooks/HooksRunner';
 
@@ -101,6 +106,9 @@ export { throttle } from './utils/throttle';
 export { debounce } from './utils/debounce';
 export { shallowCache } from './utils/shallowCache';
 export { once } from './utils/once';
+
+// Execution
+export { type ExecutionContext } from './ExecutionContext';
 
 // Utils
 export { select } from './select';


### PR DESCRIPTION
## Summary

Adds an optional `onException` handler as the first constructor argument of `AddOnConstructHookModule`, plus a general `ExecutionContext` interface.

When an `@onConstruct` hook throws during instance construction, the exception is now forwarded to the handler instead of bubbling up — provided a handler was supplied. Without a handler, the exception is rethrown, preserving the previous behavior.

### New API

```ts
new AddOnConstructHookModule((ex: unknown, context: ExecutionContext) => {
  // handle the error; context.scope is the IContainer that resolved the instance
});
```

```ts
export interface ExecutionContext {
  scope: IContainer;
}
```

`ExecutionContext` is introduced as a general-purpose interface for callbacks that run within a scope, and is exported from `lib/index.ts` along with the `OnExceptionHandler` type.

## Changes
- `lib/ExecutionContext.ts` — new `ExecutionContext` interface
- `lib/hooks/onConstruct.ts` — `AddOnConstructHookModule` now accepts an optional `onException` handler; wraps hook execution in try/catch
- `lib/index.ts` — export `ExecutionContext` and `OnExceptionHandler`
- `__tests__/readme/onConstruct.spec.ts` — tests for forwarding, rethrow-when-absent, and scope exposure via the context

## Testing
- `pnpm test` — 326 passed
- `pnpm run type-check` — clean
- `pnpm run lint` — 0 errors (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGZhdbH9TjKakcWaZDEkxH)_