### PR TITLE
ci(release): pass GITHUB_TOKEN to the release-notes step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,7 +135,9 @@ jobs:
       - name: Create GitHub releases
         run: pnpm exec monorepo-semantic-release release-notes --context "$RELEASE_CONTEXT"
         env:
-          GH_TOKEN: ${{ github.token }}
+          # The step reads GITHUB_TOKEN, not GH_TOKEN — it sets GH_TOKEN itself
+          # when it shells out to `gh`. GITHUB_REPOSITORY is provided by Actions.
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Publish to GitHub Packages
         # Publish to GitHub Packages so it shows up in the Packages section

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,21 @@ This is what a mid-pipeline `ENEEDAUTH` means: the packages ahead of it in
 trusted publisher yet — check the npm publish timestamps against the CI failure
 time before assuming the auth setup is broken.
 
+**Status: verified end to end.** Run
+[238](https://github.com/IgorBabkin/ts-ioc-container/actions/runs/33983268562)
+published `ts-ioc-container@56.2.0` and `@ts-ioc-container/react@0.6.0` through
+OIDC with no token in CI. Both packages already existed on npm (react's `0.5.0`
+predates the trusted publisher), so both had a publisher configured and neither
+hit the first-publish restriction above. That restriction still applies to any
+*new* package added to this workspace.
+
+The chain that makes OIDC work here is not obvious, so don't "simplify" it:
+`package-manager publish` runs `pnpm publish`, and **pnpm has no OIDC support of
+its own** — it shells out to the `npm` binary on `PATH`, which is what performs
+the token exchange. That is why the `npm install -g npm@11` step exists and why
+it must stay ahead of the publish step; without it the runner's older npm would
+publish without OIDC.
+
 ### Internal dependencies use the workspace protocol
 
 `@ts-ioc-container/react` declares `ts-ioc-container` as


### PR DESCRIPTION
## Description

**OIDC is verified.** [Run 238](https://github.com/IgorBabkin/ts-ioc-container/actions/runs/33983268562) got the whole pipeline through for the first time and published both packages with no npm token in CI:

```
[package-manager] PUBLISH  ts-ioc-container@56.2.0
[package-manager] PUBLISH  @ts-ioc-container/react@0.6.0
```

Both are live on npm (`56.2.0`, `0.6.0`), the release commit `ddc9d5b` and both tags are pushed, and `pnpm install --frozen-lockfile` on `main` is clean.

The run still ended red, on the very last step:

```
[MISSING_GITHUB_CREDENTIALS] GitHub releases need a repository and token:
set release.release-notes.repository/token, or the GITHUB_REPOSITORY/GITHUB_TOKEN
environment variables
```

`release-notes` reads `process.env.GITHUB_TOKEN` (`ReleaseNotesController.ts:85`), but the workflow was setting `GH_TOKEN`. `GH_TOKEN` is what the tool sets *itself* when it shells out to `gh` (`GithubService.ts:32`) — not what it reads from the environment. The other half it needs, `GITHUB_REPOSITORY`, is provided by Actions.

One-line fix, plus a comment so it doesn't get "simplified" back.

Also updates `CLAUDE.md` to record two things worth not rediscovering:

- OIDC is verified end to end. Both packages already existed on npm (react's `0.5.0` predates the trusted publisher), so neither hit the first-publish restriction — which still applies to any *new* package added here.
- Why `npm install -g npm@11` is load-bearing: `pnpm publish` has **no OIDC support of its own** and shells out to the `npm` binary on `PATH` to perform the token exchange. Without that upgrade the runner's older npm would publish without OIDC.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [x] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`) — n/a, no library source touched
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed — n/a, `.readme.hbs.md` untouched
- [x] Tests added or updated under `__tests__/` to cover the change — n/a, workflow config and docs only
- [x] `pnpm run lint` passes — unaffected by this change; no source touched
- [x] `pnpm run type-check` passes — unaffected by this change; no source touched
- [x] `pnpm test` passes — unaffected by this change; no source touched
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

`publish.yml` was parsed to confirm it is still valid YAML. The failing step cannot be exercised locally — it needs an Actions-issued token — so the evidence here is the env var the tool reads versus the one the workflow set.

Nothing needs re-releasing: publishing, tagging and the release commit all completed. The only casualty is that **56.2.0 and react 0.6.0 have no GitHub Release entries**. This fix applies to future releases; say the word if you want me to create those two retroactively.

Branch note: `claude/npm-oidc-publishing-ozqucz` was restarted from `main` after #130 was squash-merged, so this force-updates it. The old head `e8386c9` carried nothing `main` lacks — verified by diff before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tSht5onZ6mfJU3dTEMpW6

---
_Generated by [Claude Code](https://claude.ai/code/session_012tSht5onZ6mfJU3dTEMpW6)_