### PR TITLE
ci(github): wire per-package lint/format/type-check/test into pr-checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,13 +44,16 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm run ci
 
       - name: Lint
         run: pnpm run lint
 
       - name: Type check
         run: pnpm run type-check
+
+      - name: Format check
+        run: pnpm run format:check
 
       - name: Test
         run: pnpm test --maxWorkers=2
@@ -61,5 +64,14 @@ jobs:
       - name: Type check @ts-ioc-container/react
         run: pnpm run type-check:react
 
+      - name: Format check @ts-ioc-container/react
+        run: pnpm --filter @ts-ioc-container/react run format:check
+
       - name: Test @ts-ioc-container/react
         run: pnpm run test:react
+
+      - name: Lint docs
+        run: pnpm --filter ts-ioc-container-docs run lint
+
+      - name: Format check docs
+        run: pnpm --filter ts-ioc-container-docs run format:check

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -1,9 +1,16 @@
 import eslintPluginAstro from "eslint-plugin-astro";
+import tsParser from "@typescript-eslint/parser";
 
 export default [
   // Apply recommended config from eslint-plugin-astro
   // This automatically configures the parser and rules for .astro files
   ...eslintPluginAstro.configs.recommended,
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+    },
+  },
   {
     ignores: ["dist/**", ".astro/**"],
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,6 +10,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "eslint . --ext .js,.ts,.astro",
+    "type-check": "astro check",
     "lint:fix": "eslint . --ext .js,.ts,.astro --fix",
     "format": "prettier --write \"**/*.{js,ts,astro,json,css,scss}\"",
     "format:check": "prettier --check \"**/*.{js,ts,astro,json,css,scss}\""
@@ -27,8 +28,10 @@
     "shiki": "^4.0.2"
   },
   "devDependencies": {
+    "@astrojs/check": "^0.9.10",
     "eslint-plugin-astro": "^1.5.0",
     "prettier-plugin-astro": "^0.14.1",
-    "sass": "^1.94.2"
+    "sass": "^1.94.2",
+    "typescript": "5.8.3"
   }
 }

--- a/docs/src/components/CodeBlock.astro
+++ b/docs/src/components/CodeBlock.astro
@@ -48,9 +48,7 @@ const htmlDark = await codeToHtml(code, {
 });
 ---
 
-<div
-  class="card mb-4"
->
+<div class="card mb-4">
   <div class="card-header d-flex justify-content-between align-items-center">
     <span class="badge bg-info">{langDisplay}</span>
     {filename && <span class="font-monospace small">{filename}</span>}

--- a/docs/src/components/CopyButton.astro
+++ b/docs/src/components/CopyButton.astro
@@ -65,5 +65,3 @@ const { code } = Astro.props;
     }
   }
 </style>
-
-

--- a/docs/src/components/TableOfContents.astro
+++ b/docs/src/components/TableOfContents.astro
@@ -16,17 +16,21 @@ const { headings = [] } = Astro.props;
   <div class="toc-header">
     <h5 class="mb-0">On this page</h5>
   </div>
-  {headings && headings.length > 0 ? (
-    <ul class="toc-list">
-      {headings.map((heading) => (
-        <li class={`toc-h${heading.level}`}>
-          <a href={`#${heading.id}`} class="toc-link">{heading.text}</a>
-        </li>
-      ))}
-    </ul>
-  ) : (
-    <p class="toc-empty text-muted small">No sections available</p>
-  )}
+  {
+    headings && headings.length > 0 ? (
+      <ul class="toc-list">
+        {headings.map((heading) => (
+          <li class={`toc-h${heading.level}`}>
+            <a href={`#${heading.id}`} class="toc-link">
+              {heading.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <p class="toc-empty text-muted small">No sections available</p>
+    )
+  }
 </nav>
 
 <style>
@@ -92,5 +96,3 @@ const { headings = [] } = Astro.props;
     font-size: 0.8rem;
   }
 </style>
-
-

--- a/docs/src/components/ThemeToggle.astro
+++ b/docs/src/components/ThemeToggle.astro
@@ -3,8 +3,14 @@ import sunIcon from "@assets/theme-icons/sun.svg?raw";
 import moonIcon from "@assets/theme-icons/moon.svg?raw";
 
 // Add IDs and display style to imported SVGs
-const sunIconWithId = sunIcon.replace('<svg', '<svg id="theme-icon-light" style="display: none;"');
-const moonIconWithId = moonIcon.replace('<svg', '<svg id="theme-icon-dark" style="display: none;"');
+const sunIconWithId = sunIcon.replace(
+  "<svg",
+  '<svg id="theme-icon-light" style="display: none;"',
+);
+const moonIconWithId = moonIcon.replace(
+  "<svg",
+  '<svg id="theme-icon-dark" style="display: none;"',
+);
 ---
 
 <button
@@ -18,14 +24,12 @@ const moonIconWithId = moonIcon.replace('<svg', '<svg id="theme-icon-dark" style
   <Fragment set:html={moonIconWithId} />
 </button>
 
-
 <style>
   #theme-toggle {
     transition: color 0.2s ease;
   }
-  
+
   #theme-toggle:hover {
     opacity: 0.8;
   }
 </style>
-

--- a/docs/src/config/navigation.ts
+++ b/docs/src/config/navigation.ts
@@ -9,7 +9,7 @@ export { isNavigationGroup };
 
 export const navigation: NavigationItem[] = [
   { title: "Overview", href: "/ts-ioc-container/" },
-{ title: "Dependency & Scope", href: "/ts-ioc-container/container" },
+  { title: "Dependency & Scope", href: "/ts-ioc-container/container" },
   { title: "Dependency Registration", href: "/ts-ioc-container/registration" },
   { title: "Provider Behavior", href: "/ts-ioc-container/provider" },
   { title: "Pipes", href: "/ts-ioc-container/pipes" },

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -17,7 +17,9 @@ interface Props {
 const frontmatter = Astro.props.frontmatter ?? {};
 const title = Astro.props.title ?? frontmatter.title ?? siteMetadata.title;
 const description =
-  Astro.props.description ?? frontmatter.description ?? siteMetadata.description;
+  Astro.props.description ??
+  frontmatter.description ??
+  siteMetadata.description;
 
 // Get headings for current page
 const headingsArray = getHeadingsForPath(Astro.url.pathname);
@@ -27,7 +29,9 @@ const normalizePath = (path: string) => path.replace(/\/$/, "") || "/";
 const currentPath = normalizePath(Astro.url.pathname);
 const canonicalUrl = new URL(Astro.url.pathname, siteMetadata.url).toString();
 const fullTitle =
-  title === siteMetadata.title ? siteMetadata.title : `${title} | ${siteMetadata.title}`;
+  title === siteMetadata.title
+    ? siteMetadata.title
+    : `${title} | ${siteMetadata.title}`;
 const keywords = siteMetadata.keywords.join(", ");
 const jsonLd = {
   "@context": "https://schema.org",
@@ -80,7 +84,11 @@ const jsonLd = {
     <meta name="robots" content="index, follow" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="canonical" href={canonicalUrl} />
-    <link rel="icon" type="image/svg+xml" href={`${siteMetadata.basePath}/favicon.svg`} />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href={`${siteMetadata.basePath}/favicon.svg`}
+    />
     <meta name="generator" content={Astro.generator} />
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content={siteMetadata.title} />
@@ -116,8 +124,7 @@ const jsonLd = {
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-      crossorigin="anonymous"
-    ></script>
+      crossorigin="anonymous"></script>
 
     <!-- Initialize theme before page render to prevent flash -->
     <script is:inline>
@@ -151,7 +158,9 @@ const jsonLd = {
                 });
                 return (
                   <div class="nav-group">
-                    <div class={`nav-group-label ${isGroupActive ? "text-primary fw-semibold" : "text-muted"}`}>
+                    <div
+                      class={`nav-group-label ${isGroupActive ? "text-primary fw-semibold" : "text-muted"}`}
+                    >
                       {item.title}
                     </div>
                     {item.children.map((child) => {

--- a/docs/src/pages/_benchmarks.astro
+++ b/docs/src/pages/_benchmarks.astro
@@ -1,16 +1,24 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 
-const benchmarkModules = import.meta.glob("../../../__benchmarks__/specs/*.benchmark.ts");
+const benchmarkModules = import.meta.glob(
+  "../../../__benchmarks__/specs/*.benchmark.ts",
+);
 const availableSpecs = Object.keys(benchmarkModules)
-  .map((path) => path.split("/").pop()?.replace(/\.benchmark\.ts$/, ""))
+  .map((path) =>
+    path
+      .split("/")
+      .pop()
+      ?.replace(/\.benchmark\.ts$/, ""),
+  )
   .filter((prefix): prefix is string => Boolean(prefix))
   .sort();
 
 const implementationOrder = ["ts-ioc-container", "tsyringe"];
 const getBenchmarkKey = (prefix: string) =>
   prefix.replace(/\.(ts-ioc-container|tsyringe)$/, "");
-const getImplementation = (prefix: string) => prefix.replace(`${getBenchmarkKey(prefix)}.`, "");
+const getImplementation = (prefix: string) =>
+  prefix.replace(`${getBenchmarkKey(prefix)}.`, "");
 const formatBenchmarkLabel = (key: string) =>
   key
     .split("-")
@@ -22,8 +30,10 @@ const sortSpecs = (specs: string[]) =>
     const implementationB = getImplementation(b);
     const orderA = implementationOrder.indexOf(implementationA);
     const orderB = implementationOrder.indexOf(implementationB);
-    const normalizedOrderA = orderA === -1 ? implementationOrder.length : orderA;
-    const normalizedOrderB = orderB === -1 ? implementationOrder.length : orderB;
+    const normalizedOrderA =
+      orderA === -1 ? implementationOrder.length : orderA;
+    const normalizedOrderB =
+      orderB === -1 ? implementationOrder.length : orderB;
 
     return normalizedOrderA - normalizedOrderB || a.localeCompare(b);
   });
@@ -44,7 +54,9 @@ const benchmarkGroups = Array.from(
     label: `${formatBenchmarkLabel(group.key)} (${group.specs.map(getImplementation).join(", ")})`,
   }))
   .sort((a, b) => a.label.localeCompare(b.label));
-const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependency-resolution")
+const defaultBenchmark = benchmarkGroups.some(
+  (group) => group.key === "dependency-resolution",
+)
   ? "dependency-resolution"
   : benchmarkGroups[0]?.key;
 ---
@@ -64,7 +76,12 @@ const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependen
         <select class="form-select" id="benchmark-pair" name="benchmark">
           {
             benchmarkGroups.map((group) => (
-              <option value={group.key} selected={group.key === defaultBenchmark}>{group.label}</option>
+              <option
+                value={group.key}
+                selected={group.key === defaultBenchmark}
+              >
+                {group.label}
+              </option>
             ))
           }
         </select>
@@ -117,25 +134,34 @@ const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependen
   <script>
     import "reflect-metadata";
 
-    const modules = import.meta.glob("../../../__benchmarks__/specs/*.benchmark.ts");
+    const modules = import.meta.glob(
+      "../../../__benchmarks__/specs/*.benchmark.ts",
+    );
     const moduleByPrefix = new Map(
       Object.entries(modules).map(([path, loader]) => [
-        path.split("/").pop().replace(/\.benchmark\.ts$/, ""),
+        path
+          .split("/")
+          .pop()
+          .replace(/\.benchmark\.ts$/, ""),
         loader,
       ]),
     );
     const availableSpecs = Array.from(moduleByPrefix.keys()).sort();
     const implementationOrder = ["ts-ioc-container", "tsyringe"];
-    const getBenchmarkKey = (prefix) => prefix.replace(/\.(ts-ioc-container|tsyringe)$/, "");
-    const getImplementation = (prefix) => prefix.replace(`${getBenchmarkKey(prefix)}.`, "");
+    const getBenchmarkKey = (prefix) =>
+      prefix.replace(/\.(ts-ioc-container|tsyringe)$/, "");
+    const getImplementation = (prefix) =>
+      prefix.replace(`${getBenchmarkKey(prefix)}.`, "");
     const sortSpecs = (specs) =>
       specs.toSorted((a, b) => {
         const implementationA = getImplementation(a);
         const implementationB = getImplementation(b);
         const orderA = implementationOrder.indexOf(implementationA);
         const orderB = implementationOrder.indexOf(implementationB);
-        const normalizedOrderA = orderA === -1 ? implementationOrder.length : orderA;
-        const normalizedOrderB = orderB === -1 ? implementationOrder.length : orderB;
+        const normalizedOrderA =
+          orderA === -1 ? implementationOrder.length : orderA;
+        const normalizedOrderB =
+          orderB === -1 ? implementationOrder.length : orderB;
 
         return normalizedOrderA - normalizedOrderB || a.localeCompare(b);
       });
@@ -150,7 +176,9 @@ const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependen
         specs: sortSpecs(specs),
       }),
     );
-    const benchmarkByKey = new Map(benchmarkGroups.map((group) => [group.key, group]));
+    const benchmarkByKey = new Map(
+      benchmarkGroups.map((group) => [group.key, group]),
+    );
     const defaultBenchmark = benchmarkByKey.has("dependency-resolution")
       ? "dependency-resolution"
       : benchmarkGroups[0]?.key;
@@ -162,7 +190,9 @@ const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependen
     const resultsBody = document.querySelector("#benchmark-results-body");
 
     const formatHz = (value) =>
-      new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value);
+      new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
+        value,
+      );
     const formatMean = (value) =>
       `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 4 }).format(value)} ms`;
 
@@ -188,7 +218,10 @@ const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependen
         benchmarkInput.value = defaultBenchmark;
       }
 
-      if (duration && durationInput.querySelector(`option[value="${duration}"]`)) {
+      if (
+        duration &&
+        durationInput.querySelector(`option[value="${duration}"]`)
+      ) {
         durationInput.value = duration;
       }
     };
@@ -198,7 +231,11 @@ const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependen
         benchmark: benchmarkInput.value,
         duration: durationInput.value,
       });
-      window.history.replaceState(null, "", `${window.location.pathname}?${params}`);
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}?${params}`,
+      );
     };
 
     const loadSpec = async (prefix) => {
@@ -272,7 +309,10 @@ const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependen
 
     const renderBenchmarkRows = (rows) => {
       const doneRows = rows.filter((row) => row.result);
-      const fastest = doneRows.length > 0 ? Math.max(...doneRows.map((row) => row.result.hz)) : 0;
+      const fastest =
+        doneRows.length > 0
+          ? Math.max(...doneRows.map((row) => row.result.hz))
+          : 0;
       const sortedRows = [
         ...doneRows.toSorted((a, b) => b.result.hz - a.result.hz),
         ...rows.filter((row) => !row.result),
@@ -314,7 +354,8 @@ const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependen
         })) || [];
 
       runButton.disabled = true;
-      resultsBody.innerHTML = '<tr><td colspan="7">Preparing benchmark files...</td></tr>';
+      resultsBody.innerHTML =
+        '<tr><td colspan="7">Preparing benchmark files...</td></tr>';
       writeQuery();
 
       try {
@@ -335,7 +376,9 @@ const defaultBenchmark = benchmarkGroups.some((group) => group.key === "dependen
           renderBenchmarkRows(benchmarkRows);
         }
       } catch (error) {
-        const runningRow = benchmarkRows.find((item) => item.state === "running");
+        const runningRow = benchmarkRows.find(
+          (item) => item.state === "running",
+        );
         if (runningRow) {
           runningRow.state = "failed";
           runningRow.error = error.message;

--- a/docs/src/styles/global.scss
+++ b/docs/src/styles/global.scss
@@ -1,7 +1,8 @@
 /* Minimal custom styles - Bootstrap handles most styling */
 
 /* Ensure full width layout */
-html, body {
+html,
+body {
   width: 100%;
   max-width: 100%;
   overflow-x: hidden;

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -7,5 +7,6 @@
       "@assets/*": ["./src/assets/*"]
     },
     "target": "ES2022"
-  }
+  },
+  "exclude": ["dist"]
 }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "type-check:watch": "tsc --noEmit --watch",
     "commit": "cz",
     "format": "prettier --write \"**/*.ts\"",
+    "format:check": "prettier --check \"lib/**/*.ts\" \"__tests__/**/*.ts\" \"__benchmarks__/**/*.ts\"",
     "lint": "eslint lib/**/*.ts __tests__/**/*.ts __benchmarks__/**/*.ts",
     "lint:fix": "npm run lint --fix",
     "audit": "npm audit",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -56,7 +56,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage --coverage.reporter=lcov",
     "type-check": "tsc --noEmit",
-    "lint": "eslint lib/**/*.tsx lib/**/*.ts __tests__/**/*.tsx"
+    "lint": "eslint lib/**/*.tsx lib/**/*.ts __tests__/**/*.tsx",
+    "format:check": "prettier --check \"lib/**/*.ts\" \"lib/**/*.tsx\" \"__tests__/**/*.tsx\""
   },
   "peerDependencies": {
     "react": ">=18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2
     devDependencies:
+      '@astrojs/check':
+        specifier: ^0.9.10
+        version: 0.9.10(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@5.8.3)
       eslint-plugin-astro:
         specifier: ^1.5.0
         version: 1.5.0(eslint@9.24.0(jiti@2.6.1))
@@ -129,6 +132,9 @@ importers:
       sass:
         specifier: ^1.94.2
         version: 1.99.0
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   packages/react:
     devDependencies:
@@ -189,6 +195,12 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
+  '@astrojs/check@0.9.10':
+    resolution: {integrity: sha512-zgx/UQMozdjOa3bOxjgeCFdtpE3c9rRX6xHwa+2QXvy8z8Akifu2AtubHyv/zzC2znO8dl8fFWL4K+Ba9kS8HQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0 || ^6.0.0
+
   '@astrojs/compiler@2.13.0':
     resolution: {integrity: sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==}
 
@@ -197,6 +209,18 @@ packages:
 
   '@astrojs/internal-helpers@0.4.1':
     resolution: {integrity: sha512-bMf9jFihO8YP940uD70SI/RDzIhUHJAolWVcO1v5PUivxGKvfLZTLTVVxEYzGYyPsA3ivdLNqMnL5VgmQySa+g==}
+
+  '@astrojs/language-server@2.16.14':
+    resolution: {integrity: sha512-YPXkBu6N4d1sT09pvBmIDGZay+1MemV551FSgdEM3aZRDzbkxd2H7Cvf8MsVJLVB1mIEyTf1XbMN/30gp7s46w==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^3.0.0
+      prettier-plugin-astro: '>=0.11.0'
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+      prettier-plugin-astro:
+        optional: true
 
   '@astrojs/markdown-remark@5.3.0':
     resolution: {integrity: sha512-r0Ikqr0e6ozPb5bvhup1qdWnSPUvQu6tub4ZLYaKyG50BXZ0ej6FhGz3GpChKpH7kglRFPObJd/bDyf2VM9pkg==}
@@ -217,6 +241,9 @@ packages:
   '@astrojs/telemetry@3.1.0':
     resolution: {integrity: sha512-/ca/+D8MIKEC8/A9cSaPUqQNZm+Es/ZinRv0ZAzvu2ios7POQSsVD+VOj7/hypWNsNM3T7RpfgNq7H2TU1KEHA==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=21.0.0}
+
+  '@astrojs/yaml2ts@0.2.4':
+    resolution: {integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -483,6 +510,27 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@emmetio/abbreviation@2.3.3':
+    resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
+
+  '@emmetio/css-abbreviation@2.1.8':
+    resolution: {integrity: sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==}
+
+  '@emmetio/css-parser@0.4.1':
+    resolution: {integrity: sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==}
+
+  '@emmetio/html-matcher@1.3.0':
+    resolution: {integrity: sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==}
+
+  '@emmetio/scanner@1.0.4':
+    resolution: {integrity: sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==}
+
+  '@emmetio/stream-reader-utils@0.1.0':
+    resolution: {integrity: sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==}
+
+  '@emmetio/stream-reader@2.2.0':
+    resolution: {integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==}
 
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
@@ -2418,6 +2466,32 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
+  '@volar/kit@2.4.28':
+    resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
+    peerDependencies:
+      typescript: '*'
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/language-server@2.4.28':
+    resolution: {integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==}
+
+  '@volar/language-service@2.4.28':
+    resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vscode/emmet-helper@2.11.0':
+    resolution: {integrity: sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==}
+
+  '@vscode/l10n@0.0.18':
+    resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -2450,6 +2524,14 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2457,6 +2539,11 @@ packages:
     peerDependenciesMeta:
       ajv:
         optional: true
+
+  ajv-i18n@4.2.0:
+    resolution: {integrity: sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==}
+    peerDependencies:
+      ajv: ^8.0.0-beta.0
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -2731,6 +2818,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -3140,6 +3231,9 @@ packages:
 
   elkjs@0.9.3:
     resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
+
+  emmet@2.4.11:
+    resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -3942,6 +4036,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-parser@2.3.1:
+    resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
@@ -4400,6 +4500,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
@@ -4560,6 +4663,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -4668,6 +4774,11 @@ packages:
 
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -4810,6 +4921,12 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  request-light@0.5.8:
+    resolution: {integrity: sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==}
+
+  request-light@0.7.0:
+    resolution: {integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -5086,6 +5203,10 @@ packages:
     resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
     engines: {node: '>=20'}
 
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -5279,6 +5400,12 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typesafe-path@0.2.2:
+    resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
+
+  typescript-auto-import-cache@0.3.6:
+    resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -5513,6 +5640,108 @@ packages:
       jsdom:
         optional: true
 
+  volar-service-css@0.0.71:
+    resolution: {integrity: sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-emmet@0.0.71:
+    resolution: {integrity: sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-html@0.0.71:
+    resolution: {integrity: sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-prettier@0.0.71:
+    resolution: {integrity: sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+      prettier: ^2.2 || ^3.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+      prettier:
+        optional: true
+
+  volar-service-typescript-twoslash-queries@0.0.71:
+    resolution: {integrity: sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-typescript@0.0.71:
+    resolution: {integrity: sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-yaml@0.0.71:
+    resolution: {integrity: sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  vscode-css-languageservice@6.3.10:
+    resolution: {integrity: sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==}
+
+  vscode-html-languageservice@5.6.2:
+    resolution: {integrity: sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==}
+
+  vscode-json-languageservice@4.1.8:
+    resolution: {integrity: sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==}
+    engines: {npm: '>=7.0.0'}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-jsonrpc@9.0.1:
+    resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-protocol@3.18.2:
+    resolution: {integrity: sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-nls@5.2.0:
+    resolution: {integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==}
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -5632,6 +5861,10 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml-language-server@1.23.0:
+    resolution: {integrity: sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==}
+    hasBin: true
+
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
@@ -5641,9 +5874,17 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -5695,11 +5936,48 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@astrojs/check@0.9.10(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@5.8.3)':
+    dependencies:
+      '@astrojs/language-server': 2.16.14(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@5.8.3)
+      chokidar: 4.0.3
+      kleur: 4.1.5
+      typescript: 5.8.3
+      yargs: 18.1.0
+    transitivePeerDependencies:
+      - prettier
+      - prettier-plugin-astro
+
   '@astrojs/compiler@2.13.0': {}
 
   '@astrojs/compiler@2.13.1': {}
 
   '@astrojs/internal-helpers@0.4.1': {}
+
+  '@astrojs/language-server@2.16.14(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@5.8.3)':
+    dependencies:
+      '@astrojs/compiler': 2.13.1
+      '@astrojs/yaml2ts': 0.2.4
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@volar/kit': 2.4.28(typescript@5.8.3)
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
+      muggle-string: 0.4.1
+      tinyglobby: 0.2.16
+      volar-service-css: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-emmet: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-html: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-prettier: 0.0.71(@volar/language-service@2.4.28)(prettier@3.9.6)
+      volar-service-typescript: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-typescript-twoslash-queries: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-yaml: 0.0.71(@volar/language-service@2.4.28)
+      vscode-html-languageservice: 5.6.2
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      prettier: 3.9.6
+      prettier-plugin-astro: 0.14.1
+    transitivePeerDependencies:
+      - typescript
 
   '@astrojs/markdown-remark@5.3.0':
     dependencies:
@@ -5765,6 +6043,10 @@ snapshots:
       which-pm-runs: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  '@astrojs/yaml2ts@0.2.4':
+    dependencies:
+      yaml: 2.8.3
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -6132,6 +6414,29 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@emmetio/abbreviation@2.3.3':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/css-abbreviation@2.1.8':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/css-parser@0.4.1':
+    dependencies:
+      '@emmetio/stream-reader': 2.2.0
+      '@emmetio/stream-reader-utils': 0.1.0
+
+  '@emmetio/html-matcher@1.3.0':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/scanner@1.0.4': {}
+
+  '@emmetio/stream-reader-utils@0.1.0': {}
+
+  '@emmetio/stream-reader@2.2.0': {}
 
   '@emnapi/runtime@1.7.1':
     dependencies:
@@ -8089,6 +8394,56 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@volar/kit@2.4.28(typescript@5.8.3)':
+    dependencies:
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      typesafe-path: 0.2.2
+      typescript: 5.8.3
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/language-server@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      path-browserify: 1.0.1
+      request-light: 0.7.0
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.18.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-service@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      vscode-languageserver-protocol: 3.18.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vscode/emmet-helper@2.11.0':
+    dependencies:
+      emmet: 2.4.11
+      jsonc-parser: 2.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+
+  '@vscode/l10n@0.0.18': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -8118,8 +8473,16 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-draft-04@1.0.0(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
+      ajv: 8.18.0
+
+  ajv-i18n@4.2.0(ajv@8.18.0):
+    dependencies:
       ajv: 8.18.0
 
   ajv@6.14.0:
@@ -8471,6 +8834,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   clone@1.0.4: {}
 
@@ -8892,6 +9261,11 @@ snapshots:
   electron-to-chromium@1.5.336: {}
 
   elkjs@0.9.3: {}
+
+  emmet@2.4.11:
+    dependencies:
+      '@emmetio/abbreviation': 2.3.3
+      '@emmetio/css-abbreviation': 2.1.8
 
   emoji-regex-xs@1.0.0: {}
 
@@ -9894,6 +10268,10 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-parser@2.3.1: {}
+
+  jsonc-parser@3.3.1: {}
+
   jsonfile@6.2.0:
     dependencies:
       universalify: 2.0.1
@@ -10712,6 +11090,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   mute-stream@0.0.8: {}
 
   nanoid@3.3.11: {}
@@ -10885,6 +11265,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -10975,6 +11357,8 @@ snapshots:
       sass-formatter: 0.7.9
 
   prettier@3.5.3: {}
+
+  prettier@3.9.6: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -11178,6 +11562,10 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  request-light@0.5.8: {}
+
+  request-light@0.7.0: {}
 
   require-directory@2.1.1: {}
 
@@ -11536,6 +11924,11 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -11693,6 +12086,12 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typesafe-path@0.2.2: {}
+
+  typescript-auto-import-cache@0.3.6:
+    dependencies:
+      semver: 7.7.4
 
   typescript@5.8.3: {}
 
@@ -11941,6 +12340,112 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  volar-service-css@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-css-languageservice: 6.3.10
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-emmet@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      '@emmetio/css-parser': 0.4.1
+      '@emmetio/html-matcher': 1.3.0
+      '@vscode/emmet-helper': 2.11.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-html@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-html-languageservice: 5.6.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-prettier@0.0.71(@volar/language-service@2.4.28)(prettier@3.9.6):
+    dependencies:
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+      prettier: 3.9.6
+
+  volar-service-typescript-twoslash-queries@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-typescript@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      path-browserify: 1.0.1
+      semver: 7.7.4
+      typescript-auto-import-cache: 0.3.6
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-yaml@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-uri: 3.1.0
+      yaml-language-server: 1.23.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  vscode-css-languageservice@6.3.10:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+
+  vscode-html-languageservice@5.6.2:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+
+  vscode-json-languageservice@4.1.8:
+    dependencies:
+      jsonc-parser: 3.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-jsonrpc@9.0.1: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-protocol@3.18.2:
+    dependencies:
+      vscode-jsonrpc: 9.0.1
+      vscode-languageserver-types: 3.18.0
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver-types@3.18.0: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-nls@5.2.0: {}
+
+  vscode-uri@3.1.0: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -12034,9 +12539,26 @@ snapshots:
 
   yallist@3.1.1: {}
 
+  yaml-language-server@1.23.0:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      ajv: 8.18.0
+      ajv-draft-04: 1.0.0(ajv@8.18.0)
+      ajv-i18n: 4.2.0(ajv@8.18.0)
+      prettier: 3.9.6
+      request-light: 0.5.8
+      vscode-json-languageservice: 4.1.8
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+      yaml: 2.8.3
+
   yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
 
   yargs@17.7.2:
     dependencies:
@@ -12047,6 +12569,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.2
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- Adds a `Format check` step for root and `@ts-ioc-container/react`, plus `Lint` and `Format check` steps for `docs`, so every workspace package gets the same coverage in `pr-checks.yml`.
- Extracts `pnpm install --frozen-lockfile` into a root `ci` package.json script, used by both `pr-checks.yml` and `publish.yml`, instead of duplicating the raw command.
- Bakes `--maxWorkers=2` into the root `test:coverage` script so `publish.yml` no longer passes it inline.
- Adds `"type-check": "astro check"` to `docs/package.json` but does **not** wire it into CI yet — running it today surfaces 52 pre-existing type errors in `docs/src` unrelated to this change; enforcing it belongs in a separate follow-up.
- Fixes two latent docs bugs found while getting `lint`/`format:check` to pass cleanly:
  - `docs/eslint.config.mjs` had no TypeScript parser configured for `.ts` files (astro's recommended config only wires up `.astro` parsing), so linting `.ts` files failed with parse errors.
  - `docs/tsconfig.json` didn't exclude `dist/`, so a local `astro build` output would crash `astro check` on minified bundle JS.
- Reformats 8 `docs/src` files that had drifted from Prettier's style (mechanical `--write`, no logic changes).

## Test plan
- [x] `pnpm run ci` (install)
- [x] `pnpm run lint` / `type-check` / `format:check` / `test` at root
- [x] `pnpm run lint:react` / `type-check:react` / `pnpm --filter @ts-ioc-container/react run format:check` / `test:react`
- [x] `pnpm --filter ts-ioc-container-docs run lint` / `format:check` / `docs:build`
- [x] `pnpm run test:coverage`