### PR TITLE
feat(ts-ioc-container): let @register bind directly from an InjectionToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -2166,7 +2166,7 @@ Registration is provider factory which registers provider in container.
 
 Use `bindTo(key)` to register a provider under a specific key. By default the key is the class name. Multiple registrations can share the same key.
 
-An `InjectionToken` that implements `BindToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) can also be passed directly to `@register(...)` — it binds under the hood exactly like `bindTo(token)`, so `@register(LoggerToken)` and `@register(bindTo(LoggerToken))` are equivalent.
+A plain `DependencyKey` (`string` / `symbol`) or an `InjectionToken` that implements `BindToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) can also be passed directly to `@register(...)` — it binds under the hood exactly like `bindTo(...)`, so `@register('ILogger')` / `@register(LoggerToken)` and `@register(bindTo('ILogger'))` / `@register(bindTo(LoggerToken))` are equivalent.
 
 > [!TIP]
 > Prefer `SingleToken<T>` over plain string literals as registration keys. Tokens are type-safe, rename-friendly, and prevent typos that only surface at runtime.
@@ -2252,6 +2252,16 @@ describe('Registration module', function () {
     const appContainer = createAppContainer().addRegistration(R.fromClass(FileLogger));
 
     expect(LoggerToken.resolve(appContainer)).toBeInstanceOf(FileLogger);
+  });
+
+  it('should register directly from a plain key passed to @register, without wrapping it in bindTo()', function () {
+    // A plain DependencyKey straight in @register binds to it under the hood
+    @register('PlainLogger')
+    class Logger {}
+
+    const appContainer = createAppContainer().addRegistration(R.fromClass(Logger));
+
+    expect(appContainer.resolve('PlainLogger')).toBeInstanceOf(Logger);
   });
 
   it('should register with multiple keys using aliases', function () {

--- a/README.md
+++ b/README.md
@@ -2166,6 +2166,8 @@ Registration is provider factory which registers provider in container.
 
 Use `bindTo(key)` to register a provider under a specific key. By default the key is the class name. Multiple registrations can share the same key.
 
+An `InjectionToken` that implements `BindToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) can also be passed directly to `@register(...)` — it binds under the hood exactly like `bindTo(token)`, so `@register(LoggerToken)` and `@register(bindTo(LoggerToken))` are equivalent.
+
 > [!TIP]
 > Prefer `SingleToken<T>` over plain string literals as registration keys. Tokens are type-safe, rename-friendly, and prevent typos that only surface at runtime.
 
@@ -2178,6 +2180,7 @@ import {
   Registration as R,
   scope,
   select as s,
+  SingleToken,
   singleton,
 } from 'ts-ioc-container';
 
@@ -2237,6 +2240,18 @@ describe('Registration module', function () {
     const appContainer = createAppContainer().addRegistration(R.fromClass(FileLogger));
 
     expect(appContainer.resolve('FileLogger')).toBeInstanceOf(FileLogger);
+  });
+
+  it('should register directly from a token passed to @register, without wrapping it in bindTo()', function () {
+    // Passing an InjectionToken straight to @register binds to it under the hood
+    const LoggerToken = new SingleToken<FileLogger>('ILogger');
+
+    @register(LoggerToken, singleton())
+    class FileLogger {}
+
+    const appContainer = createAppContainer().addRegistration(R.fromClass(FileLogger));
+
+    expect(LoggerToken.resolve(appContainer)).toBeInstanceOf(FileLogger);
   });
 
   it('should register with multiple keys using aliases', function () {

--- a/packages/ts-ioc-container/.readme.hbs.md
+++ b/packages/ts-ioc-container/.readme.hbs.md
@@ -379,7 +379,7 @@ Registration is provider factory which registers provider in container.
 
 Use `bindTo(key)` to register a provider under a specific key. By default the key is the class name. Multiple registrations can share the same key.
 
-An `InjectionToken` that implements `BindToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) can also be passed directly to `@register(...)` — it binds under the hood exactly like `bindTo(token)`, so `@register(LoggerToken)` and `@register(bindTo(LoggerToken))` are equivalent.
+A plain `DependencyKey` (`string` / `symbol`) or an `InjectionToken` that implements `BindToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) can also be passed directly to `@register(...)` — it binds under the hood exactly like `bindTo(...)`, so `@register('ILogger')` / `@register(LoggerToken)` and `@register(bindTo('ILogger'))` / `@register(bindTo(LoggerToken))` are equivalent.
 
 > [!TIP]
 > Prefer `SingleToken<T>` over plain string literals as registration keys. Tokens are type-safe, rename-friendly, and prevent typos that only surface at runtime.

--- a/packages/ts-ioc-container/.readme.hbs.md
+++ b/packages/ts-ioc-container/.readme.hbs.md
@@ -379,6 +379,8 @@ Registration is provider factory which registers provider in container.
 
 Use `bindTo(key)` to register a provider under a specific key. By default the key is the class name. Multiple registrations can share the same key.
 
+An `InjectionToken` that implements `BindToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) can also be passed directly to `@register(...)` — it binds under the hood exactly like `bindTo(token)`, so `@register(LoggerToken)` and `@register(bindTo(LoggerToken))` are equivalent.
+
 > [!TIP]
 > Prefer `SingleToken<T>` over plain string literals as registration keys. Tokens are type-safe, rename-friendly, and prevent typos that only surface at runtime.
 

--- a/packages/ts-ioc-container/README.md
+++ b/packages/ts-ioc-container/README.md
@@ -2166,7 +2166,7 @@ Registration is provider factory which registers provider in container.
 
 Use `bindTo(key)` to register a provider under a specific key. By default the key is the class name. Multiple registrations can share the same key.
 
-An `InjectionToken` that implements `BindToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) can also be passed directly to `@register(...)` — it binds under the hood exactly like `bindTo(token)`, so `@register(LoggerToken)` and `@register(bindTo(LoggerToken))` are equivalent.
+A plain `DependencyKey` (`string` / `symbol`) or an `InjectionToken` that implements `BindToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) can also be passed directly to `@register(...)` — it binds under the hood exactly like `bindTo(...)`, so `@register('ILogger')` / `@register(LoggerToken)` and `@register(bindTo('ILogger'))` / `@register(bindTo(LoggerToken))` are equivalent.
 
 > [!TIP]
 > Prefer `SingleToken<T>` over plain string literals as registration keys. Tokens are type-safe, rename-friendly, and prevent typos that only surface at runtime.
@@ -2252,6 +2252,16 @@ describe('Registration module', function () {
     const appContainer = createAppContainer().addRegistration(R.fromClass(FileLogger));
 
     expect(LoggerToken.resolve(appContainer)).toBeInstanceOf(FileLogger);
+  });
+
+  it('should register directly from a plain key passed to @register, without wrapping it in bindTo()', function () {
+    // A plain DependencyKey straight in @register binds to it under the hood
+    @register('PlainLogger')
+    class Logger {}
+
+    const appContainer = createAppContainer().addRegistration(R.fromClass(Logger));
+
+    expect(appContainer.resolve('PlainLogger')).toBeInstanceOf(Logger);
   });
 
   it('should register with multiple keys using aliases', function () {

--- a/packages/ts-ioc-container/README.md
+++ b/packages/ts-ioc-container/README.md
@@ -2166,6 +2166,8 @@ Registration is provider factory which registers provider in container.
 
 Use `bindTo(key)` to register a provider under a specific key. By default the key is the class name. Multiple registrations can share the same key.
 
+An `InjectionToken` that implements `BindToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) can also be passed directly to `@register(...)` — it binds under the hood exactly like `bindTo(token)`, so `@register(LoggerToken)` and `@register(bindTo(LoggerToken))` are equivalent.
+
 > [!TIP]
 > Prefer `SingleToken<T>` over plain string literals as registration keys. Tokens are type-safe, rename-friendly, and prevent typos that only surface at runtime.
 
@@ -2178,6 +2180,7 @@ import {
   Registration as R,
   scope,
   select as s,
+  SingleToken,
   singleton,
 } from 'ts-ioc-container';
 
@@ -2237,6 +2240,18 @@ describe('Registration module', function () {
     const appContainer = createAppContainer().addRegistration(R.fromClass(FileLogger));
 
     expect(appContainer.resolve('FileLogger')).toBeInstanceOf(FileLogger);
+  });
+
+  it('should register directly from a token passed to @register, without wrapping it in bindTo()', function () {
+    // Passing an InjectionToken straight to @register binds to it under the hood
+    const LoggerToken = new SingleToken<FileLogger>('ILogger');
+
+    @register(LoggerToken, singleton())
+    class FileLogger {}
+
+    const appContainer = createAppContainer().addRegistration(R.fromClass(FileLogger));
+
+    expect(LoggerToken.resolve(appContainer)).toBeInstanceOf(FileLogger);
   });
 
   it('should register with multiple keys using aliases', function () {

--- a/packages/ts-ioc-container/__tests__/readme/registration.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/registration.spec.ts
@@ -6,6 +6,7 @@ import {
   Registration as R,
   scope,
   select as s,
+  SingleToken,
   singleton,
 } from '../../lib';
 
@@ -65,6 +66,18 @@ describe('Registration module', function () {
     const appContainer = createAppContainer().addRegistration(R.fromClass(FileLogger));
 
     expect(appContainer.resolve('FileLogger')).toBeInstanceOf(FileLogger);
+  });
+
+  it('should register directly from a token passed to @register, without wrapping it in bindTo()', function () {
+    // Passing an InjectionToken straight to @register binds to it under the hood
+    const LoggerToken = new SingleToken<FileLogger>('ILogger');
+
+    @register(LoggerToken, singleton())
+    class FileLogger {}
+
+    const appContainer = createAppContainer().addRegistration(R.fromClass(FileLogger));
+
+    expect(LoggerToken.resolve(appContainer)).toBeInstanceOf(FileLogger);
   });
 
   it('should register with multiple keys using aliases', function () {

--- a/packages/ts-ioc-container/__tests__/readme/registration.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/registration.spec.ts
@@ -80,6 +80,16 @@ describe('Registration module', function () {
     expect(LoggerToken.resolve(appContainer)).toBeInstanceOf(FileLogger);
   });
 
+  it('should register directly from a plain key passed to @register, without wrapping it in bindTo()', function () {
+    // A plain DependencyKey straight in @register binds to it under the hood
+    @register('PlainLogger')
+    class Logger {}
+
+    const appContainer = createAppContainer().addRegistration(R.fromClass(Logger));
+
+    expect(appContainer.resolve('PlainLogger')).toBeInstanceOf(Logger);
+  });
+
   it('should register with multiple keys using aliases', function () {
     // Same service accessible via direct key and alias
     @register(bindTo('ILogger'), bindTo(s.alias('Logger')), singleton())

--- a/packages/ts-ioc-container/__tests__/specs/dependency-registration.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/dependency-registration.spec.ts
@@ -78,6 +78,15 @@ describe('Spec: dependency registration', () => {
     expect(LoggerToken.resolve(container)).toBeInstanceOf(ConsoleLogger);
   });
 
+  it('binds directly to a plain DependencyKey passed to @register, without wrapping it in bindTo()', () => {
+    @register('PlainKeyLogger')
+    class ConsoleLogger {}
+
+    const container = new Container().addRegistration(R.fromClass(ConsoleLogger));
+
+    expect(container.resolve('PlainKeyLogger')).toBeInstanceOf(ConsoleLogger);
+  });
+
   it('applies decorator mappers and default class-name keys', () => {
     @register()
     class DefaultPlugin {

--- a/packages/ts-ioc-container/__tests__/specs/dependency-registration.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/dependency-registration.spec.ts
@@ -6,6 +6,7 @@ import {
   register,
   Registration as R,
   scope,
+  SingleToken,
   toGroupAlias,
   toSingleAlias,
 } from '../../lib';
@@ -56,6 +57,25 @@ describe('Spec: dependency registration', () => {
     expect(container.resolve<Notifier>('EmailNotifier').channel).toBe('email');
     expect(SingleNotifier.resolve(container).channel).toBe('email');
     expect(NotifierGroup.resolve(container).map((notifier) => notifier.channel)).toEqual(['email', 'sms']);
+  });
+
+  it('binds directly to an injection token passed to @register, without wrapping it in bindTo()', () => {
+    const LoggerToken = new SingleToken<Logger>('ILogger');
+
+    interface Logger {
+      log(msg: string): void;
+    }
+
+    @register(LoggerToken)
+    class ConsoleLogger implements Logger {
+      log(msg: string) {
+        return msg;
+      }
+    }
+
+    const container = new Container().addRegistration(R.fromClass(ConsoleLogger));
+
+    expect(LoggerToken.resolve(container)).toBeInstanceOf(ConsoleLogger);
   });
 
   it('applies decorator mappers and default class-name keys', () => {

--- a/packages/ts-ioc-container/lib/registration/IRegistration.ts
+++ b/packages/ts-ioc-container/lib/registration/IRegistration.ts
@@ -42,11 +42,13 @@ const METADATA_KEY = 'registration';
 export const getTransformers = (Target: constructor<unknown>) =>
   getClassMeta<MapFn<IRegistration>[]>(Target, METADATA_KEY) ?? [];
 
-export const register = (...mappers: Array<MapFn<IRegistration> | ProviderPipe>) =>
+export const register = (...mappers: Array<MapFn<IRegistration> | ProviderPipe | BindToken>) =>
   addClassMeta(METADATA_KEY, (acc: MapFn<IRegistration>[] | undefined) => {
-    const result = mappers.map((m) =>
-      isProviderPipe(m) ? (r: IRegistration) => m.mapRegistration(r) : m,
-    ) as MapFn<IRegistration>[];
+    const result = mappers.map((m) => {
+      if (isProviderPipe(m)) return (r: IRegistration) => m.mapRegistration(r);
+      if (isBindToken(m)) return bindTo(m);
+      return m;
+    }) as MapFn<IRegistration>[];
     return acc ? [...result, ...acc] : result;
   });
 

--- a/packages/ts-ioc-container/lib/registration/IRegistration.ts
+++ b/packages/ts-ioc-container/lib/registration/IRegistration.ts
@@ -1,4 +1,4 @@
-import type { DependencyKey, IContainer, IContainerModule } from '../container/IContainer';
+import { type DependencyKey, type IContainer, type IContainerModule, isDependencyKey } from '../container/IContainer';
 import type { ArgsFn, DecorateFn, GetCacheKey, IProvider, ScopeAccessRule } from '../provider/IProvider';
 import { SingleToken } from '../token/SingleToken';
 import { BindToken, isBindToken } from '../token/BindToken';
@@ -42,11 +42,11 @@ const METADATA_KEY = 'registration';
 export const getTransformers = (Target: constructor<unknown>) =>
   getClassMeta<MapFn<IRegistration>[]>(Target, METADATA_KEY) ?? [];
 
-export const register = (...mappers: Array<MapFn<IRegistration> | ProviderPipe | BindToken>) =>
+export const register = (...mappers: Array<MapFn<IRegistration> | ProviderPipe | BindToken | DependencyKey>) =>
   addClassMeta(METADATA_KEY, (acc: MapFn<IRegistration>[] | undefined) => {
     const result = mappers.map((m) => {
       if (isProviderPipe(m)) return (r: IRegistration) => m.mapRegistration(r);
-      if (isBindToken(m)) return bindTo(m);
+      if (isBindToken(m) || isDependencyKey(m)) return bindTo(m);
       return m;
     }) as MapFn<IRegistration>[];
     return acc ? [...result, ...acc] : result;


### PR DESCRIPTION
## Summary
- `@register(...)` now accepts a bindable `InjectionToken` (`SingleToken`, `SingleAliasToken`, `GroupAliasToken`) directly and binds it under the hood — `@register(LoggerToken)` is now equivalent to `@register(bindTo(LoggerToken))`.
- Existing `@register(bindTo(token))` usage is unaffected.

## Test plan
- [x] `pnpm test` (357 passing)
- [x] `pnpm run type-check`
- [x] `pnpm run lint:fix` (0 errors, only pre-existing warnings)
- [x] Added a failing-first regression test in `__tests__/specs/dependency-registration.spec.ts`
- [x] Added a README-visible example in `__tests__/readme/registration.spec.ts` and regenerated `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)