### PR TITLE
feat(injector): make argsFn a predicate selector and args its index shortcut

### DIFF
--- a/.readme.hbs.md
+++ b/.readme.hbs.md
@@ -287,7 +287,7 @@ Constructor parameters that should pick up positional args from `ProviderOptions
 - `@inject(args(0))` — resolves the first element of the `args` array passed at resolution time
 - Works together with `token.args(...)` to pass typed dependencies through the args context
 
-`args(index)` and `argsFn(fn)` are thin shortcuts for an `InjectFn`. Every `InjectFn` receives `(scope, options)`, where `options.args` is the runtime args array — so `args(0)` is just `(scope, { args = [] }) => args[0]`, and `argsFn(fn)` is `(scope, { args = [] }) => fn(...args)` (the runtime args are spread into your callback as positional parameters).
+`argsFn(predicate)` is the general form: it iterates the runtime `args` array and returns the **first argument matching** `predicate(value, index)` — think `args.find(predicate)`. `args(index)` is just a shortcut for matching by position: `args(0)` is `argsFn((value, index) => index === 0)`. Every `InjectFn` receives `(scope, options)`, where `options.args` is the runtime args array.
 
 ### Immutable token chaining
 

--- a/README.md
+++ b/README.md
@@ -1542,7 +1542,7 @@ Constructor parameters that should pick up positional args from `ProviderOptions
 - `@inject(args(0))` — resolves the first element of the `args` array passed at resolution time
 - Works together with `token.args(...)` to pass typed dependencies through the args context
 
-`args(index)` and `argsFn(fn)` are thin shortcuts for an `InjectFn`. Every `InjectFn` receives `(scope, options)`, where `options.args` is the runtime args array — so `args(0)` is just `(scope, { args = [] }) => args[0]`, and `argsFn(fn)` is `(scope, { args = [] }) => fn(...args)` (the runtime args are spread into your callback as positional parameters).
+`argsFn(predicate)` is the general form: it iterates the runtime `args` array and returns the **first argument matching** `predicate(value, index)` — think `args.find(predicate)`. `args(index)` is just a shortcut for matching by position: `args(0)` is `argsFn((value, index) => index === 0)`. Every `InjectFn` receives `(scope, options)`, where `options.args` is the runtime args array.
 
 ### Immutable token chaining
 

--- a/__tests__/injector/inject.spec.ts
+++ b/__tests__/injector/inject.spec.ts
@@ -42,26 +42,52 @@ describe('inject helpers', () => {
       const container = createContainer().addRegistration(R.fromClass(Service));
       expect(container.resolve<Service>('Service').value).toBeUndefined();
     });
+
+    it('is a shortcut for argsFn matching on index', () => {
+      @register(appendArgs('a', 'b', 'c'))
+      class Service {
+        constructor(
+          @inject(args(1)) public viaArgs: unknown,
+          @inject(argsFn((value, index) => index === 1)) public viaArgsFn: unknown,
+        ) {}
+      }
+
+      const container = createContainer().addRegistration(R.fromClass(Service));
+      const service = container.resolve<Service>('Service');
+      expect(service.viaArgs).toBe('b');
+      expect(service.viaArgsFn).toBe('b');
+    });
   });
 
-  describe('argsFn', () => {
-    it('receives an empty array when no args are provided', () => {
+  describe('argsFn(predicate)', () => {
+    it('returns the first arg matching the predicate', () => {
+      @register(appendArgs(1, 'two', 3))
       class Service {
-        constructor(@inject(argsFn((...a) => a.length)) public count: number) {}
+        constructor(@inject(argsFn((value) => typeof value === 'string')) public value: unknown) {}
       }
 
       const container = createContainer().addRegistration(R.fromClass(Service));
-      expect(container.resolve<Service>('Service').count).toBe(0);
+      expect(container.resolve<Service>('Service').value).toBe('two');
     });
 
-    it('can transform args into a complex object', () => {
-      @register(appendArgsFn(() => ['x', 'y']))
+    it('passes the arg index as the second predicate argument', () => {
+      @register(appendArgsFn(() => ['x', 'y', 'z']))
       class Service {
-        constructor(@inject(argsFn((a, b) => ({ first: a, second: b }))) public data: unknown) {}
+        constructor(@inject(argsFn((value, index) => index === 2)) public value: unknown) {}
       }
 
       const container = createContainer().addRegistration(R.fromClass(Service));
-      expect(container.resolve<Service>('Service').data).toEqual({ first: 'x', second: 'y' });
+      expect(container.resolve<Service>('Service').value).toBe('z');
+    });
+
+    it('returns undefined when no arg matches the predicate', () => {
+      @register(appendArgs('a', 'b'))
+      class Service {
+        constructor(@inject(argsFn((value) => typeof value === 'number')) public value: unknown) {}
+      }
+
+      const container = createContainer().addRegistration(R.fromClass(Service));
+      expect(container.resolve<Service>('Service').value).toBeUndefined();
     });
   });
 });

--- a/__tests__/specs/injector-strategies.spec.ts
+++ b/__tests__/specs/injector-strategies.spec.ts
@@ -24,18 +24,18 @@ describe('Spec: injector strategies', () => {
     class Controller {
       constructor(
         @inject('Logger') readonly logger: Logger,
-        @inject(args(0)) readonly tenant: string,
-        @inject(argsFn((tenant) => `${tenant}:audit`)) readonly auditKey: string,
+        @inject(args(0)) readonly id: number,
+        @inject(argsFn((value) => typeof value === 'string')) readonly tenant: string,
       ) {}
     }
 
     const container = new Container().addRegistration(R.fromClass(Logger)).addRegistration(R.fromClass(Controller));
 
-    const controller = container.resolve<Controller>('Controller', { args: ['tenant-a'] });
+    const controller = container.resolve<Controller>('Controller', { args: [100, 'tenant-a'] });
 
     expect(controller.logger).toBeInstanceOf(Logger);
+    expect(controller.id).toBe(100);
     expect(controller.tenant).toBe('tenant-a');
-    expect(controller.auditKey).toBe('tenant-a:audit');
   });
 
   it('leaves constructor parameters without @inject metadata as undefined', () => {

--- a/docs/src/pages/injector.mdx
+++ b/docs/src/pages/injector.mdx
@@ -46,21 +46,21 @@ The default injector uses TypeScript decorators and reflection metadata to injec
 
 ### `args(index)` and `argsFn` — Positional Arg Injection
 
-`args(index)` and `argsFn(fn)` are thin shortcuts for an `InjectFn`. Every `InjectFn` receives `(scope, options)` as parameters, where `options.args` holds the runtime args array passed via `ProviderOptions`:
+`argsFn(predicate)` is the general form: it iterates the runtime `args` array and returns the **first argument matching** `predicate(value, index)` — think `args.find(predicate)`. `args(index)` is just a shortcut for matching by position. Every `InjectFn` receives `(scope, options)` as parameters, where `options.args` holds the runtime args array passed via `ProviderOptions`:
 
 ```typescript
 class Service {
   constructor(
-    // equivalent to args(0)
-    @inject((scope, { args = [] }) => args[0]) value: string,
+    // args(0) is a shortcut for argsFn((value, index) => index === 0)
+    @inject(args(0)) id: number,
 
-    // equivalent to argsFn((a, b) => (a as number) + (b as number))
-    @inject((scope, { args = [] }) => (args[0] as number) + (args[1] as number)) sum: number,
+    // select the first string argument, whatever its position
+    @inject(argsFn((value) => typeof value === 'string')) tenant: string,
   ) {}
 }
 ```
 
-Use them with `@inject` when you want a constructor parameter to receive a positional argument from the resolution context rather than a registered dependency.
+Use them with `@inject` when you want a constructor parameter to receive an argument from the resolution context — selected by position (`args`) or by predicate (`argsFn`) — rather than a registered dependency.
 
 Constructor parameters that should pick up positional args from `ProviderOptions` must be annotated with `@inject(args(index))`. Parameters without `@inject` resolve to `undefined`. `InjectionToken` values passed in `args` are resolved automatically before they reach the constructor.
 

--- a/lib/injector/MetadataInjector.ts
+++ b/lib/injector/MetadataInjector.ts
@@ -26,16 +26,12 @@ export const inject =
     );
   };
 
-export const args =
-  (index: number): InjectFn =>
-  (c, { args = [] }): unknown => {
-    return args[index];
-  };
-
 export const argsFn =
-  <T>(fn: (...args: unknown[]) => T): InjectFn<T> =>
-  (c, options) =>
-    fn(...(options.args ?? []));
+  <T = unknown>(predicate: (value: unknown, index: number) => boolean): InjectFn<T> =>
+  (c, { args = [] }): T =>
+    args.find((value, index) => predicate(value, index)) as T;
+
+export const args = (index: number): InjectFn => argsFn((value, i) => i === index);
 
 export const resolveArgs = (Target: constructor<unknown>, methodName?: string) => {
   const tokens = getParamMeta(hookMetaKey(methodName), Target) as InjectionToken[];


### PR DESCRIPTION
## Description

Upgrades the `@inject` arg helpers so argument selection is predicate-driven.

- **`argsFn(predicate)`** is now the general form: it iterates the runtime `args` array and returns the **first argument matching** `predicate(value, index)` — think `args.find(predicate)`.
- **`args(index)`** becomes a thin shortcut for matching by position: `args(0)` is `argsFn((value, index) => index === 0)`.

Previously `argsFn(fn)` spread all args into `fn` and returned the transform result; it is now a selector. `args(index)` keeps the same call signature and behaviour for callers.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [x] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

`@inject(argsFn(fn))` no longer spreads args into a transform callback. It now treats `fn` as a predicate and returns the first matching argument. Transform use cases should move to an explicit `InjectFn`, e.g. `@inject((scope, { args = [] }) => ...)`.

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed
- [x] Tests added or updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

Core change: `lib/injector/MetadataInjector.ts`. Tests updated in `__tests__/injector/inject.spec.ts` and `__tests__/specs/injector-strategies.spec.ts`; docs updated in `.readme.hbs.md` / `docs/src/pages/injector.mdx` (and regenerated `README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ApaKRCR2YYamHfzNYWiym)_