### PR TITLE
build(config): dual-format ESM/CJS package exports + environment support docs

### DIFF
--- a/.readme.hbs.md
+++ b/.readme.hbs.md
@@ -27,6 +27,7 @@ provider pipelines, aliases, and custom injector strategies.
 ## Content
 
 - [Setup](#setup)
+- [Environment support](#environment-support)
 - [Quickstart](#quickstart)
 - [Cheatsheet](#cheatsheet)
 - [Container](#container)
@@ -84,6 +85,28 @@ And `tsconfig.json` should have next options:
   }
 }
 ```
+
+## Environment support
+
+`ts-ioc-container` ships both CommonJS and ES module builds (selected
+automatically via the package `exports` map) plus TypeScript declarations, so it
+runs anywhere modern JavaScript does. The package is `sideEffects`-free, so
+bundlers tree-shake unused exports.
+
+| Environment | Supported | Module format | Notes |
+| --- | :---: | --- | --- |
+| Node.js (ESM, `import`) | ✅ | ESM | Node.js 18+; resolved via the `import` condition. |
+| Node.js (CommonJS, `require`) | ✅ | CJS | Node.js 18+; resolved via the `require` condition. |
+| Browser / Web (via bundlers) | ✅ | ESM | webpack, Vite, Rollup, esbuild, Parcel; tree-shakeable. |
+| TypeScript | ✅ | CJS + ESM | Types shipped for both; needs `experimentalDecorators` for the metadata injector. |
+| Deno | ✅ | ESM | Use the `npm:ts-ioc-container` specifier. |
+| Bun | ✅ | CJS + ESM | Runs the native ESM/CJS builds directly. |
+
+> [!NOTE]
+> The default `MetadataInjector` (and the `@inject` / `@onConstruct` /
+> `@onDispose` decorators) rely on `reflect-metadata`. It is declared as an
+> optional peer dependency — install it and import it once at your entrypoint.
+> `SimpleInjector` and `ProxyInjector` do not need it.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ provider pipelines, aliases, and custom injector strategies.
 ## Content
 
 - [Setup](#setup)
+- [Environment support](#environment-support)
 - [Quickstart](#quickstart)
 - [Cheatsheet](#cheatsheet)
 - [Container](#container)
@@ -84,6 +85,28 @@ And `tsconfig.json` should have next options:
   }
 }
 ```
+
+## Environment support
+
+`ts-ioc-container` ships both CommonJS and ES module builds (selected
+automatically via the package `exports` map) plus TypeScript declarations, so it
+runs anywhere modern JavaScript does. The package is `sideEffects`-free, so
+bundlers tree-shake unused exports.
+
+| Environment | Supported | Module format | Notes |
+| --- | :---: | --- | --- |
+| Node.js (ESM, `import`) | ✅ | ESM | Node.js 18+; resolved via the `import` condition. |
+| Node.js (CommonJS, `require`) | ✅ | CJS | Node.js 18+; resolved via the `require` condition. |
+| Browser / Web (via bundlers) | ✅ | ESM | webpack, Vite, Rollup, esbuild, Parcel; tree-shakeable. |
+| TypeScript | ✅ | CJS + ESM | Types shipped for both; needs `experimentalDecorators` for the metadata injector. |
+| Deno | ✅ | ESM | Use the `npm:ts-ioc-container` specifier. |
+| Bun | ✅ | CJS + ESM | Runs the native ESM/CJS builds directly. |
+
+> [!NOTE]
+> The default `MetadataInjector` (and the `@inject` / `@onConstruct` /
+> `@onDispose` decorators) rely on `reflect-metadata`. It is declared as an
+> optional peer dependency — install it and import it once at your entrypoint.
+> `SimpleInjector` and `ProxyInjector` do not need it.
 
 ## Quickstart
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "ts-ioc-container",
   "version": "55.5.0",
   "description": "Fast, lightweight TypeScript dependency injection container with a clean API, scoped lifecycles, decorators, tokens, hooks, lazy injection, customizable providers, and no global container objects.",
-  "workspaces": [
-    "docs"
-  ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
@@ -16,6 +13,19 @@
   "main": "cjm/index.js",
   "types": "typings/index.d.ts",
   "module": "esm/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./typings/index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./typings/index.d.ts",
+        "default": "./cjm/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "keywords": [
     "dependency-injection",
     "inversion-of-control",
@@ -41,10 +51,6 @@
     "service-container",
     "inject"
   ],
-  "directories": {
-    "lib": "lib",
-    "test": "__tests__"
-  },
   "files": [
     "cjm/**/*",
     "esm/**/*",
@@ -56,8 +62,8 @@
   },
   "scripts": {
     "build:cjm": "rimraf cjm && tsc -p tsconfig.production.json --outDir cjm --module CommonJS",
-    "build:esm": "rimraf esm && tsc -p tsconfig.production.json --outDir esm",
-    "build:types": "rimraf typings && tsc -p tsconfig.production.json --outDir typings --emitDeclarationOnly --declaration",
+    "build:esm": "rimraf esm && tsc -p tsconfig.production.json --outDir esm && node scripts/postbuild-extensions.mjs esm --esm",
+    "build:types": "rimraf typings && tsc -p tsconfig.production.json --outDir typings --emitDeclarationOnly --declaration && node scripts/postbuild-extensions.mjs typings",
     "generate:docs": "scripts/generate-readme/generate-readme.ts && git add README.md",
     "build": "npm run build:cjm && npm run build:esm && npm run build:types",
     "test": "vitest run",
@@ -77,6 +83,14 @@
     "docs:serve": "pnpm --filter ts-ioc-container-docs run dev",
     "docs:build": "pnpm --filter ts-ioc-container-docs run build",
     "docs:preview": "pnpm --filter ts-ioc-container-docs run preview"
+  },
+  "peerDependencies": {
+    "reflect-metadata": "^0.2.0"
+  },
+  "peerDependenciesMeta": {
+    "reflect-metadata": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@commitlint/cli": "^20.2.0",
@@ -132,6 +146,6 @@
   },
   "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
   "engines": {
-    "node": ">= 22.14.0"
+    "node": ">= 18"
   }
 }

--- a/scripts/postbuild-extensions.mjs
+++ b/scripts/postbuild-extensions.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Post-processes a build output directory so it is resolvable under Node's
+// native ESM/`node16` rules: relative specifiers get an explicit `.js`
+// extension. When run against the ESM output it also drops a
+// `package.json` marking the folder as ESM (`"type": "module"`).
+//
+// Source stays extensionless (moduleResolution: Node); only the emitted
+// artifact is rewritten, so tests and type-checking are unaffected.
+//
+// Usage: node scripts/postbuild-extensions.mjs <dir> [--esm]
+
+import { readdir, readFile, writeFile, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+const [, , targetArg, ...flags] = process.argv;
+if (!targetArg) {
+  console.error('Usage: node scripts/postbuild-extensions.mjs <dir> [--esm]');
+  process.exit(1);
+}
+const targetDir = resolve(targetArg);
+const isEsm = flags.includes('--esm');
+
+// Rewrites `from '<relative>'` and `import('<relative>')` specifiers that do
+// not already carry an extension. Every relative specifier in this codebase
+// points at a sibling file (no directory/index imports), so a flat `.js`
+// suffix is correct.
+const rewrite = (code) =>
+  code
+    .replace(/(from\s+['"])(\.\.?\/[^'"]+?)(['"])/g, (m, pre, spec, post) =>
+      /\.[cm]?js$/.test(spec) ? m : `${pre}${spec}.js${post}`,
+    )
+    .replace(/(import\(\s*['"])(\.\.?\/[^'"]+?)(['"]\s*\))/g, (m, pre, spec, post) =>
+      /\.[cm]?js$/.test(spec) ? m : `${pre}${spec}.js${post}`,
+    );
+
+const walk = async (dir) => {
+  const entries = await readdir(dir);
+  await Promise.all(
+    entries.map(async (entry) => {
+      const full = join(dir, entry);
+      const info = await stat(full);
+      if (info.isDirectory()) return walk(full);
+      if (/\.(js|d\.ts)$/.test(entry)) {
+        const original = await readFile(full, 'utf8');
+        const updated = rewrite(original);
+        if (updated !== original) await writeFile(full, updated);
+      }
+    }),
+  );
+};
+
+await walk(targetDir);
+
+if (isEsm) {
+  await writeFile(join(targetDir, 'package.json'), `${JSON.stringify({ type: 'module' }, null, 2)}\n`);
+}

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -13,6 +13,7 @@
     "resolveJsonModule": true,
     "noUnusedLocals": true,
     "isolatedModules": true,
+    "removeComments": true,
     "allowImportingTsExtensions": false
   },
   "include": [


### PR DESCRIPTION
## Description

Package audit follow-up: fix and modernize how the package is published, and document runtime support.

**Packaging / exports**
- Add a conditional `exports` map (`import` → ESM, `require` → CJS, each with matching `types`), keeping legacy `main`/`module`/`types` as fallbacks.
- Make the ESM build genuinely loadable under **native Node ESM**. Previously `esm/index.js` failed with `ERR_MODULE_NOT_FOUND` (extensionless relative imports) and emitted a `MODULE_TYPELESS_PACKAGE_JSON` warning; it only worked through bundlers reading the legacy `module` field. A new `scripts/postbuild-extensions.mjs` appends `.js` to relative specifiers in `esm/` and `typings/` and writes `esm/package.json` `{"type":"module"}`. **Source stays extensionless** (`moduleResolution: Node`), so tests and type-check are unaffected — only the build artifact is rewritten.
- Declare `reflect-metadata` as an **optional `peerDependency`** so consumers get a signal it's required by the metadata injector (it was only a devDependency).

**Size / hygiene**
- Enable `removeComments` in the production build.
- Loosen `engines.node` from `>= 22.14.0` to `>= 18`.
- Drop the redundant npm `workspaces` and cosmetic `directories` fields (pnpm already uses `pnpm-workspace.yaml`).

**Docs**
- Add an **Environment support** table to the README (Node.js ESM/CJS, browser via bundlers, TypeScript, Deno, Bun) plus a note on the optional `reflect-metadata` requirement.

Verified: `require('ts-ioc-container')` and `import('ts-ioc-container')` both resolve all 82 exports via the new `exports` map (tested through a symlinked consumer in both CJS and ESM package contexts).

## Type of change

- [x] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

Committed as `build(config):` + `docs(pages):` (non-release). Note: this is a genuine consumer-facing packaging improvement — if you'd prefer it to ship as a release, re-tag the packaging commit as `feat`/`fix` before merging.

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`) — no `lib/` changes; only build config, a postbuild script, and README source
- [x] `README.md` regenerated via `pnpm run generate:docs` after editing `.readme.hbs.md`
- [ ] Tests added or updated under `__tests__/` — N/A (build/packaging config; no runtime source changed)
- [x] `pnpm run lint` passes (0 errors)
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes (70 files / 332 tests)
- [x] Commit messages follow Conventional Commits with a non-release scope

## Additional notes

The `typings/` tree also gets `.js` extensions on relative imports, which is correct for consumers using `moduleResolution: node16`/`nodenext` and harmless for classic/bundler resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yKg3gCUbneLPiWtmYtnbC

---
_Generated by [Claude Code](https://claude.ai/code/session_015yKg3gCUbneLPiWtmYtnbC)_