### PR TITLE
fix(container): search scope by instance from child to parent

### DIFF
--- a/__tests__/container/IContainer.spec.ts
+++ b/__tests__/container/IContainer.spec.ts
@@ -105,7 +105,7 @@ describe('IContainer', function () {
 
       const logger = child.resolve(FileLogger);
 
-      expect(root.getScopeByInstanceOrFail(logger)).toBe(child);
+      expect(child.getScopeByInstanceOrFail(logger)).toBe(child);
     });
 
     it('should return itself when it owns the instance', () => {
@@ -116,14 +116,23 @@ describe('IContainer', function () {
       expect(root.getScopeByInstanceOrFail(logger)).toBe(root);
     });
 
-    it('should find the instance in a deeply nested scope', () => {
+    it('should find the instance in a parent scope when searching from a child', () => {
+      const root = new Container({ tags: ['root'] });
+      const child = root.createScope({ tags: ['child'] });
+
+      const logger = root.resolve(FileLogger);
+
+      expect(child.getScopeByInstanceOrFail(logger)).toBe(root);
+    });
+
+    it('should find the instance in an ancestor scope from a deeply nested scope', () => {
       const root = new Container({ tags: ['root'] });
       const child = root.createScope({ tags: ['child'] });
       const grandChild = child.createScope({ tags: ['grandChild'] });
 
-      const logger = grandChild.resolve(FileLogger);
+      const logger = root.resolve(FileLogger);
 
-      expect(root.getScopeByInstanceOrFail(logger)).toBe(grandChild);
+      expect(grandChild.getScopeByInstanceOrFail(logger)).toBe(root);
     });
 
     it('should throw ContainerNotFoundError when no scope owns the instance', () => {

--- a/lib/container/Container.ts
+++ b/lib/container/Container.ts
@@ -16,7 +16,6 @@ import { ContainerDisposedError } from '../errors/ContainerDisposedError';
 import { MetadataInjector } from '../injector/MetadataInjector';
 import { AliasMap } from './AliasMap';
 import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
-import { ContainerNotFoundError } from '../errors/ContainerNotFoundError';
 import { OnConstructHook } from '../hooks/onConstruct';
 import { OnDisposeHook } from '../hooks/onDispose';
 import { constructor, Instance, Is } from '../utils/basic';
@@ -191,16 +190,11 @@ export class Container implements IContainer {
   getScopeByInstanceOrFail(instance: object): IContainer {
     this.validateContainer();
 
-    const queue: IContainer[] = [this];
-    while (queue.length > 0) {
-      const scope = queue.shift()!;
-      if (scope.hasInstance(instance)) {
-        return scope;
-      }
-      queue.push(...scope.getScopes());
+    if (this.hasInstance(instance)) {
+      return this;
     }
 
-    throw new ContainerNotFoundError('Cannot find scope for the given instance');
+    return this.parent.getScopeByInstanceOrFail(instance);
   }
 
   removeScope(child: IContainer): void {


### PR DESCRIPTION
## Summary

`getScopeByInstanceOrFail` previously searched the scope tree **parent → child** using a breadth-first traversal over `getScopes()`. This reverses the direction to **child → parent**, so the method:

1. Checks the current scope (`this.hasInstance`) first, and
2. Delegates up the parent chain (`this.parent.getScopeByInstanceOrFail`), terminating at `EmptyContainer` which throws `ContainerNotFoundError`.

This matches the container's natural resolution direction: a scope can see its ancestors' instances but not its descendants'.

## Changes

- `lib/container/Container.ts`: replace the BFS-over-children implementation with a walk up the parent chain; drop the now-unused `ContainerNotFoundError` import (the throw now happens in `EmptyContainer`).
- `__tests__/container/IContainer.spec.ts`: update tests to exercise the child → parent direction — searching from a child/grandchild scope now finds an instance owned by a parent/ancestor scope.

## Testing

- `vitest run` — 330 tests pass
- `pnpm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DG13E6Z6sUngwze2Cyj7Wn)_