### PR TITLE
feat(ts-ioc-container): tidy Container internals and drop duplicate Instance type

### DIFF
--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -111,7 +111,7 @@ export class Container implements IContainer {
   resolveOneByAlias<T>(alias: DependencyKey, { args = [], child = this, lazy }: ResolveOneOptions = {}): T {
     this.validateContainer();
 
-    const [key, ..._] = this.aliases.getKeysByAlias(alias);
+    const [key] = this.aliases.getKeysByAlias(alias);
     const provider = key ? this.findProviderByKeyOrFail<T>(key) : undefined;
 
     return provider?.hasAccess({ invocationScope: child, providerScope: this, args })
@@ -129,7 +129,7 @@ export class Container implements IContainer {
       .addOnConstructHook(...this.onConstructHookList)
       .addOnDisposeHook(...this.onDisposeHookList);
 
-    for (const registration of [...this.parent.getRegistrations(), ...this.registrations]) {
+    for (const registration of this.getRegistrations()) {
       registration.applyTo(scope);
     }
     this.scopes.push(scope);
@@ -155,7 +155,7 @@ export class Container implements IContainer {
     this.parent = new EmptyContainer();
 
     // Reset the state
-    for (const [_, provider] of this.providers) {
+    for (const provider of this.providers.values()) {
       provider.dispose();
     }
     this.providers.clear();
@@ -164,7 +164,7 @@ export class Container implements IContainer {
     this.registrations = [];
 
     // Clear hooks
-    this.onConstructHookList.splice(0, this.onConstructHookList.length);
+    this.onConstructHookList.length = 0;
   }
 
   addRegistration(registration: IRegistration): this {
@@ -192,7 +192,7 @@ export class Container implements IContainer {
   }
 
   addInstance(instance: Instance) {
-    this.instances.push(instance as Instance);
+    this.instances.push(instance);
 
     // Execute onConstruct hooks
     for (const onConstruct of this.onConstructHookList) {

--- a/packages/ts-ioc-container/lib/utils/basic.ts
+++ b/packages/ts-ioc-container/lib/utils/basic.ts
@@ -1,9 +1,5 @@
 export type constructor<T> = new (...args: any[]) => T;
 
-export interface InstanceOfClass<T = unknown> {
-  new (...args: unknown[]): T;
-}
-
 export interface Instance<T = unknown> {
   new (...args: unknown[]): T;
 }
@@ -11,7 +7,7 @@ export interface Instance<T = unknown> {
 export const Is = {
   nullish: <T>(value: T | undefined | null): value is null | undefined => value === undefined || value === null,
   object: (target: unknown): target is object => target !== null && typeof target === 'object',
-  instance: (target: unknown): target is InstanceOfClass => Object.prototype.hasOwnProperty.call(target, 'constructor'),
+  instance: (target: unknown): target is Instance => Object.prototype.hasOwnProperty.call(target, 'constructor'),
   constructor: (target: unknown): target is constructor<unknown> => typeof target === 'function' && !!target.prototype,
 };
 


### PR DESCRIPTION
## Description

A small housekeeping pass over the core `ts-ioc-container` package, deliberately scoped as a `feat` so it produces a minor release and exercises the newly configured npm Trusted Publishing (OIDC) pipeline end to end.

No behaviour changes — every item below is a redundancy or duplication removal:

**`packages/ts-ioc-container/lib/container/Container.ts`**
- `createScope` now reuses `this.getRegistrations()` instead of re-inlining the byte-identical `[...this.parent.getRegistrations(), ...this.registrations]` concatenation.
- `resolveOneByAlias` drops the unused `...rest` element from its array destructuring (`const [key, ..._]` → `const [key]`).
- `dispose` iterates `this.providers.values()` rather than destructuring throwaway `[_, provider]` map entries, and clears `onConstructHookList` with `length = 0` instead of a full-length `splice`.
- `addInstance` drops an `as Instance` cast on a parameter already typed `Instance`.

**`packages/ts-ioc-container/lib/utils/basic.ts`**
- Removed `InstanceOfClass`, a byte-for-byte duplicate of the `Instance` interface declared four lines below it; `Is.instance` now narrows to `Instance`.

`InstanceOfClass` was internal only — it is not re-exported from `lib/index.ts`, so the public API surface is unchanged.

## Type of change

- [x] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed — n/a, `.readme.hbs.md` untouched
- [x] Tests added or updated under `__tests__/` to cover the change — n/a, pure redundancy removal with no new behaviour to cover; existing suite exercises all touched paths
- [x] `pnpm run lint` passes — 0 errors (31 pre-existing `no-explicit-any` warnings, unchanged)
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes — 359 tests / 71 files, plus `@ts-ioc-container/react` 14 tests via `pnpm run test:all`
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

- The commit is scoped exactly `feat(ts-ioc-container)`, which `release-monorepo-semantically` matches against the package `name` — so merging this should cut a minor release for `ts-ioc-container` only, leaving `@ts-ioc-container/react` untouched.
- Worth calling out that the content here is cleanup rather than a user-facing feature; `feat` was chosen for its release-triggering effect, so the generated CHANGELOG entry will read as a feature. Retype it to `refactor` if you would rather the changelog stay accurate and verify OIDC some other way.
- `pnpm run build` was also run locally and produced CJS, ESM, and type output without errors.
- Per `CLAUDE.md`, check `packages/react/package.json` and `pnpm-lock.yaml` after the release lands — the known `release-monorepo-semantically` `package-json` step defects can dirty both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tSht5onZ6mfJU3dTEMpW6

---
_Generated by [Claude Code](https://claude.ai/code/session_012tSht5onZ6mfJU3dTEMpW6)_