### PR TITLE
fix(config): upgrade release-monorepo-semantically to 1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lint-staged": "^16.4.0",
     "prettier": "3.5.3",
     "prettier-plugin-astro": "^0.14.1",
-    "release-monorepo-semantically": "1.9.0",
+    "release-monorepo-semantically": "1.9.1",
     "tsx": "^4.21.0",
     "typescript": "5.8.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1
       release-monorepo-semantically:
-        specifier: 1.9.0
-        version: 1.9.0
+        specifier: 1.9.1
+        version: 1.9.1
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -5060,8 +5060,8 @@ packages:
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
 
-  release-monorepo-semantically@1.9.0:
-    resolution: {integrity: sha512-7iiOVQPjFvTItLm47/yLLpu1GJkRN3kSyaOhNCe3xqEhN7IdgRLlHsh8SUHzxDQKIH1mkRe4Mj/lIMbhkrFADA==}
+  release-monorepo-semantically@1.9.1:
+    resolution: {integrity: sha512-Zmk6Hst5uKHxFNpFjNHC0Sfd6N8BaP4esQtoCQBrAtnU2jNUBco/b0I23Dv7sCjAfVcT16VF0Yo1Ij4JIJAJmg==}
     engines: {node: '>=20.11'}
     hasBin: true
 
@@ -7614,7 +7614,7 @@ snapshots:
   '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
@@ -11778,7 +11778,7 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
-  release-monorepo-semantically@1.9.0:
+  release-monorepo-semantically@1.9.1:
     dependencies:
       commander: 14.0.3
       glob: 10.5.0


### PR DESCRIPTION
## Summary
- Bumps `release-monorepo-semantically` 1.9.0 → 1.9.1, which makes `vcs createTag` idempotent (skips creation if the tag already exists) instead of failing fatally.
- Unblocks the `release` job in `publish.yml`, which currently fails on `main` because tag `@ts-ioc-container/react@0.1.0` already exists on `origin` pointing at unrelated stale history — see failed run: https://github.com/IgorBabkin/ts-ioc-container/actions/runs/31909985484/job/95073617220

## Test plan
- [ ] Merge and confirm the next `publish.yml` run on `main` completes the `release` job without the `git tag` collision error