### PR TITLE
fix(@ts-ioc-container/react): drop hard dependency on ts-ioc-container

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -71,7 +71,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "reflect-metadata": "^0.2.2",
-    "ts-ioc-container": "56.0.0",
+    "ts-ioc-container": "56.1.1",
     "typescript": "5.8.3",
     "unplugin-swc": "^1.5.9",
     "vitest": "^4.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       ts-ioc-container:
-        specifier: 56.0.0
-        version: 56.0.0(reflect-metadata@0.2.2)
+        specifier: 56.1.1
+        version: 56.1.1(reflect-metadata@0.2.2)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -2508,6 +2508,15 @@ packages:
 
   ts-ioc-container@56.0.0:
     resolution: {integrity: sha512-yti2q7u22mSpTTp3AEaoBVHhO1WVNmoYThKpgIf5FrsNLTfoNyrx0d8EMdCcIPEIHYheNcnRNJm6BAliZGF8MQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      reflect-metadata: ^0.2.0
+    peerDependenciesMeta:
+      reflect-metadata:
+        optional: true
+
+  ts-ioc-container@56.1.1:
+    resolution: {integrity: sha512-Z6mpBf7Ps0I30tzvkG5Sl5S2woyPSF4Od5d2F4kyo0xq41NWyAl/eYB4q7L13EXF0xs6eHSWGZ7aEPKSyMVJLQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       reflect-metadata: ^0.2.0
@@ -4999,6 +5008,10 @@ snapshots:
       typescript: 5.8.3
 
   ts-ioc-container@56.0.0(reflect-metadata@0.2.2):
+    optionalDependencies:
+      reflect-metadata: 0.2.2
+
+  ts-ioc-container@56.1.1(reflect-metadata@0.2.2):
     optionalDependencies:
       reflect-metadata: 0.2.2
 


### PR DESCRIPTION
## Description

**The title is the deliverable here.** This PR exists to cut a release for
`@ts-ioc-container/react`, and under squash-merge the PR title becomes the
commit message on `main` — so it must stay exactly as it is, scoped to
`@ts-ioc-container/react`, or no release happens.

### Why this is needed

The fix itself is already on `main`. #127 removed the `dependencies` block that
the release pipeline had injected into `packages/react/package.json`, pinning
`ts-ioc-container` exactly on top of the `peerDependencies` range and
`devDependencies` pin that already declared it.

It never reached a release. #127 was **squashed**, so its five commits collapsed
into `35e63e3`, whose message is that PR's title — `refactor(ci): ...`. A
`refactor` triggers no release for any package, so the
`fix(@ts-ioc-container/react)` commit that would have cut one no longer exists
in `main`'s history. The release run that followed produced `a8f0051`, an empty
publish commit changing zero files, and both packages stayed where they were.

### What this changes

One real change: `packages/react`'s devDependency on `ts-ioc-container` goes
`56.0.0` → `56.1.1`, which is what that release would have refreshed. React's
tests resolve the container **from the registry, not the workspace** (see the
`importers` block in `pnpm-lock.yaml`), so the stale pin meant they were running
against a core two patch versions behind the released one. All 14 react tests
pass against `56.1.1`.

## Type of change

- [ ] `feat` — new feature (minor release)
- [x] `fix` / `perf` — bug fix or performance improvement (patch release) — `@ts-ioc-container/react` only
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`) — no library source changed; manifest and lockfile only
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed — untouched; the pre-commit hook re-ran generation and produced no diff
- [x] Tests added or updated under `__tests__/` to cover the change — n/a, dependency pin only
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm test` passes — 71 files, 359 tests
- [x] `pnpm run test:react` passes — 14 tests, against `ts-ioc-container@56.1.1`
- [x] `pnpm run type-check:react`, `lint:react`, `format:check` pass
- [x] `pnpm run verify:package-contents` passes for both packages — react packs 11 files with `cjm/`, `esm/`, `typings/` present
- [x] Commit message follows Conventional Commits with the correct release scope

## Merging

Squash-merge is fine, but **do not edit the title**. `release-monorepo-semantically`
matches a commit to a package by comparing the parenthetical scope against the
package `name` exactly, and it reads only the subject line — the bullet list of
original commits that GitHub puts in a squashed commit body is ignored, which is
precisely how #127's fix got lost.

## Known limitation

This release will **not** put `@ts-ioc-container/react` on npm. The package has
never been published, and OIDC cannot create a package that does not yet exist —
as `CLAUDE.md` records under "npm authentication (Trusted Publishing / OIDC)".
Expect the pipeline to bump the version, write the changelog, tag and create the
GitHub release, then fail at the npm publish step with `ENEEDAUTH` or a 404. The
first publish has to be done by hand; every release after that can go through
OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyvaeEpGZ7PTyN84AweDZX

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyvaeEpGZ7PTyN84AweDZX)_