### PR TITLE
feat(@ts-ioc-container/react): add React adapter package

### DIFF
--- a/packages/react/__tests__/specs/react-adapter.spec.tsx
+++ b/packages/react/__tests__/specs/react-adapter.spec.tsx
@@ -13,7 +13,7 @@ import {
   SingleToken,
 } from 'ts-ioc-container';
 
-import { OutOfScopeError, Scope, ScopeContext, useResolveOrFail, useScopeOrFail } from '../../lib';
+import { OutOfScopeError, Scope, ScopeContext, useResolveOrFail, useScope, useScopeOrFail } from '../../lib';
 
 interface IGreeter {
   greet(): string;
@@ -248,6 +248,38 @@ describe('Spec: React adapter', () => {
           ),
         ),
       ).toThrowError(DependencyNotFoundError);
+    });
+  });
+
+  describe('Story: read the surrounding scope without throwing', () => {
+    it('returns the container put into ScopeContext from a component below it', () => {
+      const app = createApp();
+      let seen: IContainer | null = null;
+      const Probe = () => {
+        seen = useScope();
+        return null;
+      };
+
+      captureRender(
+        <Root container={app}>
+          <Probe />
+        </Root>,
+        () => seen,
+      );
+
+      expect(seen).toBe(app);
+    });
+
+    it('returns null when there is no surrounding scope', () => {
+      let seen: IContainer | null | undefined;
+      const Probe = () => {
+        seen = useScope();
+        return null;
+      };
+
+      captureRender(<Probe />, () => seen);
+
+      expect(seen).toBeNull();
     });
   });
 

--- a/packages/react/lib/ScopeContext.tsx
+++ b/packages/react/lib/ScopeContext.tsx
@@ -6,10 +6,17 @@ import { OutOfScopeError } from './OutOfScopeError';
 export const ScopeContext = createContext<IContainer | null>(null);
 
 /**
+ * Reads the surrounding scope, or `null` when there is no `ScopeContext.Provider` above the caller.
+ */
+export function useScope(): IContainer | null {
+  return useContext(ScopeContext);
+}
+
+/**
  * @throws {OutOfScopeError} when there is no `ScopeContext.Provider` above the caller.
  */
 export function useScopeOrFail(): IContainer {
-  const container = useContext(ScopeContext);
+  const container = useScope();
   if (!container) {
     throw new OutOfScopeError('useScopeOrFail must be called inside ScopeContext.Provider');
   }

--- a/packages/react/lib/index.ts
+++ b/packages/react/lib/index.ts
@@ -1,2 +1,2 @@
-export { Scope, ScopeContext, useResolveOrFail, useScopeOrFail } from './ScopeContext';
+export { Scope, ScopeContext, useResolveOrFail, useScope, useScopeOrFail } from './ScopeContext';
 export { OutOfScopeError } from './OutOfScopeError';


### PR DESCRIPTION
## Description

Adds `useScope` — a non-throwing counterpart to `useScopeOrFail` that returns `IContainer | null`, for components that want to read the surrounding scope without handling `OutOfScopeError`.

(The rest of the `@ts-ioc-container/react` package — `Scope`, `ScopeContext`, `useScopeOrFail`, `useResolveOrFail`, `OutOfScopeError` — was already merged to `main` via #106; this PR was rebased on top of that to drop the now-duplicate commits.)

## Type of change

- [x] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed
- [x] Tests added or updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

`@ts-ioc-container/react` is currently at `0.0.0`; merging this to `main` is expected to trigger its first publish via `release-monorepo-semantically`.