### PR TITLE
feat(ts-ioc-container): support mapper pipes in @inject and injectProp

### DIFF
--- a/packages/ts-ioc-container/.readme.hbs.md
+++ b/packages/ts-ioc-container/.readme.hbs.md
@@ -38,6 +38,7 @@ provider pipelines, aliases, and custom injector strategies.
   - [Lazy with registerPipe](#lazy-with-registerpipe) `lazy()`
 - [Injector](#injector)
   - [Metadata](#metadata) `@inject`
+  - [Mapping injected values](#mapping-injected-values)
   - [Simple](#simple)
   - [Proxy](#proxy)
 - [Provider](#provider) `provider`
@@ -125,7 +126,8 @@ bundlers tree-shake unused exports.
 - Current scope token: `select.scope.current`
 - Lazy token: `select.token('Service').lazy()`
 - Inject decorator: `@inject('Key')`
-- Property inject: `injectProp(target, 'propName', select.token('Key'))`
+- Map an injected value: `@inject('Key', sanitize(), validate())`
+- Property inject: `@hook('onInit', append(injectProp('Key')))`
 
 > [!TIP]
 > For classes, prefer the `@register(bindTo('Key'))` decorator over the fluent
@@ -241,6 +243,27 @@ Also you can [inject property.](#inject-property)
 
 ```typescript
 {{{include_file './__tests__/readme/metadataInjector.spec.ts'}}}
+```
+
+### Mapping injected values
+
+Every argument after the first one is a **mapper** applied to the resolved
+instance, left to right — the value the last mapper returns is what reaches the
+constructor parameter:
+
+```typescript
+@inject('Config', takeApiUrl(), stripTrailingSlash(), requireHttps())
+```
+
+A mapper is a plain `(value) => value` function, so mappers compose into named,
+reusable steps (selecting a member, sanitizing, validating) and each step's
+parameter type is inferred from the previous one. With no mapper the resolved
+instance is injected untouched.
+
+`injectProp` takes the same rest parameters: `injectProp('Config', takeApiUrl())`.
+
+```typescript
+{{{include_file './__tests__/readme/injectMappers.spec.ts'}}}
 ```
 
 ### Simple

--- a/packages/ts-ioc-container/README.md
+++ b/packages/ts-ioc-container/README.md
@@ -38,6 +38,7 @@ provider pipelines, aliases, and custom injector strategies.
   - [Lazy with registerPipe](#lazy-with-registerpipe) `lazy()`
 - [Injector](#injector)
   - [Metadata](#metadata) `@inject`
+  - [Mapping injected values](#mapping-injected-values)
   - [Simple](#simple)
   - [Proxy](#proxy)
 - [Provider](#provider) `provider`
@@ -157,7 +158,8 @@ describe('Quickstart', function () {
 - Current scope token: `select.scope.current`
 - Lazy token: `select.token('Service').lazy()`
 - Inject decorator: `@inject('Key')`
-- Property inject: `injectProp(target, 'propName', select.token('Key'))`
+- Map an injected value: `@inject('Key', sanitize(), validate())`
+- Property inject: `@hook('onInit', append(injectProp('Key')))`
 
 > [!TIP]
 > For classes, prefer the `@register(bindTo('Key'))` decorator over the fluent
@@ -1182,6 +1184,78 @@ describe('Metadata Injector', function () {
     const app = container.resolve(App);
 
     expect(app.getLoggerName()).toBe('Logger');
+  });
+});
+
+```
+
+### Mapping injected values
+
+Every argument after the first one is a **mapper** applied to the resolved
+instance, left to right — the value the last mapper returns is what reaches the
+constructor parameter:
+
+```typescript
+@inject('Config', takeApiUrl(), stripTrailingSlash(), requireHttps())
+```
+
+A mapper is a plain `(value) => value` function, so mappers compose into named,
+reusable steps (selecting a member, sanitizing, validating) and each step's
+parameter type is inferred from the previous one. With no mapper the resolved
+instance is injected untouched.
+
+`injectProp` takes the same rest parameters: `injectProp('Config', takeApiUrl())`.
+
+```typescript
+import 'reflect-metadata';
+import { Container, inject, Registration as R } from 'ts-ioc-container';
+
+/**
+ * Mapping injected values
+ *
+ * Every argument after the first one passed to `@inject` (or `injectProp`) is a
+ * mapper applied to the resolved instance, left to right. Mappers are plain
+ * functions, so they compose into reusable, named steps.
+ */
+
+interface Config {
+  apiUrl: string;
+  retries: number;
+}
+
+// Reusable mappers, each returning a `(value) => value` function
+const takeApiUrl = () => (config: Config) => config.apiUrl;
+const stripTrailingSlash = () => (url: string) => url.replace(/\/$/, '');
+const requireHttps = () => (url: string) => {
+  if (!url.startsWith('https://')) {
+    throw new Error(`Insecure api url: ${url}`);
+  }
+  return url;
+};
+
+describe('inject mappers', () => {
+  it('should pipe the resolved dependency through every mapper', () => {
+    class ApiClient {
+      constructor(@inject('Config', takeApiUrl(), stripTrailingSlash(), requireHttps()) readonly apiUrl: string) {}
+    }
+
+    const container = new Container().addRegistration(
+      R.fromValue<Config>({ apiUrl: 'https://api.com/', retries: 3 }).bindToKey('Config'),
+    );
+
+    expect(container.resolve(ApiClient).apiUrl).toBe('https://api.com');
+  });
+
+  it('should throw from a mapper when the resolved value is not acceptable', () => {
+    class ApiClient {
+      constructor(@inject('Config', takeApiUrl(), requireHttps()) readonly apiUrl: string) {}
+    }
+
+    const container = new Container().addRegistration(
+      R.fromValue<Config>({ apiUrl: 'http://api.com', retries: 3 }).bindToKey('Config'),
+    );
+
+    expect(() => container.resolve(ApiClient)).toThrow('Insecure api url: http://api.com');
   });
 });
 

--- a/packages/ts-ioc-container/__tests__/hooks/injectProp.spec.ts
+++ b/packages/ts-ioc-container/__tests__/hooks/injectProp.spec.ts
@@ -1,0 +1,65 @@
+import 'reflect-metadata';
+import { append, Container, hook, HooksRunner, injectProp, Registration as R } from '../../lib';
+
+describe('injectProp(token, ...mappers)', () => {
+  function createViewModel<T extends object>(Target: new () => T, container: Container) {
+    const runner = new HooksRunner('onInit');
+    const instance = container.resolve(Target);
+    runner.execute(instance, { scope: container });
+    return instance;
+  }
+
+  it('assigns the whole dependency when no mapper is given', () => {
+    class ViewModel {
+      @hook('onInit', append(injectProp('Greeting')))
+      greeting!: string;
+    }
+
+    const container = new Container().addRegistration(R.fromValue('hello').bindToKey('Greeting'));
+
+    expect(createViewModel(ViewModel, container).greeting).toBe('hello');
+  });
+
+  it('pipes the resolved dependency through every mapper, left to right', () => {
+    const trim = () => (value: string) => value.trim();
+    const upper = () => (value: string) => value.toUpperCase();
+    const exclaim = () => (value: string) => `${value}!`;
+
+    class ViewModel {
+      @hook('onInit', append(injectProp('Greeting', trim(), upper(), exclaim())))
+      greeting!: string;
+    }
+
+    const container = new Container().addRegistration(R.fromValue('  hello  ').bindToKey('Greeting'));
+
+    expect(createViewModel(ViewModel, container).greeting).toBe('HELLO!');
+  });
+
+  it('accepts a spread list of mappers', () => {
+    const mappers = [(value: string) => `${value}-a`, (value: string) => `${value}-b`];
+
+    class ViewModel {
+      @hook('onInit', append(injectProp('Greeting', ...mappers)))
+      greeting!: string;
+    }
+
+    const container = new Container().addRegistration(R.fromValue('hello').bindToKey('Greeting'));
+
+    expect(createViewModel(ViewModel, container).greeting).toBe('hello-a-b');
+  });
+
+  it('maps a class dependency down to one of its members', () => {
+    class Config {
+      readonly apiUrl = 'https://api.com';
+    }
+
+    class ViewModel {
+      @hook('onInit', append(injectProp(Config, (config) => config.apiUrl)))
+      apiUrl!: string;
+    }
+
+    const container = new Container().addRegistration(R.fromClass(Config));
+
+    expect(createViewModel(ViewModel, container).apiUrl).toBe('https://api.com');
+  });
+});

--- a/packages/ts-ioc-container/__tests__/injector/inject.spec.ts
+++ b/packages/ts-ioc-container/__tests__/injector/inject.spec.ts
@@ -152,6 +152,23 @@ describe('inject helpers', () => {
       expect(container.resolve<Service>('Service').greeting).toBe('hello-a-b');
     });
 
+    it('keeps the chain typed across ten mappers', () => {
+      const step = (n: number) => (value: string) => `${value}-${n}`;
+
+      class Service {
+        constructor(
+          @inject('Greeting', step(1), step(2), step(3), step(4), step(5), step(6), step(7), step(8), step(9), step(10))
+          public greeting: string,
+        ) {}
+      }
+
+      const container = createContainer()
+        .addRegistration(R.fromValue('hello').bindToKey('Greeting'))
+        .addRegistration(R.fromClass(Service));
+
+      expect(container.resolve<Service>('Service').greeting).toBe('hello-1-2-3-4-5-6-7-8-9-10');
+    });
+
     it('runs the mappers on every resolution', () => {
       let calls = 0;
       const count = () => (value: string) => {

--- a/packages/ts-ioc-container/__tests__/injector/inject.spec.ts
+++ b/packages/ts-ioc-container/__tests__/injector/inject.spec.ts
@@ -59,7 +59,7 @@ describe('inject helpers', () => {
     });
   });
 
-  describe('inject(token, selectFn)', () => {
+  describe('inject(token, ...mappers)', () => {
     it('injects the selected part of the resolved dependency', () => {
       class Config {
         constructor(readonly apiUrl: string = 'https://api.com') {}
@@ -120,6 +120,55 @@ describe('inject helpers', () => {
 
       const container = createContainer().addRegistration(R.fromClass(Service));
       expect(container.resolve<Service>('Service').id).toBe(42);
+    });
+
+    it('pipes the resolved dependency through every mapper, left to right', () => {
+      const trim = () => (value: string) => value.trim();
+      const upper = () => (value: string) => value.toUpperCase();
+      const exclaim = () => (value: string) => `${value}!`;
+
+      class Service {
+        constructor(@inject('Greeting', trim(), upper(), exclaim()) public greeting: string) {}
+      }
+
+      const container = createContainer()
+        .addRegistration(R.fromValue('  hello  ').bindToKey('Greeting'))
+        .addRegistration(R.fromClass(Service));
+
+      expect(container.resolve<Service>('Service').greeting).toBe('HELLO!');
+    });
+
+    it('accepts a spread list of mappers', () => {
+      const mappers = [(value: string) => `${value}-a`, (value: string) => `${value}-b`];
+
+      class Service {
+        constructor(@inject('Greeting', ...mappers) public greeting: string) {}
+      }
+
+      const container = createContainer()
+        .addRegistration(R.fromValue('hello').bindToKey('Greeting'))
+        .addRegistration(R.fromClass(Service));
+
+      expect(container.resolve<Service>('Service').greeting).toBe('hello-a-b');
+    });
+
+    it('runs the mappers on every resolution', () => {
+      let calls = 0;
+      const count = () => (value: string) => {
+        calls += 1;
+        return `${value}-${calls}`;
+      };
+
+      class Service {
+        constructor(@inject('Greeting', count()) public greeting: string) {}
+      }
+
+      const container = createContainer()
+        .addRegistration(R.fromValue('hello').bindToKey('Greeting'))
+        .addRegistration(R.fromClass(Service));
+
+      expect(container.resolve<Service>('Service').greeting).toBe('hello-1');
+      expect(container.resolve<Service>('Service').greeting).toBe('hello-2');
     });
   });
 

--- a/packages/ts-ioc-container/__tests__/readme/injectMappers.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/injectMappers.spec.ts
@@ -1,0 +1,51 @@
+import 'reflect-metadata';
+import { Container, inject, Registration as R } from '../../lib';
+
+/**
+ * Mapping injected values
+ *
+ * Every argument after the first one passed to `@inject` (or `injectProp`) is a
+ * mapper applied to the resolved instance, left to right. Mappers are plain
+ * functions, so they compose into reusable, named steps.
+ */
+
+interface Config {
+  apiUrl: string;
+  retries: number;
+}
+
+// Reusable mappers, each returning a `(value) => value` function
+const takeApiUrl = () => (config: Config) => config.apiUrl;
+const stripTrailingSlash = () => (url: string) => url.replace(/\/$/, '');
+const requireHttps = () => (url: string) => {
+  if (!url.startsWith('https://')) {
+    throw new Error(`Insecure api url: ${url}`);
+  }
+  return url;
+};
+
+describe('inject mappers', () => {
+  it('should pipe the resolved dependency through every mapper', () => {
+    class ApiClient {
+      constructor(@inject('Config', takeApiUrl(), stripTrailingSlash(), requireHttps()) readonly apiUrl: string) {}
+    }
+
+    const container = new Container().addRegistration(
+      R.fromValue<Config>({ apiUrl: 'https://api.com/', retries: 3 }).bindToKey('Config'),
+    );
+
+    expect(container.resolve(ApiClient).apiUrl).toBe('https://api.com');
+  });
+
+  it('should throw from a mapper when the resolved value is not acceptable', () => {
+    class ApiClient {
+      constructor(@inject('Config', takeApiUrl(), requireHttps()) readonly apiUrl: string) {}
+    }
+
+    const container = new Container().addRegistration(
+      R.fromValue<Config>({ apiUrl: 'http://api.com', retries: 3 }).bindToKey('Config'),
+    );
+
+    expect(() => container.resolve(ApiClient)).toThrow('Insecure api url: http://api.com');
+  });
+});

--- a/packages/ts-ioc-container/lib/hooks/injectProp.ts
+++ b/packages/ts-ioc-container/lib/hooks/injectProp.ts
@@ -1,10 +1,36 @@
-import { DependencyKey } from '../container/IContainer';
-import { HookFn, InjectFn } from './hook';
-import { InjectionToken } from '../token/InjectionToken';
-import { toToken } from '../token/toToken';
-import { type constructor } from '../utils/basic';
+import { HookFn } from './hook';
+import { type Injectable, toMappedToken } from '../token/toToken';
+import { type MapFn } from '../utils/fp';
 
-export const injectProp =
-  (fn: InjectFn | InjectionToken | DependencyKey | constructor<unknown>): HookFn =>
-  (context) =>
-    context.setProperty(toToken(fn));
+/**
+ * Injects a dependency into the decorated property.
+ *
+ * Every argument after the first is a mapper applied to the resolved instance, left to right —
+ * `injectProp('key', sanitize(), validate())` passes the resolved instance through `sanitize()`,
+ * then through `validate()`, and assigns the result.
+ */
+export function injectProp<T>(fn: Injectable<T>): HookFn;
+export function injectProp<T, B>(fn: Injectable<T>, fn1: MapFn<T, B>): HookFn;
+export function injectProp<T, B, C>(fn: Injectable<T>, fn1: MapFn<T, B>, fn2: MapFn<B, C>): HookFn;
+export function injectProp<T, B, C, D>(fn: Injectable<T>, fn1: MapFn<T, B>, fn2: MapFn<B, C>, fn3: MapFn<C, D>): HookFn;
+export function injectProp<T, B, C, D, E>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+): HookFn;
+export function injectProp<T, B, C, D, E, F>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+): HookFn;
+// Fallback for spreads or variable length chains (same type)
+export function injectProp<T>(fn: Injectable<T>, ...mappers: MapFn<T>[]): HookFn;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function injectProp<T>(fn: Injectable<T>, ...mappers: MapFn<any, any>[]): HookFn {
+  return (context) => context.setProperty(toMappedToken(fn, mappers));
+}

--- a/packages/ts-ioc-container/lib/hooks/injectProp.ts
+++ b/packages/ts-ioc-container/lib/hooks/injectProp.ts
@@ -9,7 +9,6 @@ import { type MapFn } from '../utils/fp';
  * `injectProp('key', sanitize(), validate())` passes the resolved instance through `sanitize()`,
  * then through `validate()`, and assigns the result.
  */
-export function injectProp<T>(fn: Injectable<T>): HookFn;
 export function injectProp<T, B>(fn: Injectable<T>, fn1: MapFn<T, B>): HookFn;
 export function injectProp<T, B, C>(fn: Injectable<T>, fn1: MapFn<T, B>, fn2: MapFn<B, C>): HookFn;
 export function injectProp<T, B, C, D>(fn: Injectable<T>, fn1: MapFn<T, B>, fn2: MapFn<B, C>, fn3: MapFn<C, D>): HookFn;
@@ -27,6 +26,61 @@ export function injectProp<T, B, C, D, E, F>(
   fn3: MapFn<C, D>,
   fn4: MapFn<D, E>,
   fn5: MapFn<E, F>,
+): HookFn;
+export function injectProp<T, B, C, D, E, F, G>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+): HookFn;
+export function injectProp<T, B, C, D, E, F, G, H>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+  fn7: MapFn<G, H>,
+): HookFn;
+export function injectProp<T, B, C, D, E, F, G, H, I>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+  fn7: MapFn<G, H>,
+  fn8: MapFn<H, I>,
+): HookFn;
+export function injectProp<T, B, C, D, E, F, G, H, I, J>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+  fn7: MapFn<G, H>,
+  fn8: MapFn<H, I>,
+  fn9: MapFn<I, J>,
+): HookFn;
+export function injectProp<T, B, C, D, E, F, G, H, I, J, K>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+  fn7: MapFn<G, H>,
+  fn8: MapFn<H, I>,
+  fn9: MapFn<I, J>,
+  fn10: MapFn<J, K>,
 ): HookFn;
 // Fallback for spreads or variable length chains (same type)
 export function injectProp<T>(fn: Injectable<T>, ...mappers: MapFn<T>[]): HookFn;

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -96,6 +96,7 @@ export { HooksRunner, type HooksRunnerContext, type MapHookContext } from './hoo
 
 // Tokens
 export { InjectionToken } from './token/InjectionToken';
+export { type Injectable, toToken, toMappedToken, argToToken } from './token/toToken';
 export { GroupAliasToken, toGroupAlias } from './token/GroupAliasToken';
 export { SingleAliasToken, toSingleAlias } from './token/SingleAliasToken';
 export { ClassToken } from './token/ClassToken';

--- a/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
+++ b/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
@@ -24,7 +24,6 @@ const hookMetaKey = (methodName = 'constructor') => `inject:${methodName}`;
  * `@inject('key', sanitize(), validate())` passes the resolved instance through `sanitize()`,
  * then through `validate()`, and injects the result.
  */
-export function inject<T>(fn: Injectable<T>): ParameterDecorator;
 export function inject<T, B>(fn: Injectable<T>, fn1: MapFn<T, B>): ParameterDecorator;
 export function inject<T, B, C>(fn: Injectable<T>, fn1: MapFn<T, B>, fn2: MapFn<B, C>): ParameterDecorator;
 export function inject<T, B, C, D>(
@@ -47,6 +46,61 @@ export function inject<T, B, C, D, E, F>(
   fn3: MapFn<C, D>,
   fn4: MapFn<D, E>,
   fn5: MapFn<E, F>,
+): ParameterDecorator;
+export function inject<T, B, C, D, E, F, G>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+): ParameterDecorator;
+export function inject<T, B, C, D, E, F, G, H>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+  fn7: MapFn<G, H>,
+): ParameterDecorator;
+export function inject<T, B, C, D, E, F, G, H, I>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+  fn7: MapFn<G, H>,
+  fn8: MapFn<H, I>,
+): ParameterDecorator;
+export function inject<T, B, C, D, E, F, G, H, I, J>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+  fn7: MapFn<G, H>,
+  fn8: MapFn<H, I>,
+  fn9: MapFn<I, J>,
+): ParameterDecorator;
+export function inject<T, B, C, D, E, F, G, H, I, J, K>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+  fn6: MapFn<F, G>,
+  fn7: MapFn<G, H>,
+  fn8: MapFn<H, I>,
+  fn9: MapFn<I, J>,
+  fn10: MapFn<J, K>,
 ): ParameterDecorator;
 // Fallback for spreads or variable length chains (same type)
 export function inject<T>(fn: Injectable<T>, ...mappers: MapFn<T>[]): ParameterDecorator;

--- a/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
+++ b/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
@@ -4,9 +4,9 @@ import { type constructor, Is } from '../utils/basic';
 import { getParamMeta, addParamMeta } from '../metadata/parameter';
 import { InjectionToken } from '../token/InjectionToken';
 import { ProviderOptions } from '../provider/IProvider';
-import { argToToken, toToken } from '../token/toToken';
-import { FunctionToken } from '../token/FunctionToken';
+import { argToToken, type Injectable, toMappedToken } from '../token/toToken';
 import { InjectFn } from '../hooks/hook';
+import { type MapFn } from '../utils/fp';
 
 export class MetadataInjector extends Injector implements IInjector {
   protected createInstance<T>(scope: IContainer, Target: constructor<T>, { args: deps = [] }: InjectOptions = {}): T {
@@ -17,23 +17,49 @@ export class MetadataInjector extends Injector implements IInjector {
 
 const hookMetaKey = (methodName = 'constructor') => `inject:${methodName}`;
 
-export const inject =
-  <T, R = T>(
-    fn: InjectionToken<T> | InjectFn<T> | symbol | string | constructor<T>,
-    // selectFn narrows the resolved instance before it reaches the constructor parameter.
-    selectFn: (instance: T) => R = (instance) => instance as unknown as R,
-  ): ParameterDecorator =>
-  (target, propertyKey, parameterIndex) => {
-    const toSelectedToken = () => {
-      const token = toToken(fn);
-      return new FunctionToken<R>((scope, options) => selectFn(token.resolve(scope, options)));
-    };
-    addParamMeta(hookMetaKey(propertyKey as string), toSelectedToken)(
+/**
+ * Injects a dependency into a constructor parameter.
+ *
+ * Every argument after the first is a mapper applied to the resolved instance, left to right —
+ * `@inject('key', sanitize(), validate())` passes the resolved instance through `sanitize()`,
+ * then through `validate()`, and injects the result.
+ */
+export function inject<T>(fn: Injectable<T>): ParameterDecorator;
+export function inject<T, B>(fn: Injectable<T>, fn1: MapFn<T, B>): ParameterDecorator;
+export function inject<T, B, C>(fn: Injectable<T>, fn1: MapFn<T, B>, fn2: MapFn<B, C>): ParameterDecorator;
+export function inject<T, B, C, D>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+): ParameterDecorator;
+export function inject<T, B, C, D, E>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+): ParameterDecorator;
+export function inject<T, B, C, D, E, F>(
+  fn: Injectable<T>,
+  fn1: MapFn<T, B>,
+  fn2: MapFn<B, C>,
+  fn3: MapFn<C, D>,
+  fn4: MapFn<D, E>,
+  fn5: MapFn<E, F>,
+): ParameterDecorator;
+// Fallback for spreads or variable length chains (same type)
+export function inject<T>(fn: Injectable<T>, ...mappers: MapFn<T>[]): ParameterDecorator;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function inject<T>(fn: Injectable<T>, ...mappers: MapFn<any, any>[]): ParameterDecorator {
+  return (target, propertyKey, parameterIndex) => {
+    addParamMeta(hookMetaKey(propertyKey as string), () => toMappedToken(fn, mappers))(
       Is.instance(target) ? target.constructor : target,
       propertyKey,
       parameterIndex,
     );
   };
+}
 
 export const argsFn =
   <T = unknown>(predicate: (value: unknown, index: number) => boolean): InjectFn<T> =>

--- a/packages/ts-ioc-container/lib/token/toToken.ts
+++ b/packages/ts-ioc-container/lib/token/toToken.ts
@@ -7,13 +7,14 @@ import { InjectionToken, isInjectionToken } from './InjectionToken';
 import { InjectFn } from '../hooks/hook';
 import { type constructor, Is } from '../utils/basic';
 import { ConstantToken } from './ConstantToken';
+import { type MapFn, pipe } from '../utils/fp';
+
+export type Injectable<T = any> = InjectFn<T> | InjectionToken<T> | DependencyKey | constructor<T>;
 
 /**
  * @throws {UnsupportedTokenTypeError} when `token` is not an `InjectionToken`, a `DependencyKey`, a constructor, or a function.
  */
-export const toToken = <T = any>(
-  token: InjectFn<T> | InjectionToken<T> | DependencyKey | constructor<T>,
-): InjectionToken<T> => {
+export const toToken = <T = any>(token: Injectable<T>): InjectionToken<T> => {
   if (token instanceof InjectionToken) {
     return token;
   }
@@ -34,3 +35,14 @@ export const toToken = <T = any>(
 };
 
 export const argToToken = (v: unknown): InjectionToken<unknown> => (isInjectionToken(v) ? v : new ConstantToken(v));
+
+/**
+ * Builds a token that resolves `token` and then pipes the resolved instance through `mappers`,
+ * left to right. With no mappers the instance is passed through untouched.
+ * @throws {UnsupportedTokenTypeError} when `token` is not an `InjectionToken`, a `DependencyKey`, a constructor, or a function.
+ */
+export const toMappedToken = <T = any, R = T>(token: Injectable<T>, mappers: MapFn<any, any>[]): InjectionToken<R> => {
+  const source = toToken<T>(token);
+  const mapInstance = pipe<any>(...mappers);
+  return new FunctionToken<R>((scope, options) => mapInstance(source.resolve(scope, options)));
+};


### PR DESCRIPTION
## What

`@inject` and `injectProp` now accept **mappers as rest parameters** after the token:

```typescript
@inject('some-token', sanitize(), validate(), normalize())
injectProp('Config', takeApiUrl(), requireHttps())
```

Each mapper is a plain `(value) => value` function applied to the resolved instance, left to right — the last one's result is what gets injected.

## How

- `lib/token/toToken.ts` — new exported `Injectable<T>` type (the `InjectFn | InjectionToken | DependencyKey | constructor` union both decorators accept) and `toMappedToken(token, mappers)`, which resolves the token and pipes the instance through the mappers via the existing `pipe()`. Zero mappers is the identity, so the one-arg behaviour is untouched.
- `lib/injector/MetadataInjector.ts` — `inject` became an overloaded function; the overloads chain types across the sequence (`MapFn<T,B>, MapFn<B,C>, …`) for up to 10 mappers, matching `pipe`'s overload count, plus a variadic same-type fallback so spreads work: `@inject('Key', ...mappers)`.
- `lib/hooks/injectProp.ts` — same treatment; it gained mapping support it never had.
- `lib/index.ts` — exports `Injectable`, `toToken`, `toMappedToken`, `argToToken`.

## Backward compatibility

`@inject`'s previous single `selectFn` parameter is just the one-mapper case, so every existing call site keeps working unchanged.

## Tests & docs

- `__tests__/injector/inject.spec.ts` — mappers applied left to right, spread list, mappers re-run on every resolution, and a ten-mapper chain that exercises the widest overload.
- `__tests__/hooks/injectProp.spec.ts` (new) — same coverage for property injection.
- `__tests__/readme/injectMappers.spec.ts` (new) + a "Mapping injected values" section in `.readme.hbs.md`; `README.md` regenerated. Also fixed the stale cheatsheet line for `injectProp`, which documented a signature that doesn't exist.

Verified locally: `type-check`, `test` (369 passed / 73 files), `lint` (0 errors), `build`, and `test:all` including the react package.

> Opened from a fork because the `gh` credential on this machine has read-only access to the upstream repo; the same branch also exists on upstream as `feat/inject-mapper-pipes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)