### PR TITLE
ci: pin npm to v11 line for OIDC publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,8 +54,11 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - name: Ensure npm 11.5.1 or later for OIDC
+        # Pin to the npm 11 line: it satisfies the OIDC requirement (>= 11.5.1)
+        # while staying compatible with the Node version in .nvmrc. `npm@latest`
+        # now resolves to npm 12, which requires Node >= 24.15.0 and breaks here.
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11
           npm --version
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem

The `publish` workflow fails at the **"Ensure npm 11.5.1 or later for OIDC"** step ([failing run](https://github.com/IgorBabkin/ts-ioc-container/actions/runs/29122060611/job/86459195265)):

```
npm error code EBADENGINE
npm error engine Unsupported engine
npm error notsup Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"node":"v24.14.1","npm":"11.11.0"}
```

`.nvmrc` pins Node `24.14.1`, but `npm install -g npm@latest` now resolves to `npm@12.0.1`, which requires Node `>= 24.15.0`. The engine check fails and the job exits with code 1 before it can publish.

## Fix

Pin the npm upgrade to the **npm 11 line** (`npm install -g npm@11`). npm 11.x:
- still satisfies the OIDC Trusted Publishing requirement (`>= 11.5.1`), and
- stays compatible with the Node version pinned in `.nvmrc`.

The GitHub runner already ships `npm 11.11.0`, so this keeps the effective npm version essentially unchanged while removing the fragile coupling to `npm@latest` jumping ahead of the pinned Node minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bFwHX9MMHV5s87wqJct2C

---
_Generated by [Claude Code](https://claude.ai/code/session_015bFwHX9MMHV5s87wqJct2C)_