### PR TITLE
ci(release): unblock the pipeline via the workspace protocol

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -58,6 +58,11 @@ jobs:
       - name: Test
         run: pnpm test --maxWorkers=2
 
+      # @ts-ioc-container/react resolves ts-ioc-container through the
+      # workspace link, so the checks below need its build output on disk.
+      - name: Build ts-ioc-container
+        run: pnpm run build
+
       - name: Lint @ts-ioc-container/react
         run: pnpm run lint:react
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,11 +47,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ./packages/ts-ioc-container/coverage/lcov.info
 
-      - name: Test @ts-ioc-container/react
-        run: pnpm run test:react
-
+      # Must precede the react tests: @ts-ioc-container/react resolves
+      # ts-ioc-container through the workspace link, so it imports that
+      # package's build output rather than a tarball from the registry.
       - name: Build
         run: pnpm run build:all
+
+      - name: Test @ts-ioc-container/react
+        run: pnpm run test:react
 
       - name: Upload build artifacts
         uses: ./.github/actions/build-artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,18 +99,44 @@ This is what a mid-pipeline `ENEEDAUTH` means: the packages ahead of it in
 trusted publisher yet — check the npm publish timestamps against the CI failure
 time before assuming the auth setup is broken.
 
+### Internal dependencies use the workspace protocol
+
+`@ts-ioc-container/react` declares `ts-ioc-container` as
+`"workspace:*"`, not as an exact registry version. This is load-bearing, not
+cosmetic:
+
+- An exact pin made the release **deadlock**. `package-json` rewrote the pin to
+  the version being released, then refreshed the lockfile with
+  `pnpm install --lockfile-only`, which resolves from the registry — but that
+  version is only published four steps later, by `package-manager publish`.
+  Every release died with `ERR_PNPM_NO_MATCHING_VERSION` before reaching `vcs`.
+  Fixed upstream in `release-monorepo-semantically@1.9.4`, which never rewrites
+  a `workspace:` specifier
+  ([#8](https://github.com/IgorBabkin/release-monorepo-semantically/issues/8)).
+  Do not pin it back, and do not downgrade below 1.9.4.
+- It also keeps the react tests honest. With a registry pin they ran against a
+  *published* copy of the container, so they never exercised the change in the
+  same commit — and the pin silently drifted behind.
+
+`pnpm publish` substitutes the real version into the published tarball, so
+consumers still receive an exact version. `peerDependencies` stays a range
+(`>=56`) and is never rewritten.
+
+**Consequence for CI ordering:** react resolves the container through the
+workspace link, so it imports that package's *build output*. `pnpm run build`
+must therefore run before any react lint / type-check / test step — see the
+build steps in `pr-checks.yml` and `publish.yml`. Without it those steps fail
+to resolve `ts-ioc-container` at all.
+
 ### Known `release-monorepo-semantically` defects
 
-The `package-json` step writes internal dependency versions into a
-**`dependencies`** block, even when the package already declares that
-dependency as a `peerDependency`. For `@ts-ioc-container/react` that produced a
-`dependencies` entry pinning `ts-ioc-container` exactly, alongside the
-`peerDependencies` range and a *different* `devDependencies` pin — which would
-ship consumers a second copy of the container and break instance identity.
-It also does not refresh `pnpm-lock.yaml` after rewriting those versions, so
-the next `pnpm install --frozen-lockfile` on `main` fails with
-`ERR_PNPM_OUTDATED_LOCKFILE`. Check `packages/react/package.json` after a
-release until this is fixed upstream.
+The `package-json` step used to write internal dependency versions into a
+**`dependencies`** block even when the package already declared that dependency
+as a `peerDependency`, and did not refresh `pnpm-lock.yaml` afterwards. Both
+were fixed in 1.9.3; the workspace-protocol deadlock above was fixed in 1.9.4.
+No known outstanding defects — but the `package-json` step rewrites manifests,
+so it is still worth a glance at `packages/react/package.json` and
+`pnpm-lock.yaml` after a release.
 
 The release commit template lives at
 `packages/scripts/release/templates/release-commit-msg.hbs` — it overrides the tool's

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "3.5.3",
-    "release-monorepo-semantically": "1.9.3",
+    "release-monorepo-semantically": "1.9.4",
     "tsx": "^4.21.0",
     "typescript": "5.8.3"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -71,7 +71,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "reflect-metadata": "^0.2.2",
-    "ts-ioc-container": "56.1.1",
+    "ts-ioc-container": "workspace:*",
     "typescript": "5.8.3",
     "unplugin-swc": "^1.5.9",
     "vitest": "^4.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: 3.5.3
         version: 3.5.3
       release-monorepo-semantically:
-        specifier: 1.9.3
-        version: 1.9.3
+        specifier: 1.9.4
+        version: 1.9.4
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -84,8 +84,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       ts-ioc-container:
-        specifier: 56.1.1
-        version: 56.1.1(reflect-metadata@0.2.2)
+        specifier: workspace:*
+        version: link:../ts-ioc-container
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -2270,8 +2270,8 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
-  release-monorepo-semantically@1.9.3:
-    resolution: {integrity: sha512-GN4FotN5oLHOJ93afec+YTpVEgfxbqIyHJLNopxSrNQFs0pKlKsrvGZAZhVkq9DDlcKf7MVwBrgfzqx1sc2LMA==}
+  release-monorepo-semantically@1.9.4:
+    resolution: {integrity: sha512-7MtechGk9ymH20Njry3eF1PijWW4KJuKYLi7Up9LSNFGVpG5Zd1xM463JnAut4RfHkcCcrsaDoGAHlumlU8zgg==}
     engines: {node: '>=20.11'}
     hasBin: true
 
@@ -2508,15 +2508,6 @@ packages:
 
   ts-ioc-container@56.0.0:
     resolution: {integrity: sha512-yti2q7u22mSpTTp3AEaoBVHhO1WVNmoYThKpgIf5FrsNLTfoNyrx0d8EMdCcIPEIHYheNcnRNJm6BAliZGF8MQ==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      reflect-metadata: ^0.2.0
-    peerDependenciesMeta:
-      reflect-metadata:
-        optional: true
-
-  ts-ioc-container@56.1.1:
-    resolution: {integrity: sha512-Z6mpBf7Ps0I30tzvkG5Sl5S2woyPSF4Od5d2F4kyo0xq41NWyAl/eYB4q7L13EXF0xs6eHSWGZ7aEPKSyMVJLQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       reflect-metadata: ^0.2.0
@@ -4770,7 +4761,7 @@ snapshots:
 
   reflect-metadata@0.2.2: {}
 
-  release-monorepo-semantically@1.9.3:
+  release-monorepo-semantically@1.9.4:
     dependencies:
       commander: 14.0.3
       glob: 10.5.0
@@ -5008,10 +4999,6 @@ snapshots:
       typescript: 5.8.3
 
   ts-ioc-container@56.0.0(reflect-metadata@0.2.2):
-    optionalDependencies:
-      reflect-metadata: 0.2.2
-
-  ts-ioc-container@56.1.1(reflect-metadata@0.2.2):
     optionalDependencies:
       reflect-metadata: 0.2.2
 


### PR DESCRIPTION
## Description

Unblocks the release pipeline, which has failed on every attempt since the monorepo split, so that a release can actually reach npm and exercise the newly configured Trusted Publishing (OIDC) setup.

The `package-json` step rewrote react's exact `ts-ioc-container` pin to the version being released, then refreshed the lockfile with `pnpm install --lockfile-only` — which resolves from the registry, while that version is only published four steps later by `package-manager publish`. Every run died with `ERR_PNPM_NO_MATCHING_VERSION` before reaching `vcs`, so nothing was ever committed, tagged or published. See [run 33977849842](https://github.com/IgorBabkin/ts-ioc-container/actions/runs/33977849842/job/101337726960).

Fixed upstream in `release-monorepo-semantically@1.9.4`, which never rewrites a `workspace:` specifier — [issue #8](https://github.com/IgorBabkin/release-monorepo-semantically/issues/8), [PR #9](https://github.com/IgorBabkin/release-monorepo-semantically/pull/9). This picks up that release and adopts the shape it expects:

- `release-monorepo-semantically` 1.9.3 → **1.9.4**
- `packages/react/package.json`: `devDependencies.ts-ioc-container` `56.1.1` → **`workspace:*`**
- `pnpm-lock.yaml`: react's entry becomes `link:../ts-ioc-container`; the now-unused registry copy of `ts-ioc-container@56.1.1` drops out
- `pr-checks.yml` / `publish.yml`: `build` now runs **before** the react steps
- `CLAUDE.md`: documents why the workspace protocol is load-bearing, and retires the resolved defect notes

### Why the CI reordering is required

The workspace link means react imports the container's **build output** rather than a registry tarball, so `cjm/`, `esm/` and `typings/` must exist before any react step runs. `pr-checks.yml` had no build step at all; `publish.yml` had one, but *after* the react tests.

### Secondary benefit

The exact pin also meant react's tests resolved a *published* copy of the container, so they never exercised the change in the same commit — and the pin had silently drifted two patch versions behind (noted previously in #128). They now run against workspace code.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [x] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

Scoped `ci(release)` deliberately: no library code changes here. A release still happens on merge — `feat(ts-ioc-container)` `637fda1` sits after the last tag (`ts-ioc-container@56.1.1`) and was never published, so `report` will cut **56.2.0** from it.

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`) — n/a, no library source touched
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed — n/a, `.readme.hbs.md` untouched
- [x] Tests added or updated under `__tests__/` to cover the change — n/a, tooling and CI config only; the upstream fix carries its own unit and e2e specs
- [x] `pnpm run lint` passes — 0 errors (31 pre-existing `no-explicit-any` warnings, unchanged)
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes — 359 tests / 71 files; `test:react` 14 tests, now against workspace code
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

Verification of the CI ordering was not by inspection — I deleted `cjm/`, `esm/` and `typings/` and replayed both workflows step by step. The react steps fail to resolve `ts-ioc-container` at all without the build, and pass with it. The full `pr-checks` sequence was run from that clean state in the new order.

The step that used to deadlock was also run directly against 1.9.4 with a release context: exit 0, nothing rewritten, `workspace:*` intact.

Expect `@ts-ioc-container/react` to fail its publish with a 404 / `ENEEDAUTH` after the core package succeeds — it has never been published, and OIDC cannot create a package that does not yet exist, as `CLAUDE.md` records. The ordering favours us: `ts-ioc-container` publishes first, so OIDC gets its verification before react trips. That first react publish still needs to be done by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tSht5onZ6mfJU3dTEMpW6

---
_Generated by [Claude Code](https://claude.ai/code/session_012tSht5onZ6mfJU3dTEMpW6)_