### PR TITLE
feat(hooks): take a map function in the hook decorator

### DIFF
--- a/.readme.hbs.md
+++ b/.readme.hbs.md
@@ -410,6 +410,30 @@ Sometimes you want to encapsulate registration logic in separate module. This is
 
 Sometimes you need to invoke methods after construct or dispose of class. This is what hooks are for.
 
+The generic `@hook` decorator takes a hook key and a map function
+`(...prev: HookType[]) => HookType[]`, where `prev` is the list of hooks already
+registered on the class for the decorated member. Use `appendHooks` /
+`prependHooks` (exported as `append` / `prepend` too) to place new hooks around
+the existing ones:
+
+```typescript
+class OrderService {
+  @hook('actions', append(validate, persist))
+  @hook('actions', prepend(authorize))
+  submit() {}
+}
+```
+
+Decorators are applied bottom-up, so `authorize` runs first, then `validate` and
+`persist`. Any other map function works as well — for example
+`(...prev) => [...prev].reverse()` to reorder, or `() => [onlyThisOne]` to
+replace the accumulated hooks.
+
+`@onConstruct`, `@onConstructAsync` and `@onContainerDisposed` keep their
+variadic signature and compensate for the bottom-up application order, so
+stacked decorators run in declaration order: `@onConstruct(h1) @onConstruct(h2)`
+runs `h1` before `h2`.
+
 ### OnConstruct
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -2482,6 +2482,30 @@ describe('Container Modules', function () {
 
 Sometimes you need to invoke methods after construct or dispose of class. This is what hooks are for.
 
+The generic `@hook` decorator takes a hook key and a map function
+`(...prev: HookType[]) => HookType[]`, where `prev` is the list of hooks already
+registered on the class for the decorated member. Use `appendHooks` /
+`prependHooks` (exported as `append` / `prepend` too) to place new hooks around
+the existing ones:
+
+```typescript
+class OrderService {
+  @hook('actions', append(validate, persist))
+  @hook('actions', prepend(authorize))
+  submit() {}
+}
+```
+
+Decorators are applied bottom-up, so `authorize` runs first, then `validate` and
+`persist`. Any other map function works as well — for example
+`(...prev) => [...prev].reverse()` to reorder, or `() => [onlyThisOne]` to
+replace the accumulated hooks.
+
+`@onConstruct`, `@onConstructAsync` and `@onContainerDisposed` keep their
+variadic signature and compensate for the bottom-up application order, so
+stacked decorators run in declaration order: `@onConstruct(h1) @onConstruct(h2)`
+runs `h1` before `h2`.
+
 ### OnConstruct
 
 ```typescript
@@ -2741,7 +2765,7 @@ describe('onContainerDisposed', function () {
 
 ```typescript
 import 'reflect-metadata';
-import { Container, hook, HooksRunner, injectProp, Registration } from 'ts-ioc-container';
+import { append, Container, hook, HooksRunner, injectProp, Registration } from 'ts-ioc-container';
 
 /**
  * UI Components - Property Injection
@@ -2761,7 +2785,7 @@ describe('inject property', () => {
 
     class UserViewModel {
       // Inject 'GreetingService' into 'greeting' property during 'onInit'
-      @hook('onInit', injectProp('GreetingService'))
+      @hook('onInit', append(injectProp('GreetingService')))
       greetingService!: string;
 
       display(): string {
@@ -2787,9 +2811,12 @@ describe('inject property', () => {
     let injectedValue: unknown;
 
     class UserViewModel {
-      @hook('onInit', injectProp('GreetingService'), (context) => {
-        injectedValue = context.getProperty();
-      })
+      @hook(
+        'onInit',
+        append(injectProp('GreetingService'), (context) => {
+          injectedValue = context.getProperty();
+        }),
+      )
       greetingService!: string;
     }
 

--- a/__tests__/hooks/hook.spec.ts
+++ b/__tests__/hooks/hook.spec.ts
@@ -1,15 +1,20 @@
 import 'reflect-metadata';
 import {
+  append,
+  appendHooks,
   args,
   bindTo,
   Container,
   GroupAliasToken,
   hasHooks,
   hook,
+  type HookClass,
   HookContext,
   type HookFn,
   HooksRunner,
   inject,
+  prepend,
+  prependHooks,
   register,
   Registration as R,
 } from '../../lib';
@@ -54,9 +59,12 @@ describe('hooks', () => {
     class MyClass {
       receivedArgs: unknown[] = [];
 
-      @hook('syncBefore', (ctx) => {
-        ctx.invokeMethod();
-      })
+      @hook(
+        'syncBefore',
+        append((ctx) => {
+          ctx.invokeMethod();
+        }),
+      )
       start(@inject(args(0)) firstArg: string, @inject('suffix') suffix: string, runtimeArg: string) {
         this.receivedArgs = [firstArg, suffix, runtimeArg];
       }
@@ -80,9 +88,12 @@ describe('hooks', () => {
     class MyClass {
       receivedArgs: unknown[] = [];
 
-      @hook('syncBefore', (ctx) => {
-        ctx.invokeMethod();
-      })
+      @hook(
+        'syncBefore',
+        append((ctx) => {
+          ctx.invokeMethod();
+        }),
+      )
       start(@inject(args(0)) firstArg: string, @inject('suffix') suffix: string) {
         this.receivedArgs = [firstArg, suffix];
       }
@@ -105,9 +116,12 @@ describe('hooks', () => {
     class MyClass {
       receivedArgs: unknown[] = [];
 
-      @hook('onStart', async (ctx) => {
-        await ctx.invokeMethod();
-      })
+      @hook(
+        'onStart',
+        append(async (ctx) => {
+          await ctx.invokeMethod();
+        }),
+      )
       async start(@inject(args(0)) firstArg: string) {
         this.receivedArgs = [firstArg];
       }
@@ -130,13 +144,13 @@ describe('hooks', () => {
     class Logger {
       isStarted = false;
 
-      @hook('onStart', executeAsync)
+      @hook('onStart', append(executeAsync))
       async initialize(@inject('TimeToSleep') timeToSleep: number) {
         await sleep(timeToSleep);
         this.isStarted = true;
       }
 
-      @hook('onStart', executeAsync)
+      @hook('onStart', append(executeAsync))
       async dispose(@inject('TimeToSleep') timeToSleep: number) {
         await sleep(timeToSleep);
         this.isStarted = false;
@@ -159,7 +173,7 @@ describe('hooks', () => {
     const onStartHooksRunner = new HooksRunner('onStart');
 
     class WithHooks {
-      @hook('onStart', execute)
+      @hook('onStart', append(execute))
       start() {}
     }
 
@@ -177,7 +191,7 @@ describe('hooks', () => {
     const onStartHooksRunner = new HooksRunner('onStart');
 
     class MyClass {
-      @hook('onDispose', execute)
+      @hook('onDispose', append(execute))
       stop() {}
     }
 
@@ -192,7 +206,7 @@ describe('hooks', () => {
     class Base {
       baseStarted = false;
 
-      @hook('onStart', execute)
+      @hook('onStart', append(execute))
       startBase() {
         this.baseStarted = true;
       }
@@ -201,7 +215,7 @@ describe('hooks', () => {
     class Derived extends Base {
       derivedStarted = false;
 
-      @hook('onStart', execute)
+      @hook('onStart', append(execute))
       startDerived() {
         this.derivedStarted = true;
       }
@@ -221,18 +235,24 @@ describe('hooks', () => {
     const invoked: string[] = [];
 
     class Base {
-      @hook('onStart', (ctx) => {
-        invoked.push('startBase');
-        ctx.invokeMethod();
-      })
+      @hook(
+        'onStart',
+        append((ctx) => {
+          invoked.push('startBase');
+          ctx.invokeMethod();
+        }),
+      )
       startBase() {}
     }
 
     class Derived extends Base {
-      @hook('onStart', (ctx) => {
-        invoked.push('startDerived');
-        ctx.invokeMethod();
-      })
+      @hook(
+        'onStart',
+        append((ctx) => {
+          invoked.push('startDerived');
+          ctx.invokeMethod();
+        }),
+      )
       startDerived() {}
     }
 
@@ -248,18 +268,24 @@ describe('hooks', () => {
     const invoked: string[] = [];
 
     class Base {
-      @hook('onStart', (ctx) => {
-        invoked.push('startBase');
-        ctx.invokeMethod();
-      })
+      @hook(
+        'onStart',
+        append((ctx) => {
+          invoked.push('startBase');
+          ctx.invokeMethod();
+        }),
+      )
       startBase() {}
     }
 
     class Derived extends Base {
-      @hook('onStart', (ctx) => {
-        invoked.push('startDerived');
-        ctx.invokeMethod();
-      })
+      @hook(
+        'onStart',
+        append((ctx) => {
+          invoked.push('startDerived');
+          ctx.invokeMethod();
+        }),
+      )
       startDerived() {}
     }
 
@@ -283,7 +309,7 @@ describe('hooks', () => {
     class FirstPlugin implements Plugin {
       isStarted = false;
 
-      @hook('onPluginStart', execute)
+      @hook('onPluginStart', append(execute))
       start() {
         this.isStarted = true;
       }
@@ -293,7 +319,7 @@ describe('hooks', () => {
     class SecondPlugin implements Plugin {
       isStarted = false;
 
-      @hook('onPluginStart', execute)
+      @hook('onPluginStart', append(execute))
       start() {
         this.isStarted = true;
       }
@@ -320,5 +346,167 @@ describe('hooks', () => {
     app.runPlugins(container);
 
     expect(app.getPlugins().every((plugin) => plugin.isStarted)).toBe(true);
+  });
+
+  it('should run hooks passed to appendHooks in declaration order', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+    const invoked: string[] = [];
+
+    class MyClass {
+      @hook(
+        'onStart',
+        appendHooks(
+          () => {
+            invoked.push('first');
+          },
+          () => {
+            invoked.push('second');
+          },
+        ),
+      )
+      start() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+    onStartHooksRunner.execute(root.resolve(MyClass), { scope: root });
+
+    expect(invoked).toEqual(['first', 'second']);
+  });
+
+  it('should add hooks after the already registered ones with appendHooks', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+    const invoked: string[] = [];
+
+    class MyClass {
+      // Decorators are applied bottom-up, so 'declared' is registered first
+      @hook(
+        'onStart',
+        appendHooks(() => {
+          invoked.push('appended');
+        }),
+      )
+      @hook(
+        'onStart',
+        appendHooks(() => {
+          invoked.push('declared');
+        }),
+      )
+      start() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+    onStartHooksRunner.execute(root.resolve(MyClass), { scope: root });
+
+    expect(invoked).toEqual(['declared', 'appended']);
+  });
+
+  it('should add hooks before the already registered ones with prependHooks', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+    const invoked: string[] = [];
+
+    class MyClass {
+      @hook(
+        'onStart',
+        prependHooks(() => {
+          invoked.push('prepended');
+        }),
+      )
+      @hook(
+        'onStart',
+        appendHooks(() => {
+          invoked.push('declared');
+        }),
+      )
+      start() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+    onStartHooksRunner.execute(root.resolve(MyClass), { scope: root });
+
+    expect(invoked).toEqual(['prepended', 'declared']);
+  });
+
+  it('should expose append and prepend as aliases of appendHooks and prependHooks', () => {
+    expect(append).toBe(appendHooks);
+    expect(prepend).toBe(prependHooks);
+  });
+
+  it('should let a custom mapFn reorder the already registered hooks', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+    const invoked: string[] = [];
+
+    class MyClass {
+      @hook('onStart', (...prev) => [...prev].reverse())
+      @hook(
+        'onStart',
+        appendHooks(
+          () => {
+            invoked.push('first');
+          },
+          () => {
+            invoked.push('second');
+          },
+        ),
+      )
+      start() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+    onStartHooksRunner.execute(root.resolve(MyClass), { scope: root });
+
+    expect(invoked).toEqual(['second', 'first']);
+  });
+
+  it('should replace the already registered hooks when mapFn ignores them', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+    const invoked: string[] = [];
+
+    class MyClass {
+      @hook('onStart', () => [
+        () => {
+          invoked.push('replacement');
+        },
+      ])
+      @hook(
+        'onStart',
+        appendHooks(() => {
+          invoked.push('replaced');
+        }),
+      )
+      start() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+    onStartHooksRunner.execute(root.resolve(MyClass), { scope: root });
+
+    expect(invoked).toEqual(['replacement']);
+  });
+
+  it('should accept hook classes in appendHooks and prependHooks', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+    const invoked: string[] = [];
+
+    class AppendedHook implements HookClass {
+      execute() {
+        invoked.push('appended');
+      }
+    }
+
+    class PrependedHook implements HookClass {
+      execute() {
+        invoked.push('prepended');
+      }
+    }
+
+    class MyClass {
+      @hook('onStart', prependHooks(PrependedHook))
+      @hook('onStart', appendHooks(AppendedHook))
+      start() {}
+    }
+
+    const root = new Container({ tags: ['root'] });
+    onStartHooksRunner.execute(root.resolve(MyClass), { scope: root });
+
+    expect(invoked).toEqual(['prepended', 'appended']);
   });
 });

--- a/__tests__/readme/customHooks.spec.ts
+++ b/__tests__/readme/customHooks.spec.ts
@@ -1,4 +1,4 @@
-import { Container, hook, HooksRunner, type HookFn } from '../../lib';
+import { append, Container, hook, HooksRunner, type HookFn } from '../../lib';
 
 /**
  * User Management Domain - Custom Lifecycle Hooks
@@ -14,7 +14,7 @@ import { Container, hook, HooksRunner, type HookFn } from '../../lib';
  *
  * How it works:
  * 1. Define a HooksRunner with a unique hook name
- * 2. Create methods decorated with @hook('hookName', executor)
+ * 2. Create methods decorated with @hook('hookName', append(executor))
  * 3. Register the hook runner via addOnConstructHook
  * 4. Methods are automatically called when instances are created
  */
@@ -33,7 +33,7 @@ describe('Custom Hooks', () => {
       isWarmedUp = false;
 
       // Custom hook - called automatically after construction
-      @hook('initialize', executeInitialize)
+      @hook('initialize', append(executeInitialize))
       warmCache() {
         this.isWarmedUp = true;
       }

--- a/__tests__/readme/injectProp.spec.ts
+++ b/__tests__/readme/injectProp.spec.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { Container, hook, HooksRunner, injectProp, Registration } from '../../lib';
+import { append, Container, hook, HooksRunner, injectProp, Registration } from '../../lib';
 
 /**
  * UI Components - Property Injection
@@ -19,7 +19,7 @@ describe('inject property', () => {
 
     class UserViewModel {
       // Inject 'GreetingService' into 'greeting' property during 'onInit'
-      @hook('onInit', injectProp('GreetingService'))
+      @hook('onInit', append(injectProp('GreetingService')))
       greetingService!: string;
 
       display(): string {
@@ -45,9 +45,12 @@ describe('inject property', () => {
     let injectedValue: unknown;
 
     class UserViewModel {
-      @hook('onInit', injectProp('GreetingService'), (context) => {
-        injectedValue = context.getProperty();
-      })
+      @hook(
+        'onInit',
+        append(injectProp('GreetingService'), (context) => {
+          injectedValue = context.getProperty();
+        }),
+      )
       greetingService!: string;
     }
 

--- a/__tests__/specs/errors-and-boundaries.spec.ts
+++ b/__tests__/specs/errors-and-boundaries.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {
+  append,
   ConstantToken,
   Container,
   ContainerDisposedError,
@@ -57,7 +58,7 @@ describe('Spec: errors and boundaries', () => {
 
   it('rejects unsupported token and hook operations', () => {
     class Worker {
-      @hook('asyncOnly', async () => {})
+      @hook('asyncOnly', append(async () => {}))
       start(): void {}
     }
 

--- a/__tests__/specs/lifecycle-hooks.spec.ts
+++ b/__tests__/specs/lifecycle-hooks.spec.ts
@@ -3,6 +3,7 @@ import {
   AddOnConstructAsyncHookModule,
   AddOnConstructHookModule,
   AddOnDisposeHookModule,
+  append,
   Container,
   hasHooks,
   hook,
@@ -51,6 +52,114 @@ describe('Spec: lifecycle hooks', () => {
     container.dispose();
 
     expect(resource.disposed).toBe(true);
+  });
+
+  it('runs stacked @onConstruct decorators in declaration order', () => {
+    const invoked: string[] = [];
+    const h1: HookFn = () => {
+      invoked.push('h1');
+    };
+    const h2: HookFn = () => {
+      invoked.push('h2');
+    };
+
+    class Resource {
+      @onConstruct(h1)
+      @onConstruct(h2)
+      initialize(): void {}
+    }
+
+    const container = new Container().useModule(new AddOnConstructHookModule()).addRegistration(R.fromClass(Resource));
+
+    container.resolve<Resource>('Resource');
+
+    expect(invoked).toEqual(['h1', 'h2']);
+  });
+
+  it('runs hooks of a single @onConstruct decorator in argument order', () => {
+    const invoked: string[] = [];
+
+    class Resource {
+      @onConstruct(
+        () => {
+          invoked.push('h1');
+        },
+        () => {
+          invoked.push('h2');
+        },
+      )
+      initialize(): void {}
+    }
+
+    const container = new Container().useModule(new AddOnConstructHookModule()).addRegistration(R.fromClass(Resource));
+
+    container.resolve<Resource>('Resource');
+
+    expect(invoked).toEqual(['h1', 'h2']);
+  });
+
+  it('keeps declaration order when stacked @onConstruct decorators carry several hooks each', () => {
+    const invoked: string[] = [];
+    const push =
+      (label: string): HookFn =>
+      () => {
+        invoked.push(label);
+      };
+
+    class Resource {
+      @onConstruct(push('h1'), push('h2'))
+      @onConstruct(push('h3'), push('h4'))
+      initialize(): void {}
+    }
+
+    const container = new Container().useModule(new AddOnConstructHookModule()).addRegistration(R.fromClass(Resource));
+
+    container.resolve<Resource>('Resource');
+
+    expect(invoked).toEqual(['h1', 'h2', 'h3', 'h4']);
+  });
+
+  it('runs stacked @onContainerDisposed decorators in declaration order', () => {
+    const invoked: string[] = [];
+
+    class Resource {
+      @onContainerDisposed(() => {
+        invoked.push('h1');
+      })
+      @onContainerDisposed(() => {
+        invoked.push('h2');
+      })
+      destroy(): void {}
+    }
+
+    const container = new Container().useModule(new AddOnDisposeHookModule()).addRegistration(R.fromClass(Resource));
+
+    container.resolve<Resource>('Resource');
+    container.dispose();
+
+    expect(invoked).toEqual(['h1', 'h2']);
+  });
+
+  it('runs stacked @onConstructAsync decorators in declaration order', async () => {
+    const invoked: string[] = [];
+
+    class Resource {
+      @onConstructAsync(async () => {
+        invoked.push('h1');
+      })
+      @onConstructAsync(async () => {
+        invoked.push('h2');
+      })
+      async initialize(): Promise<void> {}
+    }
+
+    const container = new Container()
+      .useModule(new AddOnConstructAsyncHookModule())
+      .addRegistration(R.fromClass(Resource));
+
+    container.resolve<Resource>('Resource');
+
+    await vi.waitFor(() => expect(invoked).toEqual(['h1', 'h2']));
   });
 
   it('runs async construct hooks without blocking resolution', async () => {
@@ -123,12 +232,12 @@ describe('Spec: lifecycle hooks', () => {
     class Worker {
       calls: string[] = [];
 
-      @hook('workflow', AuditHook)
+      @hook('workflow', append(AuditHook))
       start(): void {
         this.calls.push('start');
       }
 
-      @hook('workflow', invoke)
+      @hook('workflow', append(invoke))
       stop(): void {
         this.calls.push('stop');
       }
@@ -163,19 +272,22 @@ describe('Spec: lifecycle hooks', () => {
     class Worker {
       calls: string[] = [];
 
-      @hook('sync', invoke)
+      @hook('sync', append(invoke))
       start(@inject('prefix') prefix: string): void {
         this.calls.push(`${prefix}:sync`);
       }
 
-      @hook('async', async (context) => {
-        context.invokeMethod();
-      })
+      @hook(
+        'async',
+        append(async (context) => {
+          context.invokeMethod();
+        }),
+      )
       stop(@inject('prefix') prefix: string): void {
         this.calls.push(`${prefix}:async`);
       }
 
-      @hook('badAsync', async () => undefined)
+      @hook('badAsync', append(async () => undefined))
       bad(): void {}
     }
 

--- a/docs/src/pages/hooks.mdx
+++ b/docs/src/pages/hooks.mdx
@@ -125,6 +125,56 @@ Create a custom hook by instantiating a `HooksRunner` with a unique hook name:
   filename="__tests__/readme/customHooks.spec.ts"
 />
 
+### Composing Hooks
+
+`@hook` takes the hook key and a map function:
+
+```typescript
+hook(key: string | symbol, mapFn: (...prev: HookType[]) => HookType[])
+```
+
+`mapFn` receives the hooks already registered on the class for the decorated member and returns the resulting list, so you decide where new hooks land. `appendHooks` and `prependHooks` (also exported as the shorter `append` and `prepend`) cover the common cases:
+
+```typescript
+import { append, appendHooks, hook, prepend, prependHooks } from 'ts-ioc-container';
+
+class OrderService {
+  @hook('actions', append(validate, persist)) // runs after hooks already registered
+  @hook('actions', prepend(authorize)) // runs before them
+  submit() {}
+}
+```
+
+Decorator expressions are evaluated top-to-bottom, but the decorators themselves are applied bottom-up — so the lowest `@hook` registers first and the ones above it map over the list it produced. In the example above the final order is `authorize`, `validate`, `persist`.
+
+Because `mapFn` is just a function, you can also reorder or replace the accumulated hooks:
+
+```typescript
+class Reversed {
+  @hook('actions', (...prev) => [...prev].reverse())
+  @hook('actions', appendHooks(first, second))
+  submit() {}
+}
+
+class Replaced {
+  @hook('actions', () => [onlyThisOne]) // ignores prev, dropping earlier hooks
+  @hook('actions', prependHooks(discarded))
+  submit() {}
+}
+```
+
+`prev` only contains hooks declared on the same class — hooks inherited from a parent class are merged separately when the runner collects them.
+
+The built-in decorators (`@onConstruct`, `@onConstructAsync`, `@onContainerDisposed`) keep their variadic signature. They prepend internally to compensate for the bottom-up application order, so stacked decorators run in declaration order:
+
+```typescript
+class Resource {
+  @onConstruct(h1)
+  @onConstruct(h2)
+  initialize() {} // runs h1, then h2
+}
+```
+
 ### Synchronous vs Asynchronous Hooks
 
 Hooks can be synchronous or asynchronous. Use the appropriate execution method:
@@ -159,9 +209,9 @@ Use `setInitialArgs()` when a hook should supply fixed positional arguments befo
 const beforeHooksRunner = new HooksRunner('syncBefore');
 
 class MyClass {
-  @hook('syncBefore', (ctx) => {
+  @hook('syncBefore', append((ctx) => {
     ctx.invokeMethod();
-  })
+  }))
   start(firstArg: string, @inject('suffix') suffix: string) {
     console.log(firstArg, suffix);
   }

--- a/lib/hooks/hook.ts
+++ b/lib/hooks/hook.ts
@@ -14,8 +14,28 @@ export interface HookClass<T extends IHookContext = IHookContext> {
   execute(context: Omit<T, 'scope'>): void | Promise<void>;
 }
 
+// HookType - anything that can be registered as a hook: a plain function or a hook class
+export type HookType<T extends IHookContext = IHookContext> = HookFn<T> | constructor<HookClass<T>>;
+
+// MapHooksFn - receives the hooks already registered for the decorated member and returns the new list
+export type MapHooksFn = (...prev: HookType[]) => HookType[];
+
 // HooksOfClass
-export type HooksOfClass = Map<string, (HookFn | constructor<HookClass>)[]>;
+export type HooksOfClass = Map<string, HookType[]>;
+
+// Adds hooks after the ones already registered for the decorated member.
+export const appendHooks =
+  (...fns: HookType[]): MapHooksFn =>
+  (...prev) => [...prev, ...fns];
+
+// Adds hooks before the ones already registered for the decorated member.
+export const prependHooks =
+  (...fns: HookType[]): MapHooksFn =>
+  (...prev) => [...fns, ...prev];
+
+// Short aliases
+export const append = appendHooks;
+export const prepend = prependHooks;
 
 const isHookClassConstructor = <C extends IHookContext>(
   execute: HookFn<C> | constructor<HookClass<C>>,
@@ -64,12 +84,12 @@ export function hasHooks(target: object, key: string | symbol): boolean {
 }
 
 // Hook decorator
-export const hook =
-  (key: string | symbol, ...fns: (HookFn | constructor<HookClass>)[]) =>
-  (target: object, propertyKey: string | symbol) => {
-    const hooks: HooksOfClass = Reflect.hasOwnMetadata(key, target.constructor)
-      ? Reflect.getOwnMetadata(key, target.constructor)
-      : new Map();
-    hooks.set(propertyKey as string, (hooks.get(propertyKey as string) ?? []).concat(fns));
-    Reflect.defineMetadata(key, hooks, target.constructor);
-  };
+// `mapFn` receives the hooks already registered on this class for the decorated member
+// and returns the resulting list, so `append(...)`/`prepend(...)` control ordering.
+export const hook = (key: string | symbol, mapFn: MapHooksFn) => (target: object, propertyKey: string | symbol) => {
+  const hooks: HooksOfClass = Reflect.hasOwnMetadata(key, target.constructor)
+    ? Reflect.getOwnMetadata(key, target.constructor)
+    : new Map();
+  hooks.set(propertyKey as string, mapFn(...(hooks.get(propertyKey as string) ?? [])));
+  Reflect.defineMetadata(key, hooks, target.constructor);
+};

--- a/lib/hooks/onConstruct.ts
+++ b/lib/hooks/onConstruct.ts
@@ -1,11 +1,13 @@
-import { hook, HookClass, HookFn } from './hook';
+import { hook, HookType, prependHooks } from './hook';
 import type { IContainer, IContainerModule } from '../container/IContainer';
-import { constructor, Instance } from '../utils/basic';
+import { Instance } from '../utils/basic';
 import { HooksRunner } from './HooksRunner';
 import type { ExecutionContext } from '../ExecutionContext';
 
 export const onConstructHooksRunner = new HooksRunner('onConstruct');
-export const onConstruct = (...fns: (HookFn | constructor<HookClass>)[]) => hook('onConstruct', ...fns);
+// Decorators are applied bottom-up, so hooks are prepended to keep them in declaration order:
+// `@onX(h1) @onX(h2) method()` runs h1 before h2.
+export const onConstruct = (...fns: HookType[]) => hook('onConstruct', prependHooks(...fns));
 
 export type OnConstructHook = (instance: Instance, scope: IContainer) => void;
 

--- a/lib/hooks/onConstructAsync.ts
+++ b/lib/hooks/onConstructAsync.ts
@@ -1,11 +1,12 @@
-import { hook, HookClass, HookFn } from './hook';
+import { hook, HookType, prependHooks } from './hook';
 import type { IContainer, IContainerModule } from '../container/IContainer';
-import { constructor } from '../utils/basic';
 import { HooksRunner } from './HooksRunner';
 import type { OnExceptionHandler } from './onConstruct';
 
 export const onConstructAsyncHooksRunner = new HooksRunner('onConstructAsync');
-export const onConstructAsync = (...fns: (HookFn | constructor<HookClass>)[]) => hook('onConstructAsync', ...fns);
+// Decorators are applied bottom-up, so hooks are prepended to keep them in declaration order:
+// `@onX(h1) @onX(h2) method()` runs h1 before h2.
+export const onConstructAsync = (...fns: HookType[]) => hook('onConstructAsync', prependHooks(...fns));
 
 // Resolution stays synchronous, so async construct hooks are started when the
 // instance is tracked and settle afterwards: `resolve` returns before they

--- a/lib/hooks/onContainerDisposed.ts
+++ b/lib/hooks/onContainerDisposed.ts
@@ -1,10 +1,11 @@
-import { hook, HookClass, HookFn } from './hook';
+import { hook, HookType, prependHooks } from './hook';
 import type { IContainer, IContainerModule } from '../container/IContainer';
 import { HooksRunner } from './HooksRunner';
-import { type constructor } from '../utils/basic';
 
 export const onContainerDisposedHooksRunner = new HooksRunner('onContainerDisposed');
-export const onContainerDisposed = (...fns: (HookFn | constructor<HookClass>)[]) => hook('onContainerDisposed', ...fns);
+// Decorators are applied bottom-up, so hooks are prepended to keep them in declaration order:
+// `@onX(h1) @onX(h2) method()` runs h1 before h2.
+export const onContainerDisposed = (...fns: HookType[]) => hook('onContainerDisposed', prependHooks(...fns));
 
 export type OnDisposeHook = (scope: IContainer) => void;
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -61,7 +61,21 @@ export { UnexpectedHookResultError } from './errors/UnexpectedHookResultError';
 export { CannonSingletonApplyTwiceError } from './errors/CannonSingletonApplyTwiceError';
 
 // Hooks
-export { getHooks, hook, hasHooks, type HookFn, type HookClass, type InjectFn, type HooksOfClass } from './hooks/hook';
+export {
+  getHooks,
+  hook,
+  hasHooks,
+  appendHooks,
+  prependHooks,
+  append,
+  prepend,
+  type HookFn,
+  type HookClass,
+  type HookType,
+  type MapHooksFn,
+  type InjectFn,
+  type HooksOfClass,
+} from './hooks/hook';
 export { HookContext, createHookContextFactory, createHookContext, type IHookContext } from './hooks/HookContext';
 export { injectProp } from './hooks/injectProp';
 export {


### PR DESCRIPTION
## Description

Changes the `@hook` decorator signature from `hook(key, ...fns)` to `hook(key, mapFn)`, where `mapFn: (...prev: HookType[]) => HookType[]` receives the hooks already registered on the class for the decorated member and returns the resulting list. This makes it possible to control where new hooks land relative to hooks already declared (e.g. by a parent decorator on the same member), via `append(...myHooks)` / `prepend(...myHooks)` — or any custom function, since `mapFn` can reorder or replace the accumulated hooks arbitrarily.

Also adds `appendHooks` / `prependHooks` as the full names for these helpers (`append` / `prepend` remain as short aliases), and exposes all four from the library entrypoint.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [x] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

`hook(key, ...fns)` → `hook(key, mapFn)`. Existing call sites need `@hook('key', fn)` → `@hook('key', append(fn))`. The built-in `@onConstruct`, `@onConstructAsync`, and `@onContainerDisposed` decorators keep their old variadic signature — no migration needed for those.

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` (`.readme.hbs.md` changed)
- [x] Tests added or updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes (354 tests)
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

Decorator expressions evaluate top-to-bottom but decorators apply bottom-up, so `@onConstruct(h1) @onConstruct(h2)` previously would have run `h2` before `h1` under a naive `append`-based implementation. The built-in decorators now `prependHooks` internally to compensate, so stacked `@onConstruct`/`@onConstructAsync`/`@onContainerDisposed` decorators run in declaration order (`h1` then `h2`), verified with new tests in `__tests__/specs/lifecycle-hooks.spec.ts`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UstiyDFWBvjtHeQSZhDM2k)_