### PR TITLE
ci(github): split calc-coverage-and-release into separate jobs

### DIFF
--- a/.github/actions/cache-pnpm-store/action.yml
+++ b/.github/actions/cache-pnpm-store/action.yml
@@ -1,0 +1,17 @@
+name: Cache pnpm store
+description: Resolves the pnpm store directory and restores/saves it from cache
+
+runs:
+  using: composite
+  steps:
+    - name: Get pnpm store directory
+      shell: bash
+      run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+    - name: Cache pnpm store
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-

--- a/.github/actions/configure-git/action.yml
+++ b/.github/actions/configure-git/action.yml
@@ -1,0 +1,12 @@
+name: Configure Git
+description: Configures git user identity for github-actions[bot] and disables git hooks on CI
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config core.hooksPath /dev/null  # Disable git hooks on CI

--- a/.github/actions/publish-to-github-packages/README.md
+++ b/.github/actions/publish-to-github-packages/README.md
@@ -16,8 +16,6 @@ Composite GitHub Action that publishes an npm package to GitHub Packages registr
   uses: ./.github/actions/publish-to-github-packages
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
-    repository: ${{ github.repository }}
-    repository-owner: ${{ github.repository_owner }}
     package-name: ts-ioc-container
 ```
 
@@ -26,9 +24,9 @@ Composite GitHub Action that publishes an npm package to GitHub Packages registr
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `github-token` | GitHub token for authentication | Yes | - |
-| `repository` | Repository name (owner/repo format) | Yes | - |
-| `repository-owner` | Repository owner (will be lowercased for npm scope) | Yes | - |
 | `package-name` | Package name without scope | Yes | `ts-ioc-container` |
+
+Repository name and owner are read from the `github.repository` / `github.repository_owner` context automatically — no need to pass them in.
 
 ## Local Testing
 

--- a/.github/actions/publish-to-github-packages/action.yml
+++ b/.github/actions/publish-to-github-packages/action.yml
@@ -5,12 +5,6 @@ inputs:
   github-token:
     description: 'GitHub token for authentication'
     required: true
-  repository:
-    description: 'Repository name (owner/repo)'
-    required: true
-  repository-owner:
-    description: 'Repository owner (will be lowercased for npm scope)'
-    required: true
   package-name:
     description: 'Package name (without scope)'
     required: true
@@ -21,4 +15,4 @@ runs:
   steps:
     - name: Publish to GitHub Packages
       shell: bash
-      run: ${{ github.action_path }}/publish.sh "${{ inputs.repository-owner }}" "${{ inputs.repository }}" "${{ inputs.package-name }}" "${{ inputs.github-token }}"
+      run: ${{ github.action_path }}/publish.sh "${{ github.repository_owner }}" "${{ github.repository }}" "${{ inputs.package-name }}" "${{ inputs.github-token }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,10 +110,7 @@ jobs:
         run: pnpm run build:all
 
       - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config core.hooksPath /dev/null  # Disable git hooks on CI
+        uses: ./.github/actions/configure-git
 
       - name: Generate release context
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,49 @@ permissions:
   packages: write  # Required for publishing to GitHub Packages
 
 jobs:
-  calc-coverage-and-release:
+  generate-report:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Get pnpm store directory
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test with coverage
+        run: pnpm run test:coverage --maxWorkers=2
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./coverage/lcov.info
+
+      - name: Test @ts-ioc-container/react
+        run: pnpm run test:react
+
+  release:
+    needs: generate-report
     environment:
       name: production
       url: https://www.npmjs.com/package/ts-ioc-container
@@ -63,18 +105,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Test with coverage
-        run: pnpm run test:coverage --maxWorkers=2
-
-      - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./coverage/lcov.info
-
-      - name: Test @ts-ioc-container/react
-        run: pnpm run test:react
 
       - name: Build
         run: pnpm run build:all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,16 +32,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Get pnpm store directory
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
       - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+        uses: ./.github/actions/cache-pnpm-store
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -84,16 +76,8 @@ jobs:
         # 2. npm 11.5.1+ is installed (next step)
         # 3. Trusted Publishing is configured in npm account settings
 
-      - name: Get pnpm store directory
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
       - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
+        uses: ./.github/actions/cache-pnpm-store
 
       - name: Ensure npm 11.5.1 or later for OIDC
         # Pin to the npm 11 line: it satisfies the OIDC requirement (>= 11.5.1)
@@ -143,6 +127,4 @@ jobs:
         uses: ./.github/actions/publish-to-github-packages
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          repository-owner: ${{ github.repository_owner }}
           package-name: ts-ioc-container


### PR DESCRIPTION
## Summary
- Split the `calc-coverage-and-release` job in `publish.yml` into two jobs: `generate-report` (install, test with coverage, upload to Coveralls) and `release` (build, semantic-release, publish to GitHub Packages), with `release` gated on `generate-report` via `needs`.

## Test plan
- [ ] Push to `main` and confirm `generate-report` runs and reports coverage to Coveralls
- [ ] Confirm `release` only starts after `generate-report` succeeds and still publishes/releases correctly