### PR TITLE
feat(injector): support optional selectFn in @inject decorator

### DIFF
--- a/__tests__/injector/inject.spec.ts
+++ b/__tests__/injector/inject.spec.ts
@@ -59,6 +59,70 @@ describe('inject helpers', () => {
     });
   });
 
+  describe('inject(token, selectFn)', () => {
+    it('injects the selected part of the resolved dependency', () => {
+      class Config {
+        constructor(readonly apiUrl: string = 'https://api.com') {}
+      }
+
+      const ConfigToken = new SingleToken<Config>('Config');
+
+      class Service {
+        constructor(@inject(ConfigToken, (config) => config.apiUrl) public apiUrl: string) {}
+      }
+
+      const container = createContainer()
+        .addRegistration(R.fromClass(Config).bindTo(ConfigToken))
+        .addRegistration(R.fromClass(Service));
+
+      expect(container.resolve<Service>('Service').apiUrl).toBe('https://api.com');
+    });
+
+    it('injects the whole dependency when selectFn is omitted', () => {
+      class Config {}
+
+      const ConfigToken = new SingleToken<Config>('Config');
+
+      class Service {
+        constructor(@inject(ConfigToken) public config: Config) {}
+      }
+
+      const container = createContainer()
+        .addRegistration(R.fromClass(Config).bindTo(ConfigToken))
+        .addRegistration(R.fromClass(Service));
+
+      expect(container.resolve<Service>('Service').config).toBeInstanceOf(Config);
+    });
+
+    it('forwards resolve args to the dependency before selecting', () => {
+      class Config {
+        constructor(@inject(args(0)) readonly apiUrl: string) {}
+      }
+
+      const ConfigToken = new SingleToken<Config>('Config');
+
+      class Service {
+        constructor(@inject(ConfigToken.args('https://other.com'), (c) => c.apiUrl) public apiUrl: string) {}
+      }
+
+      const container = createContainer()
+        .addRegistration(R.fromClass(Config).bindTo(ConfigToken))
+        .addRegistration(R.fromClass(Service));
+
+      expect(container.resolve<Service>('Service').apiUrl).toBe('https://other.com');
+    });
+
+    it('selects from a runtime arg', () => {
+      @register(appendArgs({ id: 42 }))
+      class Service {
+        constructor(@inject(args<{ id: number }>(0), (value) => value.id) public id: number) {}
+      }
+
+      const container = createContainer().addRegistration(R.fromClass(Service));
+      expect(container.resolve<Service>('Service').id).toBe(42);
+    });
+  });
+
   describe('argsFn(predicate)', () => {
     it('returns the first arg matching the predicate', () => {
       @register(appendArgs(1, 'two', 3))

--- a/lib/injector/MetadataInjector.ts
+++ b/lib/injector/MetadataInjector.ts
@@ -5,6 +5,7 @@ import { getParamMeta, addParamMeta } from '../metadata/parameter';
 import { InjectionToken } from '../token/InjectionToken';
 import { ProviderOptions } from '../provider/IProvider';
 import { argToToken, toToken } from '../token/toToken';
+import { FunctionToken } from '../token/FunctionToken';
 import { InjectFn } from '../hooks/hook';
 
 export class MetadataInjector extends Injector implements IInjector {
@@ -17,9 +18,17 @@ export class MetadataInjector extends Injector implements IInjector {
 const hookMetaKey = (methodName = 'constructor') => `inject:${methodName}`;
 
 export const inject =
-  <T>(fn: InjectionToken<T> | InjectFn<T> | symbol | string | constructor<T>): ParameterDecorator =>
+  <T, R = T>(
+    fn: InjectionToken<T> | InjectFn<T> | symbol | string | constructor<T>,
+    // selectFn narrows the resolved instance before it reaches the constructor parameter.
+    selectFn: (instance: T) => R = (instance) => instance as unknown as R,
+  ): ParameterDecorator =>
   (target, propertyKey, parameterIndex) => {
-    addParamMeta(hookMetaKey(propertyKey as string), () => toToken(fn))(
+    const toSelectedToken = () => {
+      const token = toToken(fn);
+      return new FunctionToken<R>((scope, options) => selectFn(token.resolve(scope, options)));
+    };
+    addParamMeta(hookMetaKey(propertyKey as string), toSelectedToken)(
       Is.instance(target) ? target.constructor : target,
       propertyKey,
       parameterIndex,
@@ -31,7 +40,7 @@ export const argsFn =
   (c, { args = [] }): T =>
     args.find((value, index) => predicate(value, index)) as T;
 
-export const args = (index: number): InjectFn => argsFn((value, i) => i === index);
+export const args = <T = unknown>(index: number): InjectFn<T> => argsFn<T>((value, i) => i === index);
 
 export const resolveArgs = (Target: constructor<unknown>, methodName?: string) => {
   const tokens = getParamMeta(hookMetaKey(methodName), Target) as InjectionToken[];


### PR DESCRIPTION
## Description

Adds an optional second argument to the `@inject` decorator that narrows the resolved dependency before it reaches the constructor parameter:

```typescript
class Service {
  constructor(@inject(ISomeServiceToken, (instance) => instance.someProperty) public prop: string) {}
}
```

Previously the only way to inject a part of a dependency was to resolve the whole instance and pick the property inside the constructor, or to hand-roll a `FunctionToken`.

Implementation: `inject` wraps the token in a `FunctionToken` that pipes the resolved instance through `selectFn`. The `args` and `lazy` options are forwarded to the inner token unchanged, so `Token.args(...)` and lazy resolution behave exactly as before. `selectFn` defaults to identity (`(v) => v`), so all existing single-argument usage is untouched.

Also makes `args(index)` generic — `args<T>(index)`, defaulting to `unknown` — so a select fn over a runtime arg infers its parameter type instead of failing to type-check. Backward compatible.

## Type of change

- [x] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed (`.readme.hbs.md` unchanged; the pre-commit hook regenerated README with no diff)
- [x] Tests added or updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes (no errors; only the repo's pre-existing `no-explicit-any` warnings)
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes (336/336)
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

Four cases were added to `__tests__/injector/inject.spec.ts`: selecting a property, omitting `selectFn`, selecting through `Token.args(...)`, and selecting from a runtime arg via `args<T>(0)`.

Reviewer notes:

- Every `@inject` now produces a `FunctionToken` wrapper rather than the bare token. Verified safe — `resolveArgs` and `HookContext` are the only consumers of the `inject:*` param metadata and both use `.resolve()` only.
- With `lazy`, `selectFn` runs against the lazy proxy, and reading a property forces construction. That is inherent to selecting eagerly, not something this PR can defer.
- Docs are not updated for the new parameter — happy to follow up under a `docs(pages):` commit if you want it in the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
