### PR TITLE
feat(ts-ioc-container)!: rename args(index) to arg(index), add args for full runtime args array

### DIFF
--- a/packages/ts-ioc-container/.readme.hbs.md
+++ b/packages/ts-ioc-container/.readme.hbs.md
@@ -326,14 +326,15 @@ When you pass an `InjectionToken` via `token.args(...)`, the container resolves 
 - `ServiceToken.args(new ClassToken(SomeService))` — `SomeService` is constructed by the container
 - `ServiceToken.args('literal')` — literal value passed directly
 
-### Positional arg injection with `args(index)` and `argsFn`
+### Positional arg injection with `arg(index)`, `args`, and `argsFn`
 
-Constructor parameters that should pick up positional args from `ProviderOptions` must be annotated with `@inject(args(index))`. Parameters without `@inject` resolve to `undefined`.
+Constructor parameters that should pick up positional args from `ProviderOptions` must be annotated with `@inject(arg(index))`. Parameters without `@inject` resolve to `undefined`.
 
-- `@inject(args(0))` — resolves the first element of the `args` array passed at resolution time
+- `@inject(arg(0))` — resolves the first element of the `args` array passed at resolution time
+- `@inject(args)` — resolves the whole runtime `args` array
 - Works together with `token.args(...)` to pass typed dependencies through the args context
 
-`argsFn(predicate)` is the general form: it iterates the runtime `args` array and returns the **first argument matching** `predicate(value, index)` — think `args.find(predicate)`. `args(index)` is just a shortcut for matching by position: `args(0)` is `argsFn((value, index) => index === 0)`. Every `InjectFn` receives `(scope, options)`, where `options.args` is the runtime args array.
+`argsFn(predicate)` is the general form: it iterates the runtime `args` array and returns the **first argument matching** `predicate(value, index)` — think `args.find(predicate)`. `arg(index)` is just a shortcut for matching by position: `arg(0)` is `argsFn((value, index) => index === 0)`. `args` is `(scope, options) => options.args`, i.e. it returns the runtime args array as-is. Every `InjectFn` receives `(scope, options)`, where `options.args` is the runtime args array.
 
 ### Immutable token chaining
 

--- a/packages/ts-ioc-container/README.md
+++ b/packages/ts-ioc-container/README.md
@@ -708,7 +708,7 @@ The `lazy()` registerPipe can be used in two ways: with the `@register` decorato
 import 'reflect-metadata';
 import {
   appendArgs,
-  args,
+  arg,
   bindTo,
   Container,
   inject,
@@ -1017,8 +1017,8 @@ describe('lazy registerPipe', () => {
     @register(bindTo('Config'))
     class ConfigService {
       constructor(
-        @inject(args(0)) public apiUrl: string,
-        @inject(args(1)) public timeout: number,
+        @inject(arg(0)) public apiUrl: string,
+        @inject(arg(1)) public timeout: number,
       ) {
         initLog.push(`ConfigService initialized with ${apiUrl}`);
       }
@@ -1391,7 +1391,7 @@ Provider is dependency factory which creates dependency.
 - `new Provider((container, options) => container.resolve(Logger, options))`
 
 ```typescript
-import { args, bindTo, Container, inject, lazy, Provider, register, Registration as R } from 'ts-ioc-container';
+import { arg, bindTo, Container, inject, lazy, Provider, register, Registration as R } from 'ts-ioc-container';
 
 /**
  * Data Processing Pipeline - Provider Patterns
@@ -1458,7 +1458,7 @@ describe('Provider', () => {
 
   it('supports args decorator for providing extra arguments', () => {
     class FileService {
-      constructor(@inject(args(0)) readonly basePath: string) {}
+      constructor(@inject(arg(0)) readonly basePath: string) {}
     }
 
     const container = new Container().register(
@@ -1472,7 +1472,7 @@ describe('Provider', () => {
 
   it('supports argsFn decorator for dynamic arguments', () => {
     class Database {
-      constructor(@inject(args(0)) readonly connectionString: string) {}
+      constructor(@inject(arg(0)) readonly connectionString: string) {}
     }
 
     const container = new Container().register('DbPath', Provider.fromValue('localhost:5432')).register(
@@ -1632,14 +1632,15 @@ When you pass an `InjectionToken` via `token.args(...)`, the container resolves 
 - `ServiceToken.args(new ClassToken(SomeService))` — `SomeService` is constructed by the container
 - `ServiceToken.args('literal')` — literal value passed directly
 
-### Positional arg injection with `args(index)` and `argsFn`
+### Positional arg injection with `arg(index)`, `args`, and `argsFn`
 
-Constructor parameters that should pick up positional args from `ProviderOptions` must be annotated with `@inject(args(index))`. Parameters without `@inject` resolve to `undefined`.
+Constructor parameters that should pick up positional args from `ProviderOptions` must be annotated with `@inject(arg(index))`. Parameters without `@inject` resolve to `undefined`.
 
-- `@inject(args(0))` — resolves the first element of the `args` array passed at resolution time
+- `@inject(arg(0))` — resolves the first element of the `args` array passed at resolution time
+- `@inject(args)` — resolves the whole runtime `args` array
 - Works together with `token.args(...)` to pass typed dependencies through the args context
 
-`argsFn(predicate)` is the general form: it iterates the runtime `args` array and returns the **first argument matching** `predicate(value, index)` — think `args.find(predicate)`. `args(index)` is just a shortcut for matching by position: `args(0)` is `argsFn((value, index) => index === 0)`. Every `InjectFn` receives `(scope, options)`, where `options.args` is the runtime args array.
+`argsFn(predicate)` is the general form: it iterates the runtime `args` array and returns the **first argument matching** `predicate(value, index)` — think `args.find(predicate)`. `arg(index)` is just a shortcut for matching by position: `arg(0)` is `argsFn((value, index) => index === 0)`. `args` is `(scope, options) => options.args`, i.e. it returns the runtime args array as-is. Every `InjectFn` receives `(scope, options)`, where `options.args` is the runtime args array.
 
 ### Immutable token chaining
 
@@ -1654,7 +1655,7 @@ const userToken = ApiToken.args('https://users.api.com', 1000);
 
 ```typescript
 import {
-  args,
+  arg,
   appendArgs,
   appendArgsFn,
   bindTo,
@@ -1686,7 +1687,7 @@ describe('IProvider', function () {
       // Pre-configure the logger with a filename
       @register(appendArgs('/var/log/app.log'))
       class FileLogger {
-        constructor(@inject(args(0)) public filename: string) {}
+        constructor(@inject(arg(0)) public filename: string) {}
       }
 
       const root = createContainer().addRegistration(R.fromClass(FileLogger));
@@ -1700,8 +1701,8 @@ describe('IProvider', function () {
       @register(appendArgs('ConfiguredContext'))
       class Logger {
         constructor(
-          @inject(args(0)) public runtimeContext: string,
-          @inject(args(1)) public configuredContext: string,
+          @inject(arg(0)) public runtimeContext: string,
+          @inject(arg(1)) public configuredContext: string,
         ) {}
       }
 
@@ -1723,7 +1724,7 @@ describe('IProvider', function () {
       // Extract 'env' from Config service dynamically
       @register(appendArgsFn((scope) => [scope.resolve<Config>('Config').env]))
       class Service {
-        constructor(@inject(args(0)) public env: string) {}
+        constructor(@inject(arg(0)) public env: string) {}
       }
 
       const root = createContainer()
@@ -1740,8 +1741,8 @@ describe('IProvider', function () {
       @register(appendArgs('configured'))
       class Service {
         constructor(
-          @inject(args(0)) public runtime: string,
-          @inject(args(1)) public configured: string,
+          @inject(arg(0)) public runtime: string,
+          @inject(arg(1)) public configured: string,
         ) {}
       }
 
@@ -1760,9 +1761,9 @@ describe('IProvider', function () {
       @register(appendArgs('fixed'), appendArgsFn((scope) => [scope.resolve<Config>('Config').tenant]))
       class Service {
         constructor(
-          @inject(args(0)) public runtime: string,
-          @inject(args(1)) public fixed: string,
-          @inject(args(2)) public tenant: string,
+          @inject(arg(0)) public runtime: string,
+          @inject(arg(1)) public fixed: string,
+          @inject(arg(2)) public tenant: string,
         ) {}
       }
 
@@ -1799,7 +1800,7 @@ describe('IProvider', function () {
 
     // EntityManager is generic - it works with ANY repository.
     // The repository is the first arg passed via `EntityManagerToken.args(...)`.
-    // `@inject(args(0))` reads it; the container auto-resolves InjectionToken args
+    // `@inject(arg(0))` reads it; the container auto-resolves InjectionToken args
     // before they reach the constructor.
     const EntityManagerToken = new SingleToken<EntityManager>('EntityManager');
 
@@ -1808,7 +1809,7 @@ describe('IProvider', function () {
       singleton((arg1) => (arg1 as SingleToken).token), // Cache unique instance per repository type
     )
     class EntityManager {
-      constructor(@inject(args(0)) public repository: IRepository) {}
+      constructor(@inject(arg(0)) public repository: IRepository) {}
     }
 
     class App {
@@ -2117,7 +2118,7 @@ Sometimes you want to decorate you class with some logic. Use the `decorate(...)
 
 ```typescript
 import {
-  args,
+  arg,
   bindTo,
   Container,
   decorate,
@@ -2171,7 +2172,7 @@ describe('Decorator Pattern', () => {
   // Decorator: Wraps any IRepository with logging behavior
   class LoggingRepository implements IRepository {
     constructor(
-      @inject(args(0)) private repository: IRepository,
+      @inject(arg(0)) private repository: IRepository,
       @inject(s.token('Logger').lazy()) private logger: Logger,
     ) {}
 

--- a/packages/ts-ioc-container/__tests__/container/IocContainer.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/IocContainer.spec.ts
@@ -1,8 +1,8 @@
-import { args, appendArgs, bindTo, Container, inject, register, Registration as R, scope } from '../../lib';
+import { arg, appendArgs, bindTo, Container, inject, register, Registration as R, scope } from '../../lib';
 
 @register(bindTo('logger'))
 class Logger {
-  constructor(@inject(args(0)) public topic: string) {}
+  constructor(@inject(arg(0)) public topic: string) {}
 }
 
 describe('IocContainer', function () {

--- a/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
+++ b/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 import {
   append,
   appendHooks,
-  args,
+  arg,
   bindTo,
   Container,
   GroupAliasToken,
@@ -65,7 +65,7 @@ describe('hooks', () => {
           ctx.invokeMethod();
         }),
       )
-      start(@inject(args(0)) firstArg: string, @inject('suffix') suffix: string, runtimeArg: string) {
+      start(@inject(arg(0)) firstArg: string, @inject('suffix') suffix: string, runtimeArg: string) {
         this.receivedArgs = [firstArg, suffix, runtimeArg];
       }
     }
@@ -94,7 +94,7 @@ describe('hooks', () => {
           ctx.invokeMethod();
         }),
       )
-      start(@inject(args(0)) firstArg: string, @inject('suffix') suffix: string) {
+      start(@inject(arg(0)) firstArg: string, @inject('suffix') suffix: string) {
         this.receivedArgs = [firstArg, suffix];
       }
     }
@@ -122,7 +122,7 @@ describe('hooks', () => {
           await ctx.invokeMethod();
         }),
       )
-      async start(@inject(args(0)) firstArg: string) {
+      async start(@inject(arg(0)) firstArg: string) {
         this.receivedArgs = [firstArg];
       }
     }

--- a/packages/ts-ioc-container/__tests__/injector/inject.spec.ts
+++ b/packages/ts-ioc-container/__tests__/injector/inject.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {
+  arg,
   args,
   appendArgs,
   appendArgsFn,
@@ -16,12 +17,12 @@ describe('inject helpers', () => {
     return new Container();
   }
 
-  describe('args(index)', () => {
-    it('resolves InjectionToken args before reaching @inject(args(...))', () => {
+  describe('arg(index)', () => {
+    it('resolves InjectionToken args before reaching @inject(arg(...))', () => {
       const ValueToken = new SingleToken<string>('value');
 
       class Service {
-        constructor(@inject(args(0)) public value: string) {}
+        constructor(@inject(arg(0)) public value: string) {}
       }
 
       const ServiceToken = new SingleToken<Service>('Service');
@@ -36,7 +37,7 @@ describe('inject helpers', () => {
     it('returns undefined for out-of-bounds index', () => {
       @register(appendArgs('only'))
       class Service {
-        constructor(@inject(args(5)) public value: unknown) {}
+        constructor(@inject(arg(5)) public value: unknown) {}
       }
 
       const container = createContainer().addRegistration(R.fromClass(Service));
@@ -47,7 +48,7 @@ describe('inject helpers', () => {
       @register(appendArgs('a', 'b', 'c'))
       class Service {
         constructor(
-          @inject(args(1)) public viaArgs: unknown,
+          @inject(arg(1)) public viaArgs: unknown,
           @inject(argsFn((value, index) => index === 1)) public viaArgsFn: unknown,
         ) {}
       }
@@ -56,6 +57,27 @@ describe('inject helpers', () => {
       const service = container.resolve<Service>('Service');
       expect(service.viaArgs).toBe('b');
       expect(service.viaArgsFn).toBe('b');
+    });
+  });
+
+  describe('args', () => {
+    it('resolves the whole runtime args array', () => {
+      @register(appendArgs('a', 'b', 'c'))
+      class Service {
+        constructor(@inject(args) public all: unknown[]) {}
+      }
+
+      const container = createContainer().addRegistration(R.fromClass(Service));
+      expect(container.resolve<Service>('Service').all).toEqual(['a', 'b', 'c']);
+    });
+
+    it('resolves an empty array when no args were passed', () => {
+      class Service {
+        constructor(@inject(args) public all: unknown[]) {}
+      }
+
+      const container = createContainer().addRegistration(R.fromClass(Service));
+      expect(container.resolve<Service>('Service').all).toEqual([]);
     });
   });
 
@@ -96,7 +118,7 @@ describe('inject helpers', () => {
 
     it('forwards resolve args to the dependency before selecting', () => {
       class Config {
-        constructor(@inject(args(0)) readonly apiUrl: string) {}
+        constructor(@inject(arg(0)) readonly apiUrl: string) {}
       }
 
       const ConfigToken = new SingleToken<Config>('Config');
@@ -115,7 +137,7 @@ describe('inject helpers', () => {
     it('selects from a runtime arg', () => {
       @register(appendArgs({ id: 42 }))
       class Service {
-        constructor(@inject(args<{ id: number }>(0), (value) => value.id) public id: number) {}
+        constructor(@inject(arg<{ id: number }>(0), (value) => value.id) public id: number) {}
       }
 
       const container = createContainer().addRegistration(R.fromClass(Service));

--- a/packages/ts-ioc-container/__tests__/provider/IProvider.spec.ts
+++ b/packages/ts-ioc-container/__tests__/provider/IProvider.spec.ts
@@ -1,5 +1,5 @@
 import {
-  args,
+  arg,
   appendArgs,
   appendArgsFn,
   bindTo,
@@ -31,7 +31,7 @@ describe('IProvider', function () {
       // Pre-configure the logger with a filename
       @register(appendArgs('/var/log/app.log'))
       class FileLogger {
-        constructor(@inject(args(0)) public filename: string) {}
+        constructor(@inject(arg(0)) public filename: string) {}
       }
 
       const root = createContainer().addRegistration(R.fromClass(FileLogger));
@@ -45,8 +45,8 @@ describe('IProvider', function () {
       @register(appendArgs('ConfiguredContext'))
       class Logger {
         constructor(
-          @inject(args(0)) public runtimeContext: string,
-          @inject(args(1)) public configuredContext: string,
+          @inject(arg(0)) public runtimeContext: string,
+          @inject(arg(1)) public configuredContext: string,
         ) {}
       }
 
@@ -68,7 +68,7 @@ describe('IProvider', function () {
       // Extract 'env' from Config service dynamically
       @register(appendArgsFn((scope) => [scope.resolve<Config>('Config').env]))
       class Service {
-        constructor(@inject(args(0)) public env: string) {}
+        constructor(@inject(arg(0)) public env: string) {}
       }
 
       const root = createContainer()
@@ -85,8 +85,8 @@ describe('IProvider', function () {
       @register(appendArgs('configured'))
       class Service {
         constructor(
-          @inject(args(0)) public runtime: string,
-          @inject(args(1)) public configured: string,
+          @inject(arg(0)) public runtime: string,
+          @inject(arg(1)) public configured: string,
         ) {}
       }
 
@@ -105,9 +105,9 @@ describe('IProvider', function () {
       @register(appendArgs('fixed'), appendArgsFn((scope) => [scope.resolve<Config>('Config').tenant]))
       class Service {
         constructor(
-          @inject(args(0)) public runtime: string,
-          @inject(args(1)) public fixed: string,
-          @inject(args(2)) public tenant: string,
+          @inject(arg(0)) public runtime: string,
+          @inject(arg(1)) public fixed: string,
+          @inject(arg(2)) public tenant: string,
         ) {}
       }
 
@@ -144,7 +144,7 @@ describe('IProvider', function () {
 
     // EntityManager is generic - it works with ANY repository.
     // The repository is the first arg passed via `EntityManagerToken.args(...)`.
-    // `@inject(args(0))` reads it; the container auto-resolves InjectionToken args
+    // `@inject(arg(0))` reads it; the container auto-resolves InjectionToken args
     // before they reach the constructor.
     const EntityManagerToken = new SingleToken<EntityManager>('EntityManager');
 
@@ -153,7 +153,7 @@ describe('IProvider', function () {
       singleton((arg1) => (arg1 as SingleToken).token), // Cache unique instance per repository type
     )
     class EntityManager {
-      constructor(@inject(args(0)) public repository: IRepository) {}
+      constructor(@inject(arg(0)) public repository: IRepository) {}
     }
 
     class App {

--- a/packages/ts-ioc-container/__tests__/readme/decorate.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/decorate.spec.ts
@@ -1,5 +1,5 @@
 import {
-  args,
+  arg,
   bindTo,
   Container,
   decorate,
@@ -53,7 +53,7 @@ describe('Decorator Pattern', () => {
   // Decorator: Wraps any IRepository with logging behavior
   class LoggingRepository implements IRepository {
     constructor(
-      @inject(args(0)) private repository: IRepository,
+      @inject(arg(0)) private repository: IRepository,
       @inject(s.token('Logger').lazy()) private logger: Logger,
     ) {}
 

--- a/packages/ts-ioc-container/__tests__/readme/lazyPipe.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/lazyPipe.spec.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import {
   appendArgs,
-  args,
+  arg,
   bindTo,
   Container,
   inject,
@@ -310,8 +310,8 @@ describe('lazy registerPipe', () => {
     @register(bindTo('Config'))
     class ConfigService {
       constructor(
-        @inject(args(0)) public apiUrl: string,
-        @inject(args(1)) public timeout: number,
+        @inject(arg(0)) public apiUrl: string,
+        @inject(arg(1)) public timeout: number,
       ) {
         initLog.push(`ConfigService initialized with ${apiUrl}`);
       }

--- a/packages/ts-ioc-container/__tests__/readme/provider.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/provider.spec.ts
@@ -1,4 +1,4 @@
-import { args, bindTo, Container, inject, lazy, Provider, register, Registration as R } from '../../lib';
+import { arg, bindTo, Container, inject, lazy, Provider, register, Registration as R } from '../../lib';
 
 /**
  * Data Processing Pipeline - Provider Patterns
@@ -65,7 +65,7 @@ describe('Provider', () => {
 
   it('supports args decorator for providing extra arguments', () => {
     class FileService {
-      constructor(@inject(args(0)) readonly basePath: string) {}
+      constructor(@inject(arg(0)) readonly basePath: string) {}
     }
 
     const container = new Container().register(
@@ -79,7 +79,7 @@ describe('Provider', () => {
 
   it('supports argsFn decorator for dynamic arguments', () => {
     class Database {
-      constructor(@inject(args(0)) readonly connectionString: string) {}
+      constructor(@inject(arg(0)) readonly connectionString: string) {}
     }
 
     const container = new Container().register('DbPath', Provider.fromValue('localhost:5432')).register(

--- a/packages/ts-ioc-container/__tests__/readme/tokenArgs.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/tokenArgs.spec.ts
@@ -1,4 +1,4 @@
-import { args, bindTo, Container, inject, register, Registration as R, SingleToken } from '../../lib';
+import { arg, bindTo, Container, inject, register, Registration as R, SingleToken } from '../../lib';
 
 /**
  * Configuration - Token with Arguments
@@ -19,8 +19,8 @@ interface IApiClient {
 @register(bindTo('IApiClient'))
 class ApiClient implements IApiClient {
   constructor(
-    @inject(args(0)) public baseUrl: string,
-    @inject(args(1)) public timeout: number,
+    @inject(arg(0)) public baseUrl: string,
+    @inject(arg(1)) public timeout: number,
   ) {}
 
   get(endpoint: string): string {

--- a/packages/ts-ioc-container/__tests__/readme/tokenArgsFn.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/tokenArgsFn.spec.ts
@@ -1,4 +1,4 @@
-import { args, bindTo, Container, inject, register, Registration as R, SingleToken } from '../../lib';
+import { arg, bindTo, Container, inject, register, Registration as R, SingleToken } from '../../lib';
 
 interface IConfig {
   apiUrl: string;
@@ -8,8 +8,8 @@ interface IConfig {
 @register(bindTo('IConfig'))
 class ConfigService implements IConfig {
   constructor(
-    @inject(args(0)) public apiUrl: string,
-    @inject(args(1)) public timeout: number,
+    @inject(arg(0)) public apiUrl: string,
+    @inject(arg(1)) public timeout: number,
   ) {}
 }
 

--- a/packages/ts-ioc-container/__tests__/readme/tokenLazy.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/tokenLazy.spec.ts
@@ -1,4 +1,4 @@
-import { args, appendArgs, bindTo, Container, inject, register, Registration as R, SingleToken } from '../../lib';
+import { arg, appendArgs, bindTo, Container, inject, register, Registration as R, SingleToken } from '../../lib';
 
 interface IConfig {
   apiUrl: string;
@@ -6,7 +6,7 @@ interface IConfig {
 
 @register(bindTo('IConfig'), appendArgs('https://api.example.com'))
 class ConfigService implements IConfig {
-  constructor(@inject(args(0)) public apiUrl: string) {}
+  constructor(@inject(arg(0)) public apiUrl: string) {}
 }
 
 const IConfigToken = new SingleToken<IConfig>('IConfig');

--- a/packages/ts-ioc-container/__tests__/specs/injector-strategies.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/injector-strategies.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {
+  arg,
   args,
   argsFn,
   bindTo,
@@ -24,8 +25,9 @@ describe('Spec: injector strategies', () => {
     class Controller {
       constructor(
         @inject('Logger') readonly logger: Logger,
-        @inject(args(0)) readonly id: number,
+        @inject(arg(0)) readonly id: number,
         @inject(argsFn((value) => typeof value === 'string')) readonly tenant: string,
+        @inject(args) readonly allArgs: unknown[],
       ) {}
     }
 
@@ -36,6 +38,7 @@ describe('Spec: injector strategies', () => {
     expect(controller.logger).toBeInstanceOf(Logger);
     expect(controller.id).toBe(100);
     expect(controller.tenant).toBe('tenant-a');
+    expect(controller.allArgs).toEqual([100, 'tenant-a']);
   });
 
   it('leaves constructor parameters without @inject metadata as undefined', () => {

--- a/packages/ts-ioc-container/__tests__/specs/provider-behavior.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/provider-behavior.spec.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import {
-  args,
+  arg,
   appendArgs,
   appendArgsFn,
   CannonSingletonApplyTwiceError,
@@ -61,7 +61,7 @@ describe('Spec: provider behavior', () => {
   it('caches singleton results by configured cache key', () => {
     @register(singleton((tenant) => tenant as string))
     class TenantRepository {
-      constructor(@inject(args(0)) readonly tenant: string) {}
+      constructor(@inject(arg(0)) readonly tenant: string) {}
     }
 
     const container = new Container().addRegistration(R.fromClass(TenantRepository));
@@ -84,13 +84,13 @@ describe('Spec: provider behavior', () => {
     @register(appendArgsFn((scope) => [scope.resolve<RegionConfig>('RegionConfig').region, 'billing']))
     class Endpoint {
       constructor(
-        @inject(args(0)) readonly region: string,
-        @inject(args(1)) readonly service: string,
+        @inject(arg(0)) readonly region: string,
+        @inject(arg(1)) readonly service: string,
       ) {}
     }
 
     class UsesTokenArg {
-      constructor(@inject(args(0)) readonly config: RegionConfig) {}
+      constructor(@inject(arg(0)) readonly config: RegionConfig) {}
     }
 
     const ConfigToken = new SingleToken<RegionConfig>('RegionConfig');
@@ -109,8 +109,8 @@ describe('Spec: provider behavior', () => {
     @register(appendArgs('fixed'))
     class FixedEndpoint {
       constructor(
-        @inject(args(0)) readonly runtimeValue: string,
-        @inject(args(1)) readonly fixedValue: string,
+        @inject(arg(0)) readonly runtimeValue: string,
+        @inject(arg(1)) readonly fixedValue: string,
       ) {}
     }
 
@@ -128,9 +128,9 @@ describe('Spec: provider behavior', () => {
     @register(appendArgsFn((scope) => [scope.resolve<TenantConfig>('TenantConfig').tenant]), appendArgs('tail'))
     class Endpoint {
       constructor(
-        @inject(args(0)) readonly runtime: string,
-        @inject(args(1)) readonly tenant: string,
-        @inject(args(2)) readonly tail: string,
+        @inject(arg(0)) readonly runtime: string,
+        @inject(arg(1)) readonly tenant: string,
+        @inject(arg(2)) readonly tail: string,
       ) {}
     }
 

--- a/packages/ts-ioc-container/__tests__/specs/token-based-injection.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/token-based-injection.spec.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import {
-  args,
+  arg,
   bindTo,
   ClassToken,
   ConstantToken,
@@ -54,8 +54,8 @@ describe('Spec: token-based injection', () => {
   it('composes token arguments immutably', () => {
     class Report {
       constructor(
-        @inject(args(0)) readonly format: string,
-        @inject(args(1)) readonly tenant: string,
+        @inject(arg(0)) readonly format: string,
+        @inject(arg(1)) readonly tenant: string,
       ) {}
     }
 

--- a/packages/ts-ioc-container/__tests__/token/ClassToken.spec.ts
+++ b/packages/ts-ioc-container/__tests__/token/ClassToken.spec.ts
@@ -1,9 +1,9 @@
 import 'reflect-metadata';
-import { args, ClassToken, Container, inject } from '../../lib';
+import { arg, ClassToken, Container, inject } from '../../lib';
 
 describe('ClassToken', () => {
   class TestClass {
-    constructor(@inject(args(0)) public value: string = 'default') {}
+    constructor(@inject(arg(0)) public value: string = 'default') {}
   }
 
   it('should resolve class with default value when no args supplied', () => {
@@ -13,7 +13,7 @@ describe('ClassToken', () => {
     expect(result.value).toBe('default');
   });
 
-  it('chained args+argsFn: first arg wins because args(0) reads position 0', () => {
+  it('chained args+argsFn: first arg wins because arg(0) reads position 0', () => {
     const token = new ClassToken(TestClass).args('first').argsFn(() => ['second']);
     const result = token.resolve(new Container());
     expect(result.value).toBe('first');

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -15,7 +15,7 @@ export { EmptyContainer } from './container/EmptyContainer';
 
 // Injectors
 export { type IInjector, type InjectOptions, type IInjectFnResolver, Injector } from './injector/IInjector';
-export { MetadataInjector, inject, args, argsFn, resolveArgs } from './injector/MetadataInjector';
+export { MetadataInjector, inject, arg, args, argsFn, resolveArgs } from './injector/MetadataInjector';
 export { SimpleInjector } from './injector/SimpleInjector';
 export { ProxyInjector } from './injector/ProxyInjector';
 

--- a/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
+++ b/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
@@ -120,7 +120,9 @@ export const argsFn =
   (c, { args = [] }): T =>
     args.find((value, index) => predicate(value, index)) as T;
 
-export const args = <T = unknown>(index: number): InjectFn<T> => argsFn<T>((value, i) => i === index);
+export const arg = <T = unknown>(index: number): InjectFn<T> => argsFn<T>((value, i) => i === index);
+
+export const args: InjectFn<unknown[]> = (c, { args = [] }) => args;
 
 export const resolveArgs = (Target: constructor<unknown>, methodName?: string) => {
   const tokens = getParamMeta(hookMetaKey(methodName), Target) as InjectionToken[];

--- a/packages/ts-ioc-container/specs/epics/injector-strategies.md
+++ b/packages/ts-ioc-container/specs/epics/injector-strategies.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0002 - Pluggable injector strategies](../../docs/adr/0002-pluggable-injectors.md)
-- **Public API:** `IInjector`, `Injector`, `MetadataInjector`, `SimpleInjector`, `ProxyInjector`, `inject`, `resolveArgs`, `args`, `argsFn`
+- **Public API:** `IInjector`, `Injector`, `MetadataInjector`, `SimpleInjector`, `ProxyInjector`, `inject`, `resolveArgs`, `arg`, `args`, `argsFn`
 - **Executable spec:** `__tests__/specs/injector-strategies.spec.ts`
 
 ## Intent
@@ -17,7 +17,7 @@ proxy-style access, or a custom construction strategy.
 
 As a decorator-friendly TypeScript user, I want injection to be explicit, so
 that only constructor parameters annotated with `@inject` (or its derivatives
-like `args` / `argsFn`) are resolved by the container.
+like `arg` / `args` / `argsFn`) are resolved by the container.
 
 Acceptance criteria:
 
@@ -33,7 +33,8 @@ that a dependency can be configured at resolution time.
 
 Acceptance criteria:
 
-- `args(index)` selects a runtime argument by position.
+- `arg(index)` selects a runtime argument by position.
+- `args` injects the full runtime argument list.
 - `argsFn` maps the full runtime argument list to one injected value.
 - Missing positional runtime arguments resolve as `undefined`.
 


### PR DESCRIPTION
## Description

Renames the positional-arg `InjectFn` helper `args(index)` to `arg(index)`, and repurposes the `args` export as an `InjectFn` that returns the whole runtime args array: `args = (scope, options) => options.args`. Use `@inject(arg(0))` for a single positional arg, and `@inject(args)` to receive the full runtime args array in a constructor parameter.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [x] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` (`.readme.hbs.md` changed)
- [x] Tests added or updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes (371 tests)
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

All call sites across `__tests__/` and the generated `README.md`/`.readme.hbs.md` were updated from `args(index)` to `arg(index)`. `specs/epics/injector-strategies.md` was updated to document `arg`/`args` as separate public API entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YgYpDCn1HBjCr8Zr3n83A

---
_Generated by [Claude Code](https://claude.ai/code/session_019YgYpDCn1HBjCr8Zr3n83A)_