### PR TITLE
feat(hooks): rename onDispose decorator to onContainerDisposed

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -14,7 +14,7 @@ This is a TypeScript Inversion of Control (IoC) container library. The project p
 ## Code Style & Conventions
 - Use TypeScript with strict typing
 - Follow existing patterns in the codebase
-- Use decorators for metadata injection (`@inject`, `@onConstruct`, `@onDispose`)
+- Use decorators for metadata injection (`@inject`, `@onConstruct`, `@onContainerDisposed`)
 - Prefer explicit types over `any` (use `any` only when necessary, with warnings)
 - Use interfaces for contracts (e.g., `IContainer`, `IProvider`, `IInjector`)
 - Follow the existing error handling patterns with custom error classes
@@ -48,7 +48,7 @@ This is a TypeScript Inversion of Control (IoC) container library. The project p
 - **Provider**: Handles instance creation and caching strategies. It's like a function which creates/return instance of dependency.
 - **Injector**: Manages dependency injection (Metadata, Simple, Proxy). It describes how to inject dependencies into the target constructor.
 - **Scopes**: Tagged scopes for request-level or feature-level isolation. It's just a container inside of another container. So container can create a scope inside of it.
-- **Hooks**: Lifecycle hooks (`@hook`, `@onConstruct`, `@onDispose`)
+- **Hooks**: Lifecycle hooks (`@hook`, `@onConstruct`, `@onContainerDisposed`)
 - **Tokens**: Various token types for dependency identification
 
 ## When Making Changes

--- a/.readme.hbs.md
+++ b/.readme.hbs.md
@@ -19,7 +19,7 @@ provider pipelines, aliases, and custom injector strategies.
 - clean API for classes, keys, tokens, aliases, and scopes
 - no global container object; pass containers and scopes explicitly
 - supports tagged application, request, transaction, page, and widget scopes
-- decorator support with `@register`, `@inject`, `@onConstruct`, and `@onDispose`
+- decorator support with `@register`, `@inject`, `@onConstruct`, and `@onContainerDisposed`
 - can [inject properties](#inject-property)
 - can inject [lazy dependencies](#lazy)
 - composable provider and registration pipelines
@@ -53,7 +53,7 @@ provider pipelines, aliases, and custom injector strategies.
 - [Module](#module)
 - [Hook](#hook) `@hook`
   - [OnConstruct](#onconstruct) `@onConstruct`
-  - [OnDispose](#ondispose) `@onDispose`
+  - [OnContainerDisposed](#oncontainerdisposed) `@onContainerDisposed`
   - [Inject Property](#inject-property)
   - [Inject Method](#inject-method)
 - [Mock](#mock)
@@ -104,7 +104,7 @@ bundlers tree-shake unused exports.
 
 > [!NOTE]
 > The default `MetadataInjector` (and the `@inject` / `@onConstruct` /
-> `@onDispose` decorators) rely on `reflect-metadata`. It is declared as an
+> `@onContainerDisposed` decorators) rely on `reflect-metadata`. It is declared as an
 > optional peer dependency — install it and import it once at your entrypoint.
 > `SimpleInjector` and `ProxyInjector` do not need it.
 
@@ -181,7 +181,7 @@ Sometimes you want to get all instances from container and its scopes. For examp
 Sometimes you want to dispose a container or scope. For example, when a request, page, widget, or other local lifecycle ends.
 
 - container can be disposed
-- when container is disposed then it runs its `onDispose` hooks, unregisters its providers, removes its local instances, and detaches from its parent
+- when container is disposed then it runs its `onContainerDisposed` hooks, unregisters its providers, removes its local instances, and detaches from its parent
 
 > [!IMPORTANT]
 > Dispose is local to the container being disposed. Child scopes are not disposed automatically; dispose them explicitly when their own lifecycle ends.
@@ -415,10 +415,10 @@ Sometimes you need to invoke methods after construct or dispose of class. This i
 {{{include_file '__tests__/readme/onConstruct.spec.ts'}}}
 ```
 
-### OnDispose
+### OnContainerDisposed
 
 ```typescript
-{{{include_file '__tests__/readme/onDispose.spec.ts'}}}
+{{{include_file '__tests__/readme/onContainerDisposed.spec.ts'}}}
 ```
 
 ### Inject property

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ EntityManagerToken.args(UserRepositoryToken).resolve(container);
 
 ### Hooks
 
-`@onConstruct` and `@onDispose` decorators trigger after construction / on disposal. Requires adding `AddOnConstructHookModule` / `AddOnDisposeHookModule` to the container. `@hook` is the generic base. `injectProp` enables property injection within hooks.
+`@onConstruct` and `@onContainerDisposed` decorators trigger after construction / on disposal. Requires adding `AddOnConstructHookModule` / `AddOnDisposeHookModule` to the container. `@hook` is the generic base. `injectProp` enables property injection within hooks.
 
 ## Important File Conventions
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ provider pipelines, aliases, and custom injector strategies.
 - clean API for classes, keys, tokens, aliases, and scopes
 - no global container object; pass containers and scopes explicitly
 - supports tagged application, request, transaction, page, and widget scopes
-- decorator support with `@register`, `@inject`, `@onConstruct`, and `@onDispose`
+- decorator support with `@register`, `@inject`, `@onConstruct`, and `@onContainerDisposed`
 - can [inject properties](#inject-property)
 - can inject [lazy dependencies](#lazy)
 - composable provider and registration pipelines
@@ -53,7 +53,7 @@ provider pipelines, aliases, and custom injector strategies.
 - [Module](#module)
 - [Hook](#hook) `@hook`
   - [OnConstruct](#onconstruct) `@onConstruct`
-  - [OnDispose](#ondispose) `@onDispose`
+  - [OnContainerDisposed](#oncontainerdisposed) `@onContainerDisposed`
   - [Inject Property](#inject-property)
   - [Inject Method](#inject-method)
 - [Mock](#mock)
@@ -104,7 +104,7 @@ bundlers tree-shake unused exports.
 
 > [!NOTE]
 > The default `MetadataInjector` (and the `@inject` / `@onConstruct` /
-> `@onDispose` decorators) rely on `reflect-metadata`. It is declared as an
+> `@onContainerDisposed` decorators) rely on `reflect-metadata`. It is declared as an
 > optional peer dependency — install it and import it once at your entrypoint.
 > `SimpleInjector` and `ProxyInjector` do not need it.
 
@@ -449,7 +449,7 @@ describe('Instances', function () {
 Sometimes you want to dispose a container or scope. For example, when a request, page, widget, or other local lifecycle ends.
 
 - container can be disposed
-- when container is disposed then it runs its `onDispose` hooks, unregisters its providers, removes its local instances, and detaches from its parent
+- when container is disposed then it runs its `onContainerDisposed` hooks, unregisters its providers, removes its local instances, and detaches from its parent
 
 > [!IMPORTANT]
 > Dispose is local to the container being disposed. Child scopes are not disposed automatically; dispose them explicitly when their own lifecycle ends.
@@ -468,7 +468,7 @@ import { bindTo, Container, ContainerDisposedError, register, Registration as R,
  * - Cache entries cleared
  *
  * The container.dispose() method:
- * 1. Executes all onDispose hooks
+ * 1. Executes all onContainerDisposed hooks
  * 2. Clears all instances and registrations
  * 3. Detaches from parent scope
  * 4. Prevents further resolution
@@ -2584,7 +2584,7 @@ describe('onConstruct', function () {
 
 ```
 
-### OnDispose
+### OnContainerDisposed
 
 ```typescript
 import 'reflect-metadata';
@@ -2594,7 +2594,7 @@ import {
   Container,
   type HookFn,
   inject,
-  onDispose,
+  onContainerDisposed,
   register,
   Registration as R,
   singleton,
@@ -2623,13 +2623,13 @@ class Logger {
     this.messages.push(message);
   }
 
-  @onDispose(execute)
+  @onContainerDisposed(execute)
   save() {
     this.logsRepo.saveLogs(this.messages);
   }
 }
 
-describe('onDispose', function () {
+describe('onContainerDisposed', function () {
   it('should invoke hooks on all instances when container is disposed', function () {
     const container = new Container()
       .useModule(new AddOnDisposeHookModule())

--- a/__tests__/readme/customHooks.spec.ts
+++ b/__tests__/readme/customHooks.spec.ts
@@ -4,7 +4,7 @@ import { Container, hook, HooksRunner, type HookFn } from '../../lib';
  * User Management Domain - Custom Lifecycle Hooks
  *
  * Custom hooks extend the container's lifecycle management beyond
- * the built-in @onConstruct and @onDispose hooks.
+ * the built-in @onConstruct and @onContainerDisposed hooks.
  *
  * Use cases:
  * - @validateConfig: Validate service configuration after construction

--- a/__tests__/readme/disposing.spec.ts
+++ b/__tests__/readme/disposing.spec.ts
@@ -11,7 +11,7 @@ import { bindTo, Container, ContainerDisposedError, register, Registration as R,
  * - Cache entries cleared
  *
  * The container.dispose() method:
- * 1. Executes all onDispose hooks
+ * 1. Executes all onContainerDisposed hooks
  * 2. Clears all instances and registrations
  * 3. Detaches from parent scope
  * 4. Prevents further resolution

--- a/__tests__/readme/onContainerDisposed.spec.ts
+++ b/__tests__/readme/onContainerDisposed.spec.ts
@@ -5,7 +5,7 @@ import {
   Container,
   type HookFn,
   inject,
-  onDispose,
+  onContainerDisposed,
   register,
   Registration as R,
   singleton,
@@ -34,13 +34,13 @@ class Logger {
     this.messages.push(message);
   }
 
-  @onDispose(execute)
+  @onContainerDisposed(execute)
   save() {
     this.logsRepo.saveLogs(this.messages);
   }
 }
 
-describe('onDispose', function () {
+describe('onContainerDisposed', function () {
   it('should invoke hooks on all instances when container is disposed', function () {
     const container = new Container()
       .useModule(new AddOnDisposeHookModule())

--- a/__tests__/specs/lifecycle-hooks.spec.ts
+++ b/__tests__/specs/lifecycle-hooks.spec.ts
@@ -11,7 +11,7 @@ import {
   inject,
   injectProp,
   onConstruct,
-  onDispose,
+  onContainerDisposed,
   Registration as R,
   UnexpectedHookResultError,
 } from '../../lib';
@@ -31,7 +31,7 @@ describe('Spec: lifecycle hooks', () => {
         this.initialized = true;
       }
 
-      @onDispose(invoke)
+      @onContainerDisposed(invoke)
       destroy(): void {
         this.disposed = true;
       }

--- a/docs/adr/0007-lifecycle-hooks.md
+++ b/docs/adr/0007-lifecycle-hooks.md
@@ -18,7 +18,7 @@ not need it.
 Store hook declarations with `reflect-metadata`, but activate lifecycle
 execution through container modules.
 
-Decorators such as `onConstruct` and `onDispose` attach hook metadata to class
+Decorators such as `onConstruct` and `onContainerDisposed` attach hook metadata to class
 methods. `HooksRunner` reads that metadata and executes hook functions or
 hook classes. `AddOnConstructHookModule` and `AddOnDisposeHookModule` opt a
 container into running those hooks during instance construction and scope
@@ -65,6 +65,6 @@ execution path.
 - `lib/hooks/hook.ts`
 - `lib/hooks/HooksRunner.ts`
 - `lib/hooks/onConstruct.ts`
-- `lib/hooks/onDispose.ts`
+- `lib/hooks/onContainerDisposed.ts`
 - `lib/hooks/HookContext.ts`
 - `docs/src/pages/hooks.mdx`

--- a/docs/src/assets/diagrams/create-scope-flow.mermaid
+++ b/docs/src/assets/diagrams/create-scope-flow.mermaid
@@ -1,5 +1,5 @@
 flowchart TD
-    Create([Create new Container as Scope<br/>with parent reference]) --> CopyHooks[Copy hooks<br/>onConstruct, onDispose]
+    Create([Create new Container as Scope<br/>with parent reference]) --> CopyHooks[Copy hooks<br/>onConstruct, onContainerDisposed]
     CopyHooks --> GetRegs[Get all registrations<br/>parent + current scope]
     GetRegs --> Apply[Apply registration to new scope]
     Apply --> AddScope[Add scope to<br/>scopes list]

--- a/docs/src/config/headings.ts
+++ b/docs/src/config/headings.ts
@@ -197,7 +197,7 @@ export const pageHeadings: Record<string, Heading[]> = {
   "/ts-ioc-container/hooks": [
     { id: "what-are-hooks", text: "What are Hooks?", level: 2 },
     { id: "onconstruct", text: "OnConstruct Hooks", level: 2 },
-    { id: "ondispose", text: "OnDispose Hooks", level: 2 },
+    { id: "oncontainerdisposed", text: "OnContainerDisposed Hooks", level: 2 },
     { id: "property-injection", text: "Property Injection", level: 2 },
     { id: "custom-hooks", text: "Custom Hooks", level: 2 },
     {

--- a/docs/src/pages/hooks.mdx
+++ b/docs/src/pages/hooks.mdx
@@ -7,7 +7,7 @@ description: Add TypeScript dependency injection lifecycle hooks for instance in
 import CodeBlock from "../components/CodeBlock.astro";
 import injectPropSpecCode from "../../../__tests__/readme/injectProp.spec.ts?raw";
 import onConstructSpecCode from "../../../__tests__/readme/onConstruct.spec.ts?raw";
-import onDisposeSpecCode from "../../../__tests__/readme/onDispose.spec.ts?raw";
+import onContainerDisposedSpecCode from "../../../__tests__/readme/onContainerDisposed.spec.ts?raw";
 import hookSpecCode from "../../../__tests__/hooks/hook.spec.ts?raw";
 import customHooksSpecCode from "../../../__tests__/readme/customHooks.spec.ts?raw";
 
@@ -47,18 +47,18 @@ Register an onConstruct hook on your container, then decorate methods with `@onC
 - **CacheService** - Warm up cache with frequently accessed data
 - **EmailNotifier** - Validate SMTP configuration before first use
 
-## OnDispose Hooks
+## OnContainerDisposed Hooks
 
-OnDispose hooks execute before an instance is disposed, allowing you to clean up resources, save state, or perform other cleanup operations.
+OnContainerDisposed hooks execute before an instance is disposed, allowing you to clean up resources, save state, or perform other cleanup operations.
 
 ### Basic Usage
 
-Register an onDispose hook on your container, then decorate methods with `@onDispose`:
+Register an onContainerDisposed hook on your container, then decorate methods with `@onContainerDisposed`:
 
 <CodeBlock
-  code={onDisposeSpecCode}
+  code={onContainerDisposedSpecCode}
   lang="typescript"
-  filename="__tests__/readme/onDispose.spec.ts"
+  filename="__tests__/readme/onContainerDisposed.spec.ts"
 />
 
 ### Use Cases
@@ -179,9 +179,9 @@ beforeHooksRunner.execute(instance, {
 </div>
 
 - **Use OnConstruct for initialization** - Initialize dependencies, validate state, or set up connections after construction
-- **Use OnDispose for cleanup** - Close resources, save state, or unsubscribe from events before disposal
+- **Use OnContainerDisposed for cleanup** - Close resources, save state, or unsubscribe from events before disposal
 - **Keep hook logic simple** - Hooks should perform focused operations, not complex business logic
 - **Resolve dependencies in hooks** - Use `ctx.resolveArgs()` to inject dependencies that weren't available at construction time
 - **Handle async hooks properly** - Use `executeAsync` when hooks may be asynchronous
-- **Register hooks once** - Set up onConstruct and onDispose hooks when creating your root container
+- **Register hooks once** - Set up onConstruct and onContainerDisposed hooks when creating your root container
 - **Prefer constructor injection** - Use property injection with hooks only when constructor injection isn't possible

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -29,7 +29,7 @@ Awilix.
 - Clean API for registering and resolving services by class, key, token, or alias
 - No global container object; pass scopes explicitly through your app boundary
 - Tagged scopes for application, request, transaction, page, and widget lifecycles
-- Decorator support with `@register`, `@inject`, `@onConstruct`, and `@onDispose`
+- Decorator support with `@register`, `@inject`, `@onConstruct`, and `@onContainerDisposed`
 - Lazy dependencies, property injection, custom hooks, and provider decoration
 - Composable provider and registration pipes for project-specific behavior
 

--- a/docs/src/pages/metadata.mdx
+++ b/docs/src/pages/metadata.mdx
@@ -8,7 +8,7 @@ import CodeBlock from "../components/CodeBlock.astro";
 
 # Metadata
 
-The metadata module provides a low-level API for storing and retrieving metadata on classes, methods, and parameters using the `reflect-metadata` library. This system forms the foundation for decorators like `@register`, `@inject`, `@onConstruct`, and `@onDispose`.
+The metadata module provides a low-level API for storing and retrieving metadata on classes, methods, and parameters using the `reflect-metadata` library. This system forms the foundation for decorators like `@register`, `@inject`, `@onConstruct`, and `@onContainerDisposed`.
 
 <h2 id="what-is-metadata" class="toc-link">What is Metadata?</h2>
 
@@ -352,7 +352,7 @@ The metadata system powers the core decorators:
 
 - **@register** - Uses `addClassMeta` to store registration transformers
 - **@inject** - Uses `addParamMeta` to specify constructor dependencies
-- **@onConstruct/@onDispose/@hook** - Use `addMethodMeta` for lifecycle hooks
+- **@onConstruct/@onContainerDisposed/@hook** - Use `addMethodMeta` for lifecycle hooks
 
 <h2 id="best-practices" class="toc-link">Best Practices</h2>
 

--- a/docs/src/pages/tsyringe-alternative.mdx
+++ b/docs/src/pages/tsyringe-alternative.mdx
@@ -31,10 +31,10 @@ objects are created.
 | ---- | -------------------- |
 | Fast TypeScript dependency resolution | Lightweight runtime with executable benchmark coverage against tsyringe |
 | Request or transaction scopes | Tagged child containers and scoped registration rules |
-| Decorator-based injection | `@register`, `@inject`, `@onConstruct`, `@onDispose`, and metadata utilities |
+| Decorator-based injection | `@register`, `@inject`, `@onConstruct`, `@onContainerDisposed`, and metadata utilities |
 | Explicit dependency tokens | Class, key, alias, function, constant, lazy, and grouped token shapes |
 | Custom factories | Provider APIs for values, classes, factories, arguments, singletons, visibility, and decoration |
-| Lifecycle cleanup | Disposable scopes and `onDispose` hooks |
+| Lifecycle cleanup | Disposable scopes and `onContainerDisposed` hooks |
 | Framework integration | Recipes for Express.js, Fastify, Next.js, React, and SolidJS |
 | Custom behavior | Pluggable injectors, provider pipes, registration pipes, and custom hooks |
 

--- a/lib/container/Container.ts
+++ b/lib/container/Container.ts
@@ -17,7 +17,7 @@ import { MetadataInjector } from '../injector/MetadataInjector';
 import { AliasMap } from './AliasMap';
 import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
 import { OnConstructHook } from '../hooks/onConstruct';
-import { OnDisposeHook } from '../hooks/onDispose';
+import { OnDisposeHook } from '../hooks/onContainerDisposed';
 import { constructor, Instance, Is } from '../utils/basic';
 import { Filter as F } from '../utils/array';
 

--- a/lib/container/EmptyContainer.ts
+++ b/lib/container/EmptyContainer.ts
@@ -11,7 +11,7 @@ import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
 import { ContainerNotFoundError } from '../errors/ContainerNotFoundError';
 import { type IProvider } from '../provider/IProvider';
 import { type IRegistration } from '../registration/IRegistration';
-import { OnDisposeHook } from '../hooks/onDispose';
+import { OnDisposeHook } from '../hooks/onContainerDisposed';
 import { OnConstructHook } from '../hooks/onConstruct';
 import { type constructor, type Instance } from '../utils/basic';
 

--- a/lib/container/IContainer.ts
+++ b/lib/container/IContainer.ts
@@ -1,7 +1,7 @@
 import { type IProvider, ProviderOptions } from '../provider/IProvider';
 import { type IRegistration } from '../registration/IRegistration';
 import { OnConstructHook } from '../hooks/onConstruct';
-import { OnDisposeHook } from '../hooks/onDispose';
+import { OnDisposeHook } from '../hooks/onContainerDisposed';
 import { type constructor, Instance } from '../utils/basic';
 
 export type DependencyKey = string | symbol;

--- a/lib/hooks/onContainerDisposed.ts
+++ b/lib/hooks/onContainerDisposed.ts
@@ -3,8 +3,8 @@ import type { IContainer, IContainerModule } from '../container/IContainer';
 import { HooksRunner } from './HooksRunner';
 import { type constructor } from '../utils/basic';
 
-export const onDisposeHooksRunner = new HooksRunner('onDispose');
-export const onDispose = (...fns: (HookFn | constructor<HookClass>)[]) => hook('onDispose', ...fns);
+export const onContainerDisposedHooksRunner = new HooksRunner('onContainerDisposed');
+export const onContainerDisposed = (...fns: (HookFn | constructor<HookClass>)[]) => hook('onContainerDisposed', ...fns);
 
 export type OnDisposeHook = (scope: IContainer) => void;
 
@@ -12,7 +12,7 @@ export class AddOnDisposeHookModule implements IContainerModule {
   applyTo(container: IContainer) {
     container.addOnDisposeHook((scope) => {
       for (const instance of scope.getInstances()) {
-        onDisposeHooksRunner.execute(instance, { scope });
+        onContainerDisposedHooksRunner.execute(instance, { scope });
       }
     });
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -70,7 +70,11 @@ export {
   AddOnConstructHookModule,
   type OnExceptionHandler,
 } from './hooks/onConstruct';
-export { onDisposeHooksRunner, onDispose, AddOnDisposeHookModule } from './hooks/onDispose';
+export {
+  onContainerDisposedHooksRunner,
+  onContainerDisposed,
+  AddOnDisposeHookModule,
+} from './hooks/onContainerDisposed';
 export { HooksRunner, type HooksRunnerContext, type MapHookContext } from './hooks/HooksRunner';
 
 // Tokens

--- a/specs/epics/lifecycle-hooks.md
+++ b/specs/epics/lifecycle-hooks.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0007 - Lifecycle hooks via reflect-metadata and opt-in modules](../../docs/adr/0007-lifecycle-hooks.md)
-- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `onConstruct`, `onDispose`, `injectProp`, `AddOnConstructHookModule`, `AddOnDisposeHookModule`
+- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `onConstruct`, `onContainerDisposed`, `injectProp`, `AddOnConstructHookModule`, `AddOnDisposeHookModule`
 - **Executable spec:** `__tests__/specs/lifecycle-hooks.spec.ts`
 
 ## Intent
@@ -33,7 +33,7 @@ so that local resources are released at the lifecycle boundary.
 
 Acceptance criteria:
 
-- `onDispose` stores hook metadata on a method.
+- `onContainerDisposed` stores hook metadata on a method.
 - `AddOnDisposeHookModule` opts a container into dispose hook execution.
 - Dispose hooks run for instances tracked by the disposed scope.
 - Disposing a scope does not implicitly run hooks for child scopes.
@@ -65,7 +65,7 @@ Acceptance criteria:
 
 As an application developer, I can attach disposal callbacks directly to a
 container so that cleanup logic runs when the container is disposed without
-needing a class decorated with `@onDispose`.
+needing a class decorated with `@onContainerDisposed`.
 
 Acceptance criteria:
 


### PR DESCRIPTION
## Description

Renames the `onDispose` lifecycle hook decorator (and its `HooksRunner` export) to `onContainerDisposed`, making it clearer that the hook fires when the owning container/scope is disposed — mirroring the existing `onConstruct` naming.

- `lib/hooks/onDispose.ts` → `lib/hooks/onContainerDisposed.ts`
- `onDispose` (decorator) → `onContainerDisposed`
- `onDisposeHooksRunner` → `onContainerDisposedHooksRunner`
- Updated all usages in tests, `README.md` (regenerated from `.readme.hbs.md`), docs site pages, ADR 0007, the lifecycle-hooks epic spec, `CLAUDE.md`, and `.cursorrules`.

`addOnDisposeHook`, `AddOnDisposeHookModule`, and the `OnDisposeHook` type are intentionally left unchanged — they describe the lower-level container API for registering raw dispose callbacks, not the `@onDispose` decorator itself.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [x] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` since `.readme.hbs.md` changed
- [x] Tests updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes (332 tests)
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

This is a breaking change for anyone importing `onDispose`/`onDisposeHooksRunner` or using `@onDispose(...)` — they must switch to `onContainerDisposed`/`onContainerDisposedHooksRunner`/`@onContainerDisposed(...)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjPL5nZgUx3yt27hTzNbVd)_