### PR TITLE
feat(hooks): add onConstructAsync decorator and module

### DIFF
--- a/.readme.hbs.md
+++ b/.readme.hbs.md
@@ -53,6 +53,7 @@ provider pipelines, aliases, and custom injector strategies.
 - [Module](#module)
 - [Hook](#hook) `@hook`
   - [OnConstruct](#onconstruct) `@onConstruct`
+  - [OnConstructAsync](#onconstructasync) `@onConstructAsync`
   - [OnContainerDisposed](#oncontainerdisposed) `@onContainerDisposed`
   - [Inject Property](#inject-property)
   - [Inject Method](#inject-method)
@@ -413,6 +414,16 @@ Sometimes you need to invoke methods after construct or dispose of class. This i
 
 ```typescript
 {{{include_file '__tests__/readme/onConstruct.spec.ts'}}}
+```
+
+### OnConstructAsync
+
+`@onConstructAsync` runs promise-returning initialization. Resolution stays
+synchronous: `AddOnConstructAsyncHookModule` starts the hooks when the instance
+is created and they settle afterwards, so `resolve` returns before they finish.
+
+```typescript
+{{{include_file '__tests__/readme/onConstructAsync.spec.ts'}}}
 ```
 
 ### OnContainerDisposed

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ provider pipelines, aliases, and custom injector strategies.
 - [Module](#module)
 - [Hook](#hook) `@hook`
   - [OnConstruct](#onconstruct) `@onConstruct`
+  - [OnConstructAsync](#onconstructasync) `@onConstructAsync`
   - [OnContainerDisposed](#oncontainerdisposed) `@onContainerDisposed`
   - [Inject Property](#inject-property)
   - [Inject Method](#inject-method)
@@ -2579,6 +2580,94 @@ describe('onConstruct', function () {
     child.resolve(BrokenService);
 
     expect(scope).toBe(child);
+  });
+});
+
+```
+
+### OnConstructAsync
+
+`@onConstructAsync` runs promise-returning initialization. Resolution stays
+synchronous: `AddOnConstructAsyncHookModule` starts the hooks when the instance
+is created and they settle afterwards, so `resolve` returns before they finish.
+
+```typescript
+import 'reflect-metadata';
+import {
+  AddOnConstructAsyncHookModule,
+  Container,
+  type ExecutionContext,
+  type HookFn,
+  inject,
+  onConstructAsync,
+  Registration as R,
+} from 'ts-ioc-container';
+
+const execute: HookFn = async (ctx) => {
+  await ctx.invokeMethod({ args: ctx.resolveArgs() });
+};
+
+describe('onConstructAsync', function () {
+  it('should run an async initialization method after the instance is created', async function () {
+    class DatabaseConnection {
+      isConnected = false;
+      connectionString = '';
+      readonly ready: Promise<void>;
+
+      private markReady!: () => void;
+
+      constructor() {
+        this.ready = new Promise((resolve) => {
+          this.markReady = resolve;
+        });
+      }
+
+      @onConstructAsync(execute)
+      async connect(@inject('ConnectionString') connectionString: string) {
+        await Promise.resolve();
+        this.connectionString = connectionString;
+        this.isConnected = true;
+        this.markReady();
+      }
+    }
+
+    const container = new Container()
+      .useModule(new AddOnConstructAsyncHookModule())
+      .addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
+
+    const db = container.resolve(DatabaseConnection);
+
+    // resolution does not wait for async hooks
+    expect(db.isConnected).toBe(false);
+
+    await db.ready;
+
+    expect(db.isConnected).toBe(true);
+    expect(db.connectionString).toBe('postgres://localhost:5432');
+  });
+
+  it('should forward rejected hooks to the onException handler with the execution context', async function () {
+    const failure = new Error('boom');
+
+    class BrokenService {
+      @onConstructAsync(() => Promise.reject(failure))
+      init() {}
+    }
+
+    let captured: { ex: unknown; context: ExecutionContext } | undefined;
+    const container = new Container().useModule(
+      new AddOnConstructAsyncHookModule((ex, context) => {
+        captured = { ex, context };
+      }),
+    );
+
+    const child = container.createScope();
+    child.resolve(BrokenService);
+
+    await vi.waitFor(() => expect(captured).toBeDefined());
+
+    expect(captured?.ex).toBe(failure);
+    expect(captured?.context.scope).toBe(child);
   });
 });
 

--- a/__tests__/readme/onConstructAsync.spec.ts
+++ b/__tests__/readme/onConstructAsync.spec.ts
@@ -1,0 +1,78 @@
+import 'reflect-metadata';
+import {
+  AddOnConstructAsyncHookModule,
+  Container,
+  type ExecutionContext,
+  type HookFn,
+  inject,
+  onConstructAsync,
+  Registration as R,
+} from '../../lib';
+
+const execute: HookFn = async (ctx) => {
+  await ctx.invokeMethod({ args: ctx.resolveArgs() });
+};
+
+describe('onConstructAsync', function () {
+  it('should run an async initialization method after the instance is created', async function () {
+    class DatabaseConnection {
+      isConnected = false;
+      connectionString = '';
+      readonly ready: Promise<void>;
+
+      private markReady!: () => void;
+
+      constructor() {
+        this.ready = new Promise((resolve) => {
+          this.markReady = resolve;
+        });
+      }
+
+      @onConstructAsync(execute)
+      async connect(@inject('ConnectionString') connectionString: string) {
+        await Promise.resolve();
+        this.connectionString = connectionString;
+        this.isConnected = true;
+        this.markReady();
+      }
+    }
+
+    const container = new Container()
+      .useModule(new AddOnConstructAsyncHookModule())
+      .addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
+
+    const db = container.resolve(DatabaseConnection);
+
+    // resolution does not wait for async hooks
+    expect(db.isConnected).toBe(false);
+
+    await db.ready;
+
+    expect(db.isConnected).toBe(true);
+    expect(db.connectionString).toBe('postgres://localhost:5432');
+  });
+
+  it('should forward rejected hooks to the onException handler with the execution context', async function () {
+    const failure = new Error('boom');
+
+    class BrokenService {
+      @onConstructAsync(() => Promise.reject(failure))
+      init() {}
+    }
+
+    let captured: { ex: unknown; context: ExecutionContext } | undefined;
+    const container = new Container().useModule(
+      new AddOnConstructAsyncHookModule((ex, context) => {
+        captured = { ex, context };
+      }),
+    );
+
+    const child = container.createScope();
+    child.resolve(BrokenService);
+
+    await vi.waitFor(() => expect(captured).toBeDefined());
+
+    expect(captured?.ex).toBe(failure);
+    expect(captured?.context.scope).toBe(child);
+  });
+});

--- a/__tests__/specs/lifecycle-hooks.spec.ts
+++ b/__tests__/specs/lifecycle-hooks.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {
+  AddOnConstructAsyncHookModule,
   AddOnConstructHookModule,
   AddOnDisposeHookModule,
   Container,
@@ -11,6 +12,7 @@ import {
   inject,
   injectProp,
   onConstruct,
+  onConstructAsync,
   onContainerDisposed,
   Registration as R,
   UnexpectedHookResultError,
@@ -49,6 +51,48 @@ describe('Spec: lifecycle hooks', () => {
     container.dispose();
 
     expect(resource.disposed).toBe(true);
+  });
+
+  it('runs async construct hooks without blocking resolution', async () => {
+    class Resource {
+      initialized = false;
+
+      @onConstructAsync(async (context) => {
+        await context.invokeMethod();
+      })
+      async initialize(): Promise<void> {
+        await Promise.resolve();
+        this.initialized = true;
+      }
+    }
+
+    const container = new Container()
+      .useModule(new AddOnConstructAsyncHookModule())
+      .addRegistration(R.fromClass(Resource));
+
+    const resource = container.resolve<Resource>('Resource');
+
+    expect(resource.initialized).toBe(false);
+
+    await vi.waitFor(() => expect(resource.initialized).toBe(true));
+  });
+
+  it('reports rejected async construct hooks to the module exception handler', async () => {
+    const failure = new Error('boom');
+
+    class BrokenResource {
+      @onConstructAsync(() => Promise.reject(failure))
+      initialize(): void {}
+    }
+
+    let captured: unknown;
+    const container = new Container()
+      .useModule(new AddOnConstructAsyncHookModule((ex) => (captured = ex)))
+      .addRegistration(R.fromClass(BrokenResource));
+
+    container.resolve<BrokenResource>('BrokenResource');
+
+    await vi.waitFor(() => expect(captured).toBe(failure));
   });
 
   it('injects properties through hook context scope', () => {

--- a/docs/adr/0007-lifecycle-hooks.md
+++ b/docs/adr/0007-lifecycle-hooks.md
@@ -30,7 +30,11 @@ child-scope dispose hooks. The host application owns each child scope lifecycle
 and should dispose the child explicitly when that lifecycle ends.
 
 Synchronous hook execution rejects promises and points callers at the async
-execution path.
+execution path. Promise-returning initialization uses a separate hook key:
+`onConstructAsync` with `AddOnConstructAsyncHookModule`. Because instance
+creation is synchronous, async construct hooks are started when the instance is
+created and settle after resolution returns; the module reports rejections to an
+optional exception handler instead of failing `resolve`.
 
 > [!IMPORTANT]
 > Lifecycle hooks are opt-in. Register the construct/dispose modules, or add
@@ -59,12 +63,15 @@ execution path.
   the synchronous path.
 - Child scope cleanup is not implicit; applications must dispose child scopes
   explicitly to run their dispose hooks.
+- Async construct hooks cannot block resolution, so instances that must be
+  initialized before use have to expose readiness themselves.
 
 ## References
 
 - `lib/hooks/hook.ts`
 - `lib/hooks/HooksRunner.ts`
 - `lib/hooks/onConstruct.ts`
+- `lib/hooks/onConstructAsync.ts`
 - `lib/hooks/onContainerDisposed.ts`
 - `lib/hooks/HookContext.ts`
 - `docs/src/pages/hooks.mdx`

--- a/docs/src/pages/hooks.mdx
+++ b/docs/src/pages/hooks.mdx
@@ -7,6 +7,7 @@ description: Add TypeScript dependency injection lifecycle hooks for instance in
 import CodeBlock from "../components/CodeBlock.astro";
 import injectPropSpecCode from "../../../__tests__/readme/injectProp.spec.ts?raw";
 import onConstructSpecCode from "../../../__tests__/readme/onConstruct.spec.ts?raw";
+import onConstructAsyncSpecCode from "../../../__tests__/readme/onConstructAsync.spec.ts?raw";
 import onContainerDisposedSpecCode from "../../../__tests__/readme/onContainerDisposed.spec.ts?raw";
 import hookSpecCode from "../../../__tests__/hooks/hook.spec.ts?raw";
 import customHooksSpecCode from "../../../__tests__/readme/customHooks.spec.ts?raw";
@@ -46,6 +47,26 @@ Register an onConstruct hook on your container, then decorate methods with `@onC
 - **SessionManager** - Load user session from Redis after construction
 - **CacheService** - Warm up cache with frequently accessed data
 - **EmailNotifier** - Validate SMTP configuration before first use
+
+## OnConstructAsync Hooks
+
+OnConstructAsync hooks are the promise-aware counterpart of `@onConstruct`. Use them when initialization has to await something — opening a connection, loading remote configuration, warming a cache.
+
+Instance creation is synchronous, so async hooks cannot block it. `AddOnConstructAsyncHookModule` starts them when the instance is created and lets them settle afterwards: `resolve` returns before initialization completes. Instances that need to expose readiness should publish it themselves, for example by storing the pending promise on the instance.
+
+### Basic Usage
+
+Register `AddOnConstructAsyncHookModule` on your container, then decorate methods with `@onConstructAsync`:
+
+<CodeBlock
+  code={onConstructAsyncSpecCode}
+  lang="typescript"
+  filename="__tests__/readme/onConstructAsync.spec.ts"
+/>
+
+Both modules can be registered together: `@onConstruct` and `@onConstructAsync` use separate metadata keys, so synchronous hooks keep failing fast through `UnexpectedHookResultError` while async hooks run on the async path.
+
+Rejections are reported to the optional `onException` handler passed to the module. Without a handler the rejection is rethrown and surfaces as an unhandled rejection, since there is no caller left to catch it.
 
 ## OnContainerDisposed Hooks
 

--- a/lib/hooks/onConstructAsync.ts
+++ b/lib/hooks/onConstructAsync.ts
@@ -1,0 +1,31 @@
+import { hook, HookClass, HookFn } from './hook';
+import type { IContainer, IContainerModule } from '../container/IContainer';
+import { constructor } from '../utils/basic';
+import { HooksRunner } from './HooksRunner';
+import type { OnExceptionHandler } from './onConstruct';
+
+export const onConstructAsyncHooksRunner = new HooksRunner('onConstructAsync');
+export const onConstructAsync = (...fns: (HookFn | constructor<HookClass>)[]) => hook('onConstructAsync', ...fns);
+
+// Resolution stays synchronous, so async construct hooks are started when the
+// instance is tracked and settle afterwards: `resolve` returns before they
+// finish. Instances that must expose readiness should publish it themselves,
+// for example by storing the pending promise on the instance.
+export class AddOnConstructAsyncHookModule implements IContainerModule {
+  constructor(private readonly onException?: OnExceptionHandler) {}
+
+  applyTo(container: IContainer) {
+    container.addOnConstructHook((instance, scope) => {
+      if (!onConstructAsyncHooksRunner.hasHooks(instance)) {
+        return;
+      }
+
+      onConstructAsyncHooksRunner.executeAsync(instance, { scope }).catch((ex) => {
+        if (!this.onException) {
+          throw ex;
+        }
+        this.onException(ex, { scope });
+      });
+    });
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -70,6 +70,7 @@ export {
   AddOnConstructHookModule,
   type OnExceptionHandler,
 } from './hooks/onConstruct';
+export { onConstructAsyncHooksRunner, onConstructAsync, AddOnConstructAsyncHookModule } from './hooks/onConstructAsync';
 export {
   onContainerDisposedHooksRunner,
   onContainerDisposed,

--- a/specs/epics/lifecycle-hooks.md
+++ b/specs/epics/lifecycle-hooks.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0007 - Lifecycle hooks via reflect-metadata and opt-in modules](../../docs/adr/0007-lifecycle-hooks.md)
-- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `onConstruct`, `onContainerDisposed`, `injectProp`, `AddOnConstructHookModule`, `AddOnDisposeHookModule`
+- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `onConstruct`, `onConstructAsync`, `onContainerDisposed`, `injectProp`, `AddOnConstructHookModule`, `AddOnConstructAsyncHookModule`, `AddOnDisposeHookModule`
 - **Executable spec:** `__tests__/specs/lifecycle-hooks.spec.ts`
 
 ## Intent
@@ -25,6 +25,22 @@ Acceptance criteria:
 - `AddOnConstructHookModule` opts a container into construct hook execution.
 - Construct hooks run after the instance is created and tracked.
 - Hook classes are resolved through the container before execution.
+
+### Story: Run async construct hooks
+
+As an application developer, I can run promise-returning initialization after an
+instance is constructed so that async setup does not have to be forced into the
+synchronous construct path.
+
+Acceptance criteria:
+
+- `onConstructAsync` stores hook metadata on a method under its own hook key.
+- `AddOnConstructAsyncHookModule` opts a container into async construct hook
+  execution.
+- Async construct hooks start when the instance is created and settle after
+  resolution returns.
+- Rejected hooks are reported to the module `onException` handler when one is
+  provided.
 
 ### Story: Run dispose hooks
 


### PR DESCRIPTION
## Description

Add `onConstructAsync` decorator and `AddOnConstructAsyncHookModule` for promise-returning initialization hooks. This is the async counterpart of `@onConstruct`, used when initialization must await something — opening a connection, loading remote configuration, warming a cache.

## Design

Instance creation stays synchronous: `AddOnConstructAsyncHookModule` registers a synchronous construct hook that starts `executeAsync` and lets it settle after resolution returns. Rejections go to an optional `onException` handler, or are rethrown as unhandled rejections when no handler is given. The module skips instances with no async hooks to avoid allocating a promise per resolution.

Because async hooks cannot block resolution, instances that must expose readiness should publish it themselves — the readme spec shows a `ready` promise on the instance.

## Type of change

- [x] `feat` — new feature (minor release)

## Checklist

- [x] Source edited only under `lib/`
- [x] README.md regenerated via pnpm run generate:docs
- [x] Tests added under __tests__/ (readme spec + acceptance specs)
- [x] pnpm run lint passes
- [x] pnpm run type-check passes
- [x] pnpm test passes (336 tests)
- [x] Commit messages follow Conventional Commits

## Files changed

- lib/hooks/onConstructAsync.ts — decorator, runner, module
- lib/index.ts — export new API
- __tests__/readme/onConstructAsync.spec.ts — doc-driven example
- __tests__/specs/lifecycle-hooks.spec.ts — acceptance specs
- .readme.hbs.md + README.md — updated reference docs
- docs/src/pages/hooks.mdx — new section + examples
- docs/adr/0007-lifecycle-hooks.md — updated ADR
- specs/epics/lifecycle-hooks.md — new story + updated public API list