### PR TITLE
feat(hooks): add getInitialArgs to IHookContext

### DIFF
--- a/__tests__/hooks/hook.spec.ts
+++ b/__tests__/hooks/hook.spec.ts
@@ -32,6 +32,22 @@ describe('hooks', () => {
     expect(context.setInitialArgs('arg1')).toBe(context);
   });
 
+  it('should return the args passed to setInitialArgs from getInitialArgs', () => {
+    const root = new Container({ tags: ['root'] });
+    const context = new HookContext({}, root, 'constructor');
+
+    context.setInitialArgs('arg1', 'arg2');
+
+    expect(context.getInitialArgs()).toEqual(['arg1', 'arg2']);
+  });
+
+  it('should return an empty array from getInitialArgs when no initial args were set', () => {
+    const root = new Container({ tags: ['root'] });
+    const context = new HookContext({}, root, 'constructor');
+
+    expect(context.getInitialArgs()).toEqual([]);
+  });
+
   it('should prepend initial args when resolving hook method arguments', () => {
     const beforeHooksRunner = new HooksRunner('syncBefore');
 

--- a/lib/hooks/HookContext.ts
+++ b/lib/hooks/HookContext.ts
@@ -19,6 +19,8 @@ export interface IHookContext {
   getProperty(): unknown;
 
   setInitialArgs(...args: unknown[]): this;
+
+  getInitialArgs(): unknown[];
 }
 
 export class HookContext implements IHookContext {
@@ -57,6 +59,10 @@ export class HookContext implements IHookContext {
   setInitialArgs(...args: unknown[]): this {
     this.initialArgs = args;
     return this;
+  }
+
+  getInitialArgs(): unknown[] {
+    return this.initialArgs;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `getInitialArgs(): unknown[]` to the `IHookContext` interface, mirroring the existing `setInitialArgs(...)`.
- Implement it on `HookContext`, returning the private `initialArgs` array set via `setInitialArgs`.
- Add tests covering the returned args and the empty-array default.

## Test plan
- [x] `pnpm exec vitest run __tests__/hooks/hook.spec.ts` — 13 passed
- [x] `pnpm test` — 71 files / 342 tests passed
- [x] `pnpm run type-check` — passes
- [x] `pnpm run lint:fix` — no new errors (pre-existing `no-explicit-any` warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)