### PR TITLE
feat(hooks): add hasHooks method to HooksRunner

### DIFF
--- a/__tests__/hooks/hook.spec.ts
+++ b/__tests__/hooks/hook.spec.ts
@@ -139,6 +139,37 @@ describe('hooks', () => {
     expect(hasHooks(instance, 'onStart')).toBe(true);
   });
 
+  it('should report whether a target has hooks for the runner key', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+
+    class WithHooks {
+      @hook('onStart', execute)
+      start() {}
+    }
+
+    class WithoutHooks {
+      start() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+
+    expect(onStartHooksRunner.hasHooks(root.resolve(WithHooks))).toBe(true);
+    expect(onStartHooksRunner.hasHooks(root.resolve(WithoutHooks))).toBe(false);
+  });
+
+  it('should report no hooks when the target has hooks under a different key only', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+
+    class MyClass {
+      @hook('onDispose', execute)
+      stop() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+
+    expect(onStartHooksRunner.hasHooks(root.resolve(MyClass))).toBe(false);
+  });
+
   it('should run hooks declared on a parent (extended-from) class', () => {
     const onStartHooksRunner = new HooksRunner('onStart');
 

--- a/lib/hooks/HooksRunner.ts
+++ b/lib/hooks/HooksRunner.ts
@@ -1,6 +1,6 @@
 import { createHookContext, type CreateHookContext, type IHookContext } from './HookContext';
 import type { IContainer } from '../container/IContainer';
-import { getHooks, HookFn, toHookFn } from './hook';
+import { getHooks, hasHooks, HookFn, toHookFn } from './hook';
 import { UnexpectedHookResultError } from '../errors/UnexpectedHookResultError';
 
 import { promisify } from '../utils/promise';
@@ -16,6 +16,10 @@ export type HooksRunnerContext = {
 
 export class HooksRunner {
   constructor(private readonly key: string | symbol) {}
+
+  hasHooks(target: object): boolean {
+    return hasHooks(target, this.key);
+  }
 
   execute(
     target: object,


### PR DESCRIPTION
## Summary

Adds a `hasHooks(target)` method to `HooksRunner` that checks whether a target object has any hooks registered under the runner's key.

The `hasHooks` helper already existed in `lib/hooks/hook.ts` (taking an explicit key argument). This exposes it as a convenience method on `HooksRunner`, so callers that already hold a runner can check for hooks without repeating the key:

```typescript
const onStartHooksRunner = new HooksRunner('onStart');
onStartHooksRunner.hasHooks(instance); // true if instance has 'onStart' hooks
```

The method walks the target's constructor prototype chain (matching the existing hook-collection behavior) and unwraps proxies, so it correctly reports hooks declared on parent classes.

## Changes

- `lib/hooks/HooksRunner.ts`: add `hasHooks(target)` method delegating to the existing `hasHooks` helper with the runner's configured key.
- `__tests__/hooks/hook.spec.ts`: add tests covering targets with hooks, without hooks, and with hooks only under a different key.

## Testing

- `pnpm exec vitest run __tests__/hooks/hook.spec.ts` — 11 passed
- `pnpm run type-check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011xUkDKjnnWedh7radrsxhx)_