### PR TITLE
ci(release): drop the GitHub Packages publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,11 +138,3 @@ jobs:
           # The step reads GITHUB_TOKEN, not GH_TOKEN — it sets GH_TOKEN itself
           # when it shells out to `gh`. GITHUB_REPOSITORY is provided by Actions.
           GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Publish to GitHub Packages
-        # Publish to GitHub Packages so it shows up in the Packages section
-        continue-on-error: true
-        uses: ./.github/actions/publish-to-github-packages
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: ts-ioc-container


### PR DESCRIPTION
## Description

Removes the `Publish to GitHub Packages` step from `publish.yml`. It has been failing on every run it reached, silently, because it sits behind `continue-on-error: true` — visible in [run 239](https://github.com/IgorBabkin/ts-ioc-container/actions/runs/33983597622/job/101353175529):

```
Publishing version undefined to GitHub Packages...
npm error Cannot read properties of null (reading 'prerelease')
```

`publish.sh:16` reads the version from the repository root:

```bash
PACKAGE_VERSION=$(node -p "require('./package.json').version")
```

But the root manifest is the private workspace shell — `name: root`, `private: true`, **no `version` field**. Confirmed locally:

```
$ node -p "require('./package.json').version"
undefined
```

So the version was `undefined`, and the `npm publish` that followed was trying to publish that private shell rather than the library. `undefined` doesn't parse as semver, which is where the `prerelease` error comes from. It broke when the library moved to `packages/ts-ioc-container` and the script stayed pointed at the root.

Dropping the step rather than repointing it: it existed only so the package shows up in the repository's Packages tab, npm is the registry consumers actually use, and nobody noticed its absence in the months it was broken.

The composite action under `.github/actions/publish-to-github-packages/` is left in place, unused, along with the `packages: write` permission it needed — happy to remove either or both in a follow-up if you'd rather not keep dead weight.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [x] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`) — n/a, no library source touched
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed — n/a, `.readme.hbs.md` untouched
- [x] Tests added or updated under `__tests__/` to cover the change — n/a, workflow config only
- [x] `pnpm run lint` passes — unaffected; no source touched
- [x] `pnpm run type-check` passes — unaffected; no source touched
- [x] `pnpm test` passes — unaffected; no source touched
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

`publish.yml` was parsed after the edit to confirm it is still valid YAML and that the `release` job now ends on `Create GitHub releases`. The diff is a pure deletion of 8 lines in one file.

Run 239 was green overall despite this failure — `continue-on-error` swallowed it — so removing the step changes no run outcome, it just stops burning a step on something that cannot succeed.

Still outstanding, unrelated to this PR: **56.2.0 and `@ts-ioc-container/react` 0.6.0 have no GitHub Release entries**, because run 238 hit the `GH_TOKEN`/`GITHUB_TOKEN` mismatch fixed in #131. That fix applies from the next release onward; those two can be created retroactively on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tSht5onZ6mfJU3dTEMpW6

---
_Generated by [Claude Code](https://claude.ai/code/session_012tSht5onZ6mfJU3dTEMpW6)_