### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Description
+
+<!-- Summarize what this PR changes and why. Link any related issues (e.g. Closes #123). -->
+
+## Type of change
+
+<!-- Check the type that matches your commit scope (see Commit Message Conventions in CLAUDE.md). -->
+
+- [ ] `feat` — new feature (minor release)
+- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
+- [ ] `BREAKING CHANGE` — incompatible API change (major release)
+- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release
+
+## Checklist
+
+- [ ] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
+- [ ] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed
+- [ ] Tests added or updated under `__tests__/` to cover the change
+- [ ] `pnpm run lint` passes
+- [ ] `pnpm run type-check` passes
+- [ ] `pnpm test` passes
+- [ ] Commit messages follow Conventional Commits with the correct release/non-release scope
+
+## Additional notes
+
+<!-- Anything reviewers should know: trade-offs, follow-ups, or areas needing extra attention. -->


### PR DESCRIPTION
## Description

Adds a `.github/pull_request_template.md` so new pull requests open with a consistent, project-specific structure. There was no existing template in the repository.

The template is tailored to this repo's conventions:
- **Type of change** maps to the Conventional Commit scopes documented in `CLAUDE.md`, distinguishing release-triggering (`feat`/`fix`/`perf`/`BREAKING CHANGE`) from non-release scopes.
- **Checklist** mirrors the actual CI (`pr-checks.yml` runs `lint`, `type-check`, `test`) plus the repo's file conventions: edit `lib/` only, regenerate `README.md` from `.readme.hbs.md`, and add tests under `__tests__/`.

## Type of change

- [x] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (N/A — repo tooling file under `.github/`)
- [x] Commit messages follow Conventional Commits with the correct non-release scope (`chore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiwncEiA3GNbwd5dJscRHc)_