### PR TITLE
docs(config): move react-adapter epic into packages/react/specs

### DIFF
--- a/packages/react/specs/README.md
+++ b/packages/react/specs/README.md
@@ -1,0 +1,17 @@
+# Specs — @ts-ioc-container/react
+
+Package-local epics for `@ts-ioc-container/react`. Cross-cutting specs for the
+core container live in the root [`specs/`](../../../specs/README.md); this
+directory holds epics whose contract is specific to this package.
+
+See the root `specs/README.md` for the spec-driven workflow, style, and
+traceability conventions — they apply here unchanged.
+
+## Structure
+
+```text
+specs/
+  README.md
+  epics/
+    react-adapter.md
+```

--- a/packages/react/specs/epics/react-adapter.md
+++ b/packages/react/specs/epics/react-adapter.md
@@ -1,7 +1,7 @@
 # Epic: React adapter
 
 - **Status:** Proposed
-- **ADR:** [ADR 0001 - Container as a linked list of scopes](../../docs/adr/0001-container-as-linked-list.md)
+- **ADR:** [ADR 0001 - Container as a linked list of scopes](../../../../docs/adr/0001-container-as-linked-list.md)
 - **Public API:** `ScopeContext`, `Scope`, `useScopeOrFail`, `useResolveOrFail`, `OutOfScopeError`
 - **Package:** `@ts-ioc-container/react`
 - **Executable spec:** `packages/react/__tests__/specs/react-adapter.spec.tsx`

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,10 +1,17 @@
 # Specifications
 
-This directory is the product-facing contract for `ts-ioc-container`.
+This directory is the product-facing contract for `ts-ioc-container`, the core
+library at the repo root.
 
 Specs describe what the library promises before the implementation describes
 how it works. They are written for maintainers, contributors, and reviewers who
 need to understand intended behavior without reading all of `lib/`.
+
+Epics scoped to a single other workspace package (for example
+`@ts-ioc-container/react`) live in that package's own `specs/` directory
+instead of here — see `packages/react/specs/README.md`. This directory covers
+the core library only. The workflow, style, and traceability conventions below
+apply the same way in both places.
 
 ## Artifact roles
 


### PR DESCRIPTION
## Summary
- `specs/epics/react-adapter.md` is scoped entirely to `@ts-ioc-container/react` (its `Package:` and `Executable spec:` fields already point at the react package) but lived in the core library's global `specs/epics/` next to root-only epics.
- Moves it to `packages/react/specs/epics/react-adapter.md`, adds a short `packages/react/specs/README.md` pointing back at the root conventions, and fixes the relative ADR link for the new depth.
- Documents the global-vs-local split in the root `specs/README.md`: core-library epics stay in `specs/`, package-scoped epics live in that package's own `specs/`.

## Test plan
- [x] Grepped for any other reference to the old `specs/epics/react-adapter.md` path — none found.
- [x] Verified the relative ADR link in the moved file resolves to `docs/adr/0001-container-as-linked-list.md`.