### PR TITLE
feat(ts-ioc-container): add autoResolve provider pipe and AutoResolveModule

### DIFF
--- a/packages/ts-ioc-container/.readme.hbs.md
+++ b/packages/ts-ioc-container/.readme.hbs.md
@@ -323,6 +323,13 @@ never create them, because nothing asks for them.
   every scope created afterwards
 - `container.autoResolve()` resolves the eager providers of one container on demand
 
+Both accept an optional `AutoResolveOptions` (`{ args?: unknown[] }`) whose `args`
+are forwarded to every eagerly resolved provider, exactly as `resolve` forwards
+them - so they reach `@inject(arg(0))` parameters, `scopeAccess` rules and the
+`singleton()` cache key. `new AutoResolveModule({ args })` applies the same args
+to every created scope; call `scope.autoResolve({ args })` yourself when the
+value differs per scope.
+
 > [!IMPORTANT]
 > `autoResolve()` on its own does nothing - the container has to opt in with
 > `AutoResolveModule`. The container the module is applied to is not a created

--- a/packages/ts-ioc-container/.readme.hbs.md
+++ b/packages/ts-ioc-container/.readme.hbs.md
@@ -43,6 +43,7 @@ provider pipelines, aliases, and custom injector strategies.
   - [Proxy](#proxy)
 - [Provider](#provider) `provider`
   - [Singleton](#singleton) `singleton`
+  - [Auto resolve](#auto-resolve) `autoResolve`
   - [Arguments](#arguments) `appendArgs` `appendArgsFn`
   - [Visibility](#visibility) `visible`
   - [Alias](#alias) `asAlias`
@@ -121,6 +122,7 @@ bundlers tree-shake unused exports.
 - Register value: `R.fromValue(config).bindTo('Config')`
 - Register factory: `R.fromFn((c) => createX(c)).bindTo('X')`
 - Singleton: `@register(singleton())`
+- Eager service: `@register(autoResolve())` + `container.useModule(new AutoResolveModule())`
 - Scoped registration: `@register(scope((s) => s.hasTag('request')))`
 - Resolve by alias: `container.resolveByAlias('Alias')`
 - Current scope token: `select.scope.current`
@@ -308,6 +310,32 @@ Sometimes you need to create only one instance of dependency per scope. For exam
 
 ```typescript
 {{{include_file './__tests__/readme/Singleton.spec.ts'}}}
+```
+
+### Auto resolve
+
+Some services are never injected anywhere - they subscribe to a queue, start a
+timer, or warm a cache as soon as their scope exists. Lazy resolution would
+never create them, because nothing asks for them.
+
+- `@register(autoResolve())` marks a provider as eager
+- `container.useModule(new AutoResolveModule())` enables eager resolution for
+  every scope created afterwards
+- `container.autoResolve()` resolves the eager providers of one container on demand
+
+> [!IMPORTANT]
+> `autoResolve()` on its own does nothing - the container has to opt in with
+> `AutoResolveModule`. The container the module is applied to is not a created
+> scope, so call `container.autoResolve()` explicitly to eagerly resolve its own
+> providers.
+
+Eager resolution goes through the provider unchanged, so `singleton()` still
+returns the eagerly created instance later, and providers which are not
+registered in the created scope (`scope(...)`) or deny access to it
+(`scopeAccess(...)`) are skipped.
+
+```typescript
+{{{include_file './__tests__/readme/autoResolve.spec.ts'}}}
 ```
 
 ### Arguments

--- a/packages/ts-ioc-container/README.md
+++ b/packages/ts-ioc-container/README.md
@@ -1629,6 +1629,13 @@ never create them, because nothing asks for them.
   every scope created afterwards
 - `container.autoResolve()` resolves the eager providers of one container on demand
 
+Both accept an optional `AutoResolveOptions` (`{ args?: unknown[] }`) whose `args`
+are forwarded to every eagerly resolved provider, exactly as `resolve` forwards
+them - so they reach `@inject(arg(0))` parameters, `scopeAccess` rules and the
+`singleton()` cache key. `new AutoResolveModule({ args })` applies the same args
+to every created scope; call `scope.autoResolve({ args })` yourself when the
+value differs per scope.
+
 > [!IMPORTANT]
 > `autoResolve()` on its own does nothing - the container has to opt in with
 > `AutoResolveModule`. The container the module is applied to is not a created
@@ -1643,11 +1650,13 @@ registered in the created scope (`scope(...)`) or deny access to it
 ```typescript
 import 'reflect-metadata';
 import {
+  arg,
   autoResolve,
   AutoResolveModule,
   bindTo,
   Container,
   type IContainer,
+  inject,
   register,
   Registration as R,
   scope,
@@ -1666,12 +1675,21 @@ import {
  */
 
 const auditTrail: string[] = [];
+const openedLogs: string[] = [];
 
 // Started for every request, even though no other class injects it
 @register(bindTo('IRequestAuditor'), scope((s) => s.hasTag('request')), autoResolve(), singleton())
 class RequestAuditor {
   constructor() {
     auditTrail.push('request started');
+  }
+}
+
+// Eager too, but parameterized - the args come from whoever triggers eager resolution
+@register(bindTo('IRequestLog'), scope((s) => s.hasTag('request')), autoResolve())
+class RequestLog {
+  constructor(@inject(arg(0)) readonly requestId: string = 'anonymous') {
+    openedLogs.push(requestId);
   }
 }
 
@@ -1684,15 +1702,17 @@ class UserRepository {
 }
 
 describe('Auto resolve', function () {
-  function createAppContainer(): IContainer {
+  function createAppContainer(options: { args?: unknown[] } = {}): IContainer {
     return new Container({ tags: ['application'] })
-      .useModule(new AutoResolveModule())
+      .useModule(new AutoResolveModule(options))
       .addRegistration(R.fromClass(RequestAuditor))
+      .addRegistration(R.fromClass(RequestLog))
       .addRegistration(R.fromClass(UserRepository));
   }
 
   beforeEach(() => {
     auditTrail.length = 0;
+    openedLogs.length = 0;
   });
 
   it('should create eager services as soon as a scope is created', function () {
@@ -1715,6 +1735,25 @@ describe('Auto resolve', function () {
 
     expect(auditTrail).toEqual(['request started']);
     expect(requestScope.resolve<RequestAuditor>('IRequestAuditor')).toBe(auditor);
+  });
+
+  it('should treat resolve options as optional', function () {
+    createAppContainer().createScope({ tags: ['request'] });
+
+    expect(openedLogs).toEqual(['anonymous']);
+  });
+
+  it('should forward args to every eagerly resolved provider', function () {
+    // The same args reach every scope the module creates...
+    createAppContainer({ args: ['req-42'] }).createScope({ tags: ['request'] });
+
+    expect(openedLogs).toEqual(['req-42']);
+
+    // ...or pass a per-scope value by calling autoResolve yourself
+    const requestScope = createAppContainer().createScope({ tags: ['request'] });
+    requestScope.autoResolve({ args: ['req-43'] });
+
+    expect(openedLogs).toEqual(['req-42', 'anonymous', 'req-43']);
   });
 
   it('should leave other providers lazy', function () {

--- a/packages/ts-ioc-container/README.md
+++ b/packages/ts-ioc-container/README.md
@@ -43,6 +43,7 @@ provider pipelines, aliases, and custom injector strategies.
   - [Proxy](#proxy)
 - [Provider](#provider) `provider`
   - [Singleton](#singleton) `singleton`
+  - [Auto resolve](#auto-resolve) `autoResolve`
   - [Arguments](#arguments) `appendArgs` `appendArgsFn`
   - [Visibility](#visibility) `visible`
   - [Alias](#alias) `asAlias`
@@ -153,6 +154,7 @@ describe('Quickstart', function () {
 - Register value: `R.fromValue(config).bindTo('Config')`
 - Register factory: `R.fromFn((c) => createX(c)).bindTo('X')`
 - Singleton: `@register(singleton())`
+- Eager service: `@register(autoResolve())` + `container.useModule(new AutoResolveModule())`
 - Scoped registration: `@register(scope((s) => s.hasTag('request')))`
 - Resolve by alias: `container.resolveByAlias('Alias')`
 - Current scope token: `select.scope.current`
@@ -1611,6 +1613,114 @@ describe('Singleton', function () {
     const hasher2 = requestScope.resolve<PasswordHasher>('IPasswordHasher');
 
     expect(hasher1).toBe(hasher2);
+  });
+});
+
+```
+
+### Auto resolve
+
+Some services are never injected anywhere - they subscribe to a queue, start a
+timer, or warm a cache as soon as their scope exists. Lazy resolution would
+never create them, because nothing asks for them.
+
+- `@register(autoResolve())` marks a provider as eager
+- `container.useModule(new AutoResolveModule())` enables eager resolution for
+  every scope created afterwards
+- `container.autoResolve()` resolves the eager providers of one container on demand
+
+> [!IMPORTANT]
+> `autoResolve()` on its own does nothing - the container has to opt in with
+> `AutoResolveModule`. The container the module is applied to is not a created
+> scope, so call `container.autoResolve()` explicitly to eagerly resolve its own
+> providers.
+
+Eager resolution goes through the provider unchanged, so `singleton()` still
+returns the eagerly created instance later, and providers which are not
+registered in the created scope (`scope(...)`) or deny access to it
+(`scopeAccess(...)`) are skipped.
+
+```typescript
+import 'reflect-metadata';
+import {
+  autoResolve,
+  AutoResolveModule,
+  bindTo,
+  Container,
+  type IContainer,
+  register,
+  Registration as R,
+  scope,
+  singleton,
+} from 'ts-ioc-container';
+
+/**
+ * User Management Domain - Eager Services
+ *
+ * Some services are never injected anywhere: they subscribe to a queue, start a
+ * timer, or warm a cache as soon as their scope exists. Nothing resolves them,
+ * so lazy resolution would never create them at all.
+ *
+ * `autoResolve()` marks such a provider as eager, and `AutoResolveModule`
+ * resolves every eager provider of a scope right after the scope is created.
+ */
+
+const auditTrail: string[] = [];
+
+// Started for every request, even though no other class injects it
+@register(bindTo('IRequestAuditor'), scope((s) => s.hasTag('request')), autoResolve(), singleton())
+class RequestAuditor {
+  constructor() {
+    auditTrail.push('request started');
+  }
+}
+
+// Resolved on demand, the usual way
+@register(bindTo('IUserRepository'), singleton())
+class UserRepository {
+  findById(id: string): string {
+    return `user_${id}`;
+  }
+}
+
+describe('Auto resolve', function () {
+  function createAppContainer(): IContainer {
+    return new Container({ tags: ['application'] })
+      .useModule(new AutoResolveModule())
+      .addRegistration(R.fromClass(RequestAuditor))
+      .addRegistration(R.fromClass(UserRepository));
+  }
+
+  beforeEach(() => {
+    auditTrail.length = 0;
+  });
+
+  it('should create eager services as soon as a scope is created', function () {
+    const app = createAppContainer();
+
+    // Nothing has been created yet - the application container is not a created scope
+    expect(auditTrail).toEqual([]);
+
+    app.createScope({ tags: ['request'] });
+    app.createScope({ tags: ['request'] });
+
+    // One auditor per request scope, without anybody resolving it
+    expect(auditTrail).toEqual(['request started', 'request started']);
+  });
+
+  it('should reuse the eagerly created instance', function () {
+    const requestScope = createAppContainer().createScope({ tags: ['request'] });
+
+    const auditor = requestScope.resolve<RequestAuditor>('IRequestAuditor');
+
+    expect(auditTrail).toEqual(['request started']);
+    expect(requestScope.resolve<RequestAuditor>('IRequestAuditor')).toBe(auditor);
+  });
+
+  it('should leave other providers lazy', function () {
+    const requestScope = createAppContainer().createScope({ tags: ['request'] });
+
+    expect(requestScope.resolve<UserRepository>('IUserRepository').findById('1')).toBe('user_1');
   });
 });
 

--- a/packages/ts-ioc-container/__tests__/container/AutoResolve.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/AutoResolve.spec.ts
@@ -1,0 +1,179 @@
+import 'reflect-metadata';
+import {
+  autoResolve,
+  AutoResolveModule,
+  bindTo,
+  Container,
+  ContainerDisposedError,
+  EmptyContainer,
+  type IContainer,
+  MethodNotImplementedError,
+  register,
+  Registration as R,
+  scope,
+  scopeAccess,
+  singleton,
+} from '../../lib';
+
+describe('autoResolve', function () {
+  let constructed: string[] = [];
+
+  beforeEach(() => {
+    constructed = [];
+  });
+
+  @register(bindTo('IWorker'), autoResolve(), singleton())
+  class Worker {
+    constructor() {
+      constructed.push('Worker');
+    }
+  }
+
+  @register(bindTo('ILogger'), singleton())
+  class Logger {
+    constructor() {
+      constructed.push('Logger');
+    }
+  }
+
+  function createApp(): IContainer {
+    return new Container({ tags: ['application'] })
+      .useModule(new AutoResolveModule())
+      .addRegistration(R.fromClass(Worker))
+      .addRegistration(R.fromClass(Logger));
+  }
+
+  it('should not resolve auto-resolvable providers without the module', function () {
+    const app = new Container({ tags: ['application'] }).addRegistration(R.fromClass(Worker));
+
+    app.createScope({ tags: ['request'] });
+
+    expect(constructed).toEqual([]);
+  });
+
+  it('should resolve auto-resolvable providers when a scope is created', function () {
+    createApp().createScope({ tags: ['request'] });
+
+    expect(constructed).toEqual(['Worker']);
+  });
+
+  it('should leave providers without the pipe untouched', function () {
+    const requestScope = createApp().createScope({ tags: ['request'] });
+
+    expect(constructed).toEqual(['Worker']);
+
+    requestScope.resolve('ILogger');
+
+    expect(constructed).toEqual(['Worker', 'Logger']);
+  });
+
+  it('should reuse the eagerly created instance for later resolution', function () {
+    const requestScope = createApp().createScope({ tags: ['request'] });
+
+    const worker = requestScope.resolve<Worker>('IWorker');
+
+    expect(constructed).toEqual(['Worker']);
+    expect(requestScope.resolve<Worker>('IWorker')).toBe(worker);
+  });
+
+  it('should resolve one instance per created scope', function () {
+    const app = createApp();
+
+    const request1 = app.createScope({ tags: ['request'] });
+    const request2 = app.createScope({ tags: ['request'] });
+
+    expect(constructed).toEqual(['Worker', 'Worker']);
+    expect(request1.resolve('IWorker')).not.toBe(request2.resolve('IWorker'));
+  });
+
+  it('should be inherited by nested scopes', function () {
+    const requestScope = createApp().createScope({ tags: ['request'] });
+
+    requestScope.createScope({ tags: ['transaction'] });
+
+    expect(constructed).toEqual(['Worker', 'Worker']);
+  });
+
+  it('should skip providers which are not registered in the created scope', function () {
+    @register(bindTo('ITransactionLog'), autoResolve(), scope((s) => s.hasTag('transaction')))
+    class TransactionLog {
+      constructor() {
+        constructed.push('TransactionLog');
+      }
+    }
+
+    const app = new Container({ tags: ['application'] })
+      .useModule(new AutoResolveModule())
+      .addRegistration(R.fromClass(TransactionLog));
+
+    const requestScope = app.createScope({ tags: ['request'] });
+
+    expect(constructed).toEqual([]);
+
+    requestScope.createScope({ tags: ['transaction'] });
+
+    expect(constructed).toEqual(['TransactionLog']);
+  });
+
+  it('should skip providers which deny access to the created scope', function () {
+    @register(
+      bindTo('IAdminPanel'),
+      autoResolve(),
+      scopeAccess(({ invocationScope }) => invocationScope.hasTag('admin')),
+    )
+    class AdminPanel {
+      constructor() {
+        constructed.push('AdminPanel');
+      }
+    }
+
+    const app = new Container({ tags: ['application'] })
+      .useModule(new AutoResolveModule())
+      .addRegistration(R.fromClass(AdminPanel));
+
+    app.createScope({ tags: ['request'] });
+
+    expect(constructed).toEqual([]);
+
+    app.createScope({ tags: ['request', 'admin'] });
+
+    expect(constructed).toEqual(['AdminPanel']);
+  });
+
+  it('should not auto resolve the container the module is applied to', function () {
+    const app = createApp();
+
+    expect(constructed).toEqual([]);
+
+    expect(app.autoResolve()).toBe(app);
+    expect(constructed).toEqual(['Worker']);
+  });
+
+  it('should not resolve auto-resolvable providers twice on the same scope', function () {
+    const requestScope = createApp().createScope({ tags: ['request'] });
+
+    requestScope.autoResolve();
+
+    expect(constructed).toEqual(['Worker']);
+  });
+
+  it('should throw when the container is disposed', function () {
+    const app = createApp();
+    app.dispose();
+
+    expect(() => app.autoResolve()).toThrowError(ContainerDisposedError);
+  });
+
+  it('should stop auto resolving scopes of a disposed parent', function () {
+    const app = createApp();
+    const requestScope = app.createScope({ tags: ['request'] });
+    requestScope.dispose();
+
+    expect(() => requestScope.createScope({ tags: ['transaction'] })).toThrowError(ContainerDisposedError);
+  });
+
+  it('should not be supported by an empty container', function () {
+    expect(() => new EmptyContainer().autoResolve()).toThrowError(MethodNotImplementedError);
+    expect(() => new EmptyContainer().addOnScopeCreatedHook(() => {})).toThrowError(MethodNotImplementedError);
+  });
+});

--- a/packages/ts-ioc-container/__tests__/container/AutoResolve.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/AutoResolve.spec.ts
@@ -3,7 +3,6 @@ import {
   arg,
   autoResolve,
   AutoResolveModule,
-  bindTo,
   Container,
   ContainerDisposedError,
   EmptyContainer,
@@ -24,14 +23,14 @@ describe('autoResolve', function () {
     constructed = [];
   });
 
-  @register(bindTo('IWorker'), autoResolve(), singleton())
+  @register(autoResolve(), singleton())
   class Worker {
     constructor() {
       constructed.push('Worker');
     }
   }
 
-  @register(bindTo('ILogger'), singleton())
+  @register(singleton())
   class Logger {
     constructor() {
       constructed.push('Logger');
@@ -64,7 +63,7 @@ describe('autoResolve', function () {
 
     expect(constructed).toEqual(['Worker']);
 
-    requestScope.resolve('ILogger');
+    requestScope.resolve('Logger');
 
     expect(constructed).toEqual(['Worker', 'Logger']);
   });
@@ -72,10 +71,10 @@ describe('autoResolve', function () {
   it('should reuse the eagerly created instance for later resolution', function () {
     const requestScope = createApp().createScope({ tags: ['request'] });
 
-    const worker = requestScope.resolve<Worker>('IWorker');
+    const worker = requestScope.resolve<Worker>('Worker');
 
     expect(constructed).toEqual(['Worker']);
-    expect(requestScope.resolve<Worker>('IWorker')).toBe(worker);
+    expect(requestScope.resolve<Worker>('Worker')).toBe(worker);
   });
 
   it('should resolve one instance per created scope', function () {
@@ -85,7 +84,7 @@ describe('autoResolve', function () {
     const request2 = app.createScope({ tags: ['request'] });
 
     expect(constructed).toEqual(['Worker', 'Worker']);
-    expect(request1.resolve('IWorker')).not.toBe(request2.resolve('IWorker'));
+    expect(request1.resolve('Worker')).not.toBe(request2.resolve('Worker'));
   });
 
   it('should be inherited by nested scopes', function () {
@@ -97,7 +96,7 @@ describe('autoResolve', function () {
   });
 
   it('should skip providers which are not registered in the created scope', function () {
-    @register(bindTo('ITransactionLog'), autoResolve(), scope((s) => s.hasTag('transaction')))
+    @register(autoResolve(), scope((s) => s.hasTag('transaction')))
     class TransactionLog {
       constructor() {
         constructed.push('TransactionLog');
@@ -118,11 +117,7 @@ describe('autoResolve', function () {
   });
 
   it('should skip providers which deny access to the created scope', function () {
-    @register(
-      bindTo('IAdminPanel'),
-      autoResolve(),
-      scopeAccess(({ invocationScope }) => invocationScope.hasTag('admin')),
-    )
+    @register(autoResolve(), scopeAccess(({ invocationScope }) => invocationScope.hasTag('admin')))
     class AdminPanel {
       constructor() {
         constructed.push('AdminPanel');
@@ -180,7 +175,7 @@ describe('autoResolve', function () {
   });
 
   describe('args', function () {
-    @register(bindTo('IReporter'), autoResolve(), singleton())
+    @register(autoResolve(), singleton())
     class Reporter {
       constructor(@inject(arg(0)) readonly requestId: string = 'none') {
         constructed.push(`Reporter:${requestId}`);
@@ -193,7 +188,7 @@ describe('autoResolve', function () {
       app.autoResolve({ args: ['request-1'] });
 
       expect(constructed).toEqual(['Reporter:request-1']);
-      expect(app.resolve<Reporter>('IReporter').requestId).toBe('request-1');
+      expect(app.resolve<Reporter>('Reporter').requestId).toBe('request-1');
     });
 
     it('should forward module args to every created scope', function () {
@@ -204,7 +199,7 @@ describe('autoResolve', function () {
       const requestScope = app.createScope({ tags: ['request'] });
 
       expect(constructed).toEqual(['Reporter:request-1']);
-      expect(requestScope.resolve<Reporter>('IReporter').requestId).toBe('request-1');
+      expect(requestScope.resolve<Reporter>('Reporter').requestId).toBe('request-1');
     });
 
     it('should treat args as optional', function () {
@@ -222,7 +217,6 @@ describe('autoResolve', function () {
       const seenArgs: unknown[][] = [];
 
       @register(
-        bindTo('IAuditedReporter'),
         autoResolve(),
         scopeAccess(({ args: accessArgs }) => {
           seenArgs.push(accessArgs);
@@ -239,7 +233,7 @@ describe('autoResolve', function () {
     });
 
     it('should pass args to the singleton cache key', function () {
-      @register(bindTo('ITenantCache'), autoResolve(), singleton((tenant) => tenant as string))
+      @register(autoResolve(), singleton((tenant) => tenant as string))
       class TenantCache {
         constructor(@inject(arg(0)) readonly tenant: string) {
           constructed.push(`TenantCache:${tenant}`);

--- a/packages/ts-ioc-container/__tests__/container/AutoResolve.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/AutoResolve.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {
+  arg,
   autoResolve,
   AutoResolveModule,
   bindTo,
@@ -7,6 +8,7 @@ import {
   ContainerDisposedError,
   EmptyContainer,
   type IContainer,
+  inject,
   MethodNotImplementedError,
   register,
   Registration as R,
@@ -175,5 +177,82 @@ describe('autoResolve', function () {
   it('should not be supported by an empty container', function () {
     expect(() => new EmptyContainer().autoResolve()).toThrowError(MethodNotImplementedError);
     expect(() => new EmptyContainer().addOnScopeCreatedHook(() => {})).toThrowError(MethodNotImplementedError);
+  });
+
+  describe('args', function () {
+    @register(bindTo('IReporter'), autoResolve(), singleton())
+    class Reporter {
+      constructor(@inject(arg(0)) readonly requestId: string = 'none') {
+        constructed.push(`Reporter:${requestId}`);
+      }
+    }
+
+    it('should forward args to eagerly resolved providers', function () {
+      const app = new Container({ tags: ['application'] }).addRegistration(R.fromClass(Reporter));
+
+      app.autoResolve({ args: ['request-1'] });
+
+      expect(constructed).toEqual(['Reporter:request-1']);
+      expect(app.resolve<Reporter>('IReporter').requestId).toBe('request-1');
+    });
+
+    it('should forward module args to every created scope', function () {
+      const app = new Container({ tags: ['application'] })
+        .useModule(new AutoResolveModule({ args: ['request-1'] }))
+        .addRegistration(R.fromClass(Reporter));
+
+      const requestScope = app.createScope({ tags: ['request'] });
+
+      expect(constructed).toEqual(['Reporter:request-1']);
+      expect(requestScope.resolve<Reporter>('IReporter').requestId).toBe('request-1');
+    });
+
+    it('should treat args as optional', function () {
+      const app = new Container({ tags: ['application'] })
+        .useModule(new AutoResolveModule({}))
+        .addRegistration(R.fromClass(Reporter));
+
+      app.autoResolve();
+      app.createScope({ tags: ['request'] });
+
+      expect(constructed).toEqual(['Reporter:none', 'Reporter:none']);
+    });
+
+    it('should pass args to the scope access rule', function () {
+      const seenArgs: unknown[][] = [];
+
+      @register(
+        bindTo('IAuditedReporter'),
+        autoResolve(),
+        scopeAccess(({ args: accessArgs }) => {
+          seenArgs.push(accessArgs);
+          return true;
+        }),
+      )
+      class AuditedReporter {}
+
+      new Container({ tags: ['application'] })
+        .addRegistration(R.fromClass(AuditedReporter))
+        .autoResolve({ args: ['request-1'] });
+
+      expect(seenArgs).toEqual([['request-1']]);
+    });
+
+    it('should pass args to the singleton cache key', function () {
+      @register(bindTo('ITenantCache'), autoResolve(), singleton((tenant) => tenant as string))
+      class TenantCache {
+        constructor(@inject(arg(0)) readonly tenant: string) {
+          constructed.push(`TenantCache:${tenant}`);
+        }
+      }
+
+      const app = new Container({ tags: ['application'] }).addRegistration(R.fromClass(TenantCache));
+
+      app.autoResolve({ args: ['acme'] });
+      app.autoResolve({ args: ['acme'] });
+      app.autoResolve({ args: ['globex'] });
+
+      expect(constructed).toEqual(['TenantCache:acme', 'TenantCache:globex']);
+    });
   });
 });

--- a/packages/ts-ioc-container/__tests__/readme/autoResolve.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/autoResolve.spec.ts
@@ -1,10 +1,12 @@
 import 'reflect-metadata';
 import {
+  arg,
   autoResolve,
   AutoResolveModule,
   bindTo,
   Container,
   type IContainer,
+  inject,
   register,
   Registration as R,
   scope,
@@ -23,12 +25,21 @@ import {
  */
 
 const auditTrail: string[] = [];
+const openedLogs: string[] = [];
 
 // Started for every request, even though no other class injects it
 @register(bindTo('IRequestAuditor'), scope((s) => s.hasTag('request')), autoResolve(), singleton())
 class RequestAuditor {
   constructor() {
     auditTrail.push('request started');
+  }
+}
+
+// Eager too, but parameterized - the args come from whoever triggers eager resolution
+@register(bindTo('IRequestLog'), scope((s) => s.hasTag('request')), autoResolve())
+class RequestLog {
+  constructor(@inject(arg(0)) readonly requestId: string = 'anonymous') {
+    openedLogs.push(requestId);
   }
 }
 
@@ -41,15 +52,17 @@ class UserRepository {
 }
 
 describe('Auto resolve', function () {
-  function createAppContainer(): IContainer {
+  function createAppContainer(options: { args?: unknown[] } = {}): IContainer {
     return new Container({ tags: ['application'] })
-      .useModule(new AutoResolveModule())
+      .useModule(new AutoResolveModule(options))
       .addRegistration(R.fromClass(RequestAuditor))
+      .addRegistration(R.fromClass(RequestLog))
       .addRegistration(R.fromClass(UserRepository));
   }
 
   beforeEach(() => {
     auditTrail.length = 0;
+    openedLogs.length = 0;
   });
 
   it('should create eager services as soon as a scope is created', function () {
@@ -72,6 +85,25 @@ describe('Auto resolve', function () {
 
     expect(auditTrail).toEqual(['request started']);
     expect(requestScope.resolve<RequestAuditor>('IRequestAuditor')).toBe(auditor);
+  });
+
+  it('should treat resolve options as optional', function () {
+    createAppContainer().createScope({ tags: ['request'] });
+
+    expect(openedLogs).toEqual(['anonymous']);
+  });
+
+  it('should forward args to every eagerly resolved provider', function () {
+    // The same args reach every scope the module creates...
+    createAppContainer({ args: ['req-42'] }).createScope({ tags: ['request'] });
+
+    expect(openedLogs).toEqual(['req-42']);
+
+    // ...or pass a per-scope value by calling autoResolve yourself
+    const requestScope = createAppContainer().createScope({ tags: ['request'] });
+    requestScope.autoResolve({ args: ['req-43'] });
+
+    expect(openedLogs).toEqual(['req-42', 'anonymous', 'req-43']);
   });
 
   it('should leave other providers lazy', function () {

--- a/packages/ts-ioc-container/__tests__/readme/autoResolve.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/autoResolve.spec.ts
@@ -1,0 +1,82 @@
+import 'reflect-metadata';
+import {
+  autoResolve,
+  AutoResolveModule,
+  bindTo,
+  Container,
+  type IContainer,
+  register,
+  Registration as R,
+  scope,
+  singleton,
+} from '../../lib';
+
+/**
+ * User Management Domain - Eager Services
+ *
+ * Some services are never injected anywhere: they subscribe to a queue, start a
+ * timer, or warm a cache as soon as their scope exists. Nothing resolves them,
+ * so lazy resolution would never create them at all.
+ *
+ * `autoResolve()` marks such a provider as eager, and `AutoResolveModule`
+ * resolves every eager provider of a scope right after the scope is created.
+ */
+
+const auditTrail: string[] = [];
+
+// Started for every request, even though no other class injects it
+@register(bindTo('IRequestAuditor'), scope((s) => s.hasTag('request')), autoResolve(), singleton())
+class RequestAuditor {
+  constructor() {
+    auditTrail.push('request started');
+  }
+}
+
+// Resolved on demand, the usual way
+@register(bindTo('IUserRepository'), singleton())
+class UserRepository {
+  findById(id: string): string {
+    return `user_${id}`;
+  }
+}
+
+describe('Auto resolve', function () {
+  function createAppContainer(): IContainer {
+    return new Container({ tags: ['application'] })
+      .useModule(new AutoResolveModule())
+      .addRegistration(R.fromClass(RequestAuditor))
+      .addRegistration(R.fromClass(UserRepository));
+  }
+
+  beforeEach(() => {
+    auditTrail.length = 0;
+  });
+
+  it('should create eager services as soon as a scope is created', function () {
+    const app = createAppContainer();
+
+    // Nothing has been created yet - the application container is not a created scope
+    expect(auditTrail).toEqual([]);
+
+    app.createScope({ tags: ['request'] });
+    app.createScope({ tags: ['request'] });
+
+    // One auditor per request scope, without anybody resolving it
+    expect(auditTrail).toEqual(['request started', 'request started']);
+  });
+
+  it('should reuse the eagerly created instance', function () {
+    const requestScope = createAppContainer().createScope({ tags: ['request'] });
+
+    const auditor = requestScope.resolve<RequestAuditor>('IRequestAuditor');
+
+    expect(auditTrail).toEqual(['request started']);
+    expect(requestScope.resolve<RequestAuditor>('IRequestAuditor')).toBe(auditor);
+  });
+
+  it('should leave other providers lazy', function () {
+    const requestScope = createAppContainer().createScope({ tags: ['request'] });
+
+    expect(requestScope.resolve<UserRepository>('IUserRepository').findById('1')).toBe('user_1');
+  });
+});

--- a/packages/ts-ioc-container/__tests__/specs/container-modules.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/container-modules.spec.ts
@@ -1,6 +1,8 @@
 import 'reflect-metadata';
 import {
   AddOnConstructHookModule,
+  autoResolve,
+  AutoResolveModule,
   bindTo,
   Container,
   type IContainer,
@@ -8,6 +10,7 @@ import {
   onConstruct,
   register,
   Registration as R,
+  scopeAccess,
   singleton,
 } from '../../lib';
 
@@ -74,5 +77,46 @@ describe('Spec: container modules', () => {
     const request = app.createScope({ tags: ['request'] });
 
     expect(request.resolve<FeatureService>('FeatureService').started).toBe(true);
+  });
+
+  it('eagerly instantiates scope services through a module', () => {
+    const started: string[] = [];
+
+    @register(bindTo('IHeartbeat'), autoResolve(), singleton())
+    class Heartbeat {
+      constructor() {
+        started.push('heartbeat');
+      }
+    }
+
+    @register(
+      bindTo('IAdminConsole'),
+      autoResolve(),
+      scopeAccess(({ invocationScope }) => invocationScope.hasTag('admin')),
+    )
+    class AdminConsole {
+      constructor() {
+        started.push('admin-console');
+      }
+    }
+
+    const app = new Container({ tags: ['application'] })
+      .useModule(new AutoResolveModule())
+      .addRegistration(R.fromClass(Heartbeat))
+      .addRegistration(R.fromClass(AdminConsole));
+
+    expect(started).toEqual([]);
+
+    const request = app.createScope({ tags: ['request'] });
+
+    expect(started).toEqual(['heartbeat']);
+
+    request.createScope({ tags: ['transaction'] });
+
+    expect(started).toEqual(['heartbeat', 'heartbeat']);
+
+    app.createScope({ tags: ['request', 'admin'] });
+
+    expect(started).toEqual(['heartbeat', 'heartbeat', 'heartbeat', 'admin-console']);
   });
 });

--- a/packages/ts-ioc-container/__tests__/specs/container-modules.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/container-modules.spec.ts
@@ -82,18 +82,14 @@ describe('Spec: container modules', () => {
   it('eagerly instantiates scope services through a module', () => {
     const started: string[] = [];
 
-    @register(bindTo('IHeartbeat'), autoResolve(), singleton())
+    @register(autoResolve(), singleton())
     class Heartbeat {
       constructor() {
         started.push('heartbeat');
       }
     }
 
-    @register(
-      bindTo('IAdminConsole'),
-      autoResolve(),
-      scopeAccess(({ invocationScope }) => invocationScope.hasTag('admin')),
-    )
+    @register(autoResolve(), scopeAccess(({ invocationScope }) => invocationScope.hasTag('admin')))
     class AdminConsole {
       constructor() {
         started.push('admin-console');

--- a/packages/ts-ioc-container/__tests__/specs/provider-behavior.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/provider-behavior.spec.ts
@@ -3,6 +3,8 @@ import {
   arg,
   appendArgs,
   appendArgsFn,
+  autoResolve,
+  AutoResolveModule,
   CannonSingletonApplyTwiceError,
   Container,
   decorate,
@@ -163,6 +165,29 @@ describe('Spec: provider behavior', () => {
     expect(HeavyService.constructed).toBe(0);
     expect(service.value).toBe('ready');
     expect(HeavyService.constructed).toBe(1);
+  });
+
+  it('eagerly creates auto-resolvable providers when their scope is created', () => {
+    @register(autoResolve(), singleton())
+    class Scheduler {
+      static constructed = 0;
+
+      constructor() {
+        Scheduler.constructed += 1;
+      }
+    }
+
+    const lazyApp = new Container().addRegistration(R.fromClass(Scheduler));
+    lazyApp.createScope({ tags: ['request'] });
+
+    expect(Scheduler.constructed).toBe(0);
+
+    const eagerApp = new Container().useModule(new AutoResolveModule()).addRegistration(R.fromClass(Scheduler));
+    const request = eagerApp.createScope({ tags: ['request'] });
+
+    expect(Scheduler.constructed).toBe(1);
+    expect(request.resolve<Scheduler>('Scheduler')).toBe(request.resolve<Scheduler>('Scheduler'));
+    expect(Scheduler.constructed).toBe(1);
   });
 
   it('restricts visibility and decorates provider results through pipes', () => {

--- a/packages/ts-ioc-container/__tests__/specs/provider-behavior.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/provider-behavior.spec.ts
@@ -190,6 +190,26 @@ describe('Spec: provider behavior', () => {
     expect(Scheduler.constructed).toBe(1);
   });
 
+  it('forwards optional args to eagerly resolved providers', () => {
+    @register(autoResolve(), singleton())
+    class RequestTracer {
+      constructor(@inject(arg(0)) readonly requestId: string = 'none') {}
+    }
+
+    const app = new Container().addRegistration(R.fromClass(RequestTracer));
+
+    app.autoResolve();
+
+    expect(app.resolve<RequestTracer>('RequestTracer').requestId).toBe('none');
+
+    const traced = new Container()
+      .useModule(new AutoResolveModule({ args: ['request-1'] }))
+      .addRegistration(R.fromClass(RequestTracer))
+      .createScope({ tags: ['request'] });
+
+    expect(traced.resolve<RequestTracer>('RequestTracer').requestId).toBe('request-1');
+  });
+
   it('restricts visibility and decorates provider results through pipes', () => {
     @register(
       scopeAccess(({ invocationScope }) => invocationScope.hasTag('admin')),

--- a/packages/ts-ioc-container/lib/container/AutoResolveModule.ts
+++ b/packages/ts-ioc-container/lib/container/AutoResolveModule.ts
@@ -1,4 +1,4 @@
-import { type IContainer, type IContainerModule } from './IContainer';
+import { type AutoResolveOptions, type IContainer, type IContainerModule } from './IContainer';
 
 /**
  * Enables eager resolution of providers marked with the `autoResolve()` pipe.
@@ -8,11 +8,17 @@ import { type IContainer, type IContainerModule } from './IContainer';
  * before anyone asks for them. Child scopes inherit the behaviour, so a single
  * `useModule` call on the root covers the whole scope tree.
  *
+ * `options.args` are forwarded to every eagerly resolved provider of every such
+ * scope. Pass a per-scope value by calling `scope.autoResolve({ args })`
+ * directly instead.
+ *
  * The container the module is applied to is not a created scope — call
  * `container.autoResolve()` explicitly to eagerly resolve its own providers.
  */
 export class AutoResolveModule implements IContainerModule {
+  constructor(private readonly options: AutoResolveOptions = {}) {}
+
   applyTo(container: IContainer): void {
-    container.addOnScopeCreatedHook((scope) => scope.autoResolve());
+    container.addOnScopeCreatedHook((scope) => scope.autoResolve(this.options));
   }
 }

--- a/packages/ts-ioc-container/lib/container/AutoResolveModule.ts
+++ b/packages/ts-ioc-container/lib/container/AutoResolveModule.ts
@@ -1,0 +1,18 @@
+import { type IContainer, type IContainerModule } from './IContainer';
+
+/**
+ * Enables eager resolution of providers marked with the `autoResolve()` pipe.
+ *
+ * Every scope created after this module is applied resolves its own
+ * auto-resolvable providers as part of `createScope`, so the instances exist
+ * before anyone asks for them. Child scopes inherit the behaviour, so a single
+ * `useModule` call on the root covers the whole scope tree.
+ *
+ * The container the module is applied to is not a created scope — call
+ * `container.autoResolve()` explicitly to eagerly resolve its own providers.
+ */
+export class AutoResolveModule implements IContainerModule {
+  applyTo(container: IContainer): void {
+    container.addOnScopeCreatedHook((scope) => scope.autoResolve());
+  }
+}

--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -3,6 +3,7 @@ import {
   type DependencyKey,
   type IContainer,
   type IContainerModule,
+  type OnScopeCreatedHook,
   type RegisterOptions,
   ResolveManyOptions,
   type ResolveOneOptions,
@@ -33,6 +34,7 @@ export class Container implements IContainer {
   private readonly injector: IInjector;
   private readonly onConstructHookList: OnConstructHook[] = [];
   private readonly onDisposeHookList: OnDisposeHook[] = [];
+  private readonly onScopeCreatedHookList: OnScopeCreatedHook[] = [];
 
   constructor(
     options: {
@@ -127,14 +129,37 @@ export class Container implements IContainer {
 
     const scope = new Container({ injector: this.injector, parent: this, tags })
       .addOnConstructHook(...this.onConstructHookList)
-      .addOnDisposeHook(...this.onDisposeHookList);
+      .addOnDisposeHook(...this.onDisposeHookList)
+      .addOnScopeCreatedHook(...this.onScopeCreatedHookList);
 
     for (const registration of this.getRegistrations()) {
       registration.applyTo(scope);
     }
     this.scopes.push(scope);
 
+    // Hooks run once the scope is fully registered and attached, so they observe a usable scope.
+    for (const onScopeCreated of this.onScopeCreatedHookList) {
+      onScopeCreated(scope);
+    }
+
     return scope;
+  }
+
+  /**
+   * Eagerly resolves every provider of this scope which was marked with `autoResolve()`.
+   *
+   * @throws {ContainerDisposedError} when the container has already been disposed.
+   */
+  autoResolve(): this {
+    this.validateContainer();
+
+    for (const provider of this.providers.values()) {
+      if (provider.isAutoResolvable() && provider.hasAccess({ invocationScope: this, providerScope: this, args: [] })) {
+        provider.resolve(this, { args: [] });
+      }
+    }
+
+    return this;
   }
 
   /**
@@ -165,6 +190,7 @@ export class Container implements IContainer {
 
     // Clear hooks
     this.onConstructHookList.length = 0;
+    this.onScopeCreatedHookList.length = 0;
   }
 
   addRegistration(registration: IRegistration): this {
@@ -188,6 +214,11 @@ export class Container implements IContainer {
 
   addOnDisposeHook(...hooks: OnDisposeHook[]): this {
     this.onDisposeHookList.push(...hooks);
+    return this;
+  }
+
+  addOnScopeCreatedHook(...hooks: OnScopeCreatedHook[]): this {
+    this.onScopeCreatedHookList.push(...hooks);
     return this;
   }
 

--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -1,4 +1,5 @@
 import {
+  type AutoResolveOptions,
   type CreateScopeOptions,
   type DependencyKey,
   type IContainer,
@@ -148,14 +149,16 @@ export class Container implements IContainer {
   /**
    * Eagerly resolves every provider of this scope which was marked with `autoResolve()`.
    *
+   * `args` are forwarded to each of those providers, exactly as `resolve` forwards them.
+   *
    * @throws {ContainerDisposedError} when the container has already been disposed.
    */
-  autoResolve(): this {
+  autoResolve({ args = [] }: AutoResolveOptions = {}): this {
     this.validateContainer();
 
     for (const provider of this.providers.values()) {
-      if (provider.isAutoResolvable() && provider.hasAccess({ invocationScope: this, providerScope: this, args: [] })) {
-        provider.resolve(this, { args: [] });
+      if (provider.isAutoResolvable() && provider.hasAccess({ invocationScope: this, providerScope: this, args })) {
+        provider.resolve(this, { args });
       }
     }
 

--- a/packages/ts-ioc-container/lib/container/EmptyContainer.ts
+++ b/packages/ts-ioc-container/lib/container/EmptyContainer.ts
@@ -1,4 +1,5 @@
 import {
+  type AutoResolveOptions,
   type DependencyKey,
   type IContainer,
   type IContainerModule,
@@ -59,7 +60,7 @@ export class EmptyContainer implements IContainer {
   /**
    * @throws {MethodNotImplementedError} always — the empty container holds no providers to resolve.
    */
-  autoResolve(): this {
+  autoResolve(options?: AutoResolveOptions): this {
     throw new MethodNotImplementedError();
   }
 

--- a/packages/ts-ioc-container/lib/container/EmptyContainer.ts
+++ b/packages/ts-ioc-container/lib/container/EmptyContainer.ts
@@ -2,6 +2,7 @@ import {
   type DependencyKey,
   type IContainer,
   type IContainerModule,
+  type OnScopeCreatedHook,
   type ResolveManyOptions,
   type ResolveOneOptions,
   type Tag,
@@ -52,6 +53,13 @@ export class EmptyContainer implements IContainer {
    * @throws {MethodNotImplementedError} always — the empty container cannot create scopes.
    */
   createScope(): IContainer {
+    throw new MethodNotImplementedError();
+  }
+
+  /**
+   * @throws {MethodNotImplementedError} always — the empty container holds no providers to resolve.
+   */
+  autoResolve(): this {
     throw new MethodNotImplementedError();
   }
 
@@ -136,6 +144,13 @@ export class EmptyContainer implements IContainer {
    * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
    */
   addOnConstructHook(...hooks: OnConstructHook[]): this {
+    throw new MethodNotImplementedError();
+  }
+
+  /**
+   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
+   */
+  addOnScopeCreatedHook(...hooks: OnScopeCreatedHook[]): this {
     throw new MethodNotImplementedError();
   }
 }

--- a/packages/ts-ioc-container/lib/container/IContainer.ts
+++ b/packages/ts-ioc-container/lib/container/IContainer.ts
@@ -2,6 +2,7 @@ import { type IProvider, ProviderOptions } from '../provider/IProvider';
 import { type IRegistration } from '../registration/IRegistration';
 import { OnConstructHook } from '../hooks/onConstruct';
 import { OnDisposeHook } from '../hooks/onContainerDisposed';
+import { type WithArgs } from '../injector/IInjector';
 import { type constructor, Instance } from '../utils/basic';
 
 export type DependencyKey = string | symbol;
@@ -28,6 +29,7 @@ export interface IContainerModule {
   applyTo(container: IContainer): void;
 }
 export type CreateScopeOptions = Partial<WithTags>;
+export type AutoResolveOptions = Partial<WithArgs>;
 export type OnScopeCreatedHook = (scope: IContainer) => void;
 export type RegisterOptions = { aliases?: DependencyKey[] };
 
@@ -56,7 +58,7 @@ export interface IContainer extends Tagged {
 
   createScope(options?: CreateScopeOptions): IContainer;
 
-  autoResolve(): this;
+  autoResolve(options?: AutoResolveOptions): this;
 
   getScopes(): IContainer[];
 

--- a/packages/ts-ioc-container/lib/container/IContainer.ts
+++ b/packages/ts-ioc-container/lib/container/IContainer.ts
@@ -28,6 +28,7 @@ export interface IContainerModule {
   applyTo(container: IContainer): void;
 }
 export type CreateScopeOptions = Partial<WithTags>;
+export type OnScopeCreatedHook = (scope: IContainer) => void;
 export type RegisterOptions = { aliases?: DependencyKey[] };
 
 export interface IContainer extends Tagged {
@@ -36,6 +37,8 @@ export interface IContainer extends Tagged {
   addOnConstructHook(...hooks: OnConstructHook[]): this;
 
   addOnDisposeHook(...hooks: OnDisposeHook[]): this;
+
+  addOnScopeCreatedHook(...hooks: OnScopeCreatedHook[]): this;
 
   register(key: DependencyKey, value: IProvider, options?: RegisterOptions): this;
 
@@ -52,6 +55,8 @@ export interface IContainer extends Tagged {
   resolveOneByAlias<T>(alias: DependencyKey, options?: ResolveOneOptions): T;
 
   createScope(options?: CreateScopeOptions): IContainer;
+
+  autoResolve(): this;
 
   getScopes(): IContainer[];
 

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -9,6 +9,7 @@ export {
   type ResolveOneOptions,
   type ResolveManyOptions,
   type OnScopeCreatedHook,
+  type AutoResolveOptions,
   isDependencyKey,
 } from './container/IContainer';
 export { Container } from './container/Container';

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -8,9 +8,11 @@ export {
   type Tagged,
   type ResolveOneOptions,
   type ResolveManyOptions,
+  type OnScopeCreatedHook,
   isDependencyKey,
 } from './container/IContainer';
 export { Container } from './container/Container';
+export { AutoResolveModule } from './container/AutoResolveModule';
 export { EmptyContainer } from './container/EmptyContainer';
 
 // Injectors
@@ -43,6 +45,7 @@ export {
   scope,
   scopeAccess,
   lazy,
+  autoResolve,
   singleton,
   decorate,
   appendArgs,

--- a/packages/ts-ioc-container/lib/provider/IProvider.ts
+++ b/packages/ts-ioc-container/lib/provider/IProvider.ts
@@ -25,6 +25,10 @@ export interface IProvider<T = any> {
 
   lazy(): this;
 
+  autoResolve(): this;
+
+  isAutoResolvable(): boolean;
+
   singleton(getCacheKey?: GetCacheKey): this;
 
   dispose(): void;

--- a/packages/ts-ioc-container/lib/provider/Provider.ts
+++ b/packages/ts-ioc-container/lib/provider/Provider.ts
@@ -30,6 +30,7 @@ export class Provider<T = any> implements IProvider<T> {
   private readonly accessRules: ScopeAccessRule[] = [];
   private readonly mappers: DecorateFn<T>[] = [];
   private isLazy = false;
+  private isAutoResolve = false;
   private cache = new Map<string | symbol, unknown>();
   private getKey: GetCacheKey | undefined;
   private isDisposed: boolean = false;
@@ -78,6 +79,20 @@ export class Provider<T = any> implements IProvider<T> {
     return this;
   }
 
+  autoResolve(): this {
+    this.isAutoResolve = true;
+    return this;
+  }
+
+  /**
+   * @throws {ProviderDisposedError} when the provider has already been disposed.
+   */
+  isAutoResolvable(): boolean {
+    ProviderDisposedError.assert(!this.isDisposed, 'Provider is already disposed');
+
+    return this.isAutoResolve;
+  }
+
   addArgsFn(...fns: ArgsFn[]): this {
     this.argsFnList.push(...fns);
     return this;
@@ -107,6 +122,7 @@ export class Provider<T = any> implements IProvider<T> {
   dispose(): void {
     ProviderDisposedError.assert(!this.isDisposed, 'Provider is already disposed');
     this.isDisposed = true;
+    this.isAutoResolve = false;
     this.getKey = undefined;
     this.cache.clear();
     this.accessRules.splice(0, this.accessRules.length);

--- a/packages/ts-ioc-container/lib/registration/IRegistration.ts
+++ b/packages/ts-ioc-container/lib/registration/IRegistration.ts
@@ -77,6 +77,8 @@ export const scopeAccess = <T>(rule: ScopeAccessRule) => registerPipe<T>((p) => 
 
 export const lazy = <T>() => registerPipe<T>((p) => p.lazy());
 
+export const autoResolve = <T>() => registerPipe<T>((p) => p.autoResolve());
+
 export const decorate = (...fns: DecorateFn[]) => registerPipe((p) => p.map(...fns));
 
 export const singleton = <T = unknown>(getCacheKey?: GetCacheKey) => registerPipe<T>((p) => p.singleton(getCacheKey));

--- a/packages/ts-ioc-container/specs/epics/container-modules.md
+++ b/packages/ts-ioc-container/specs/epics/container-modules.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0007 - Lifecycle hooks via reflect-metadata and opt-in modules](../../docs/adr/0007-lifecycle-hooks.md)
-- **Public API:** `IContainerModule`, `Container.useModule`, `AddOnConstructHookModule`, `AddOnDisposeHookModule`
+- **Public API:** `IContainerModule`, `Container.useModule`, `AddOnConstructHookModule`, `AddOnDisposeHookModule`, `AutoResolveModule`, `Container.autoResolve`
 - **Executable spec:** `__tests__/specs/container-modules.spec.ts`
 
 ## Intent
@@ -50,6 +50,21 @@ Acceptance criteria:
   by the disposed scope.
 - Child scopes created after module setup inherit the lifecycle hooks configured
   on the parent.
+
+### Story: Eagerly instantiate scope services through a module
+
+As an application architect, I can opt into eager resolution through a module so
+that services marked with `autoResolve()` are created as soon as a scope exists.
+
+Acceptance criteria:
+
+- `AutoResolveModule` resolves auto-resolvable providers of every scope created
+  after the module was applied.
+- Child scopes inherit eager resolution from the scope they were created in.
+- Providers that are not registered in a created scope, or that deny access to
+  it, are skipped instead of failing scope creation.
+- The container the module is applied to is not itself a created scope; its own
+  providers are resolved eagerly only by calling `autoResolve()` on it.
 
 ## Notes
 

--- a/packages/ts-ioc-container/specs/epics/container-modules.md
+++ b/packages/ts-ioc-container/specs/epics/container-modules.md
@@ -65,6 +65,8 @@ Acceptance criteria:
   it, are skipped instead of failing scope creation.
 - The container the module is applied to is not itself a created scope; its own
   providers are resolved eagerly only by calling `autoResolve()` on it.
+- Eager resolution options are optional; when `args` are supplied they are
+  forwarded to every eagerly resolved provider of every created scope.
 
 ## Notes
 

--- a/packages/ts-ioc-container/specs/epics/provider-behavior.md
+++ b/packages/ts-ioc-container/specs/epics/provider-behavior.md
@@ -81,6 +81,8 @@ Acceptance criteria:
 - Without that module, marking a provider as auto-resolvable changes nothing.
 - Eager creation reuses the provider's own caching, so a singleton provider
   returns the eagerly created instance for later resolution.
+- Eager creation forwards optional `args` to the provider the same way ordinary
+  resolution does.
 
 ### Story: Restrict provider visibility
 

--- a/packages/ts-ioc-container/specs/epics/provider-behavior.md
+++ b/packages/ts-ioc-container/specs/epics/provider-behavior.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0004 - Pipe-based composition via ProviderPipe](../../docs/adr/0004-provider-pipe-composition.md), [ADR 0011 - Specs-driven development workflow](../../docs/adr/0011-spec-driven-development.md)
-- **Public API:** `Provider`, `IProvider`, `singleton`, `multiCache`, `appendArgs`, `appendArgsFn`, `lazy`, `scopeAccess`, `decorate`, `ProviderPipe`
+- **Public API:** `Provider`, `IProvider`, `singleton`, `multiCache`, `appendArgs`, `appendArgsFn`, `lazy`, `autoResolve`, `scopeAccess`, `decorate`, `ProviderPipe`
 - **Executable spec:** `__tests__/specs/provider-behavior.spec.ts`
 
 ## Intent
@@ -67,6 +67,20 @@ Acceptance criteria:
   accessed.
 - The underlying instance is constructed on first property or method access.
 - Repeated access uses the same constructed instance for that lazy proxy.
+
+### Story: Eagerly create a provider instance
+
+As an application developer, I can mark a provider as auto-resolvable so that
+services which work on their own — schedulers, subscribers, warm caches — exist
+without anyone injecting them first.
+
+Acceptance criteria:
+
+- An auto-resolvable provider is created when its scope is created, provided the
+  container opted into `AutoResolveModule`.
+- Without that module, marking a provider as auto-resolvable changes nothing.
+- Eager creation reuses the provider's own caching, so a singleton provider
+  returns the eagerly created instance for later resolution.
 
 ### Story: Restrict provider visibility
 


### PR DESCRIPTION
## Description

Adds eager provider resolution. Some services are never injected anywhere — they subscribe to a queue, start a timer, or warm a cache as soon as their scope exists. Lazy resolution never creates them, because nothing asks for them.

Four pieces:

- **`autoResolve()`** — a registration pipe (`registerPipe`, like `lazy()` / `singleton()`) marking a provider as eager. `IProvider` gains `autoResolve()` and `isAutoResolvable()`.
- **`IContainer.autoResolve(options?)`** — resolves this container's eager providers, skipping any that deny access to it via `scopeAccess(...)`. Returns `this`, throws `ContainerDisposedError` on a disposed container. `EmptyContainer` throws `MethodNotImplementedError`, like `register` / `useModule`.
- **`AutoResolveModule`** — opts a container in. Every scope created afterwards resolves its own eager providers as part of `createScope`, and child scopes inherit the behaviour, so one `useModule` on the root covers the whole scope tree.
- **`AutoResolveOptions { args?: unknown[] }`** — parameterizes eager resolution. Built on the `WithArgs` already exported from `IInjector.ts` rather than redeclaring the shape, matching how `CreateScopeOptions` / `InjectOptions` are derived.

The wiring is a new `addOnScopeCreatedHook` on `IContainer`, mirroring the existing construct/dispose hook lists so it propagates through `createScope` and is cleared on `dispose`. Hooks run after registrations are applied and the scope is attached, so they observe a usable scope.

Notable semantics, documented in the README and specs:

- `autoResolve()` alone does nothing — the container must opt in with `AutoResolveModule`.
- The container the module is applied to is **not** a created scope. Its own eager providers are resolved only by calling `container.autoResolve()` explicitly. This avoids an ordering trap where registrations added after `useModule(...)` would be silently missed.
- Eager resolution goes through the provider unchanged, so `singleton()` still hands back the eagerly created instance later, and providers not registered in the created scope (`scope(...)`) or denying access to it (`scopeAccess(...)`) are skipped rather than failing scope creation.
- Options and `args` are optional at every level — `autoResolve()`, `new AutoResolveModule()` and `new AutoResolveModule({})` all behave as before, since `args` defaults to `[]`. Because args travel the normal resolution path they reach `@inject(arg(0))` parameters, `scopeAccess` rules, and the `singleton(getCacheKey)` cache key. `new AutoResolveModule({ args })` applies one set of args to every scope it creates; `scope.autoResolve({ args })` covers the per-scope case.

## Type of change

- [x] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed
- [x] Tests added or updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

Follows the repo's specs workflow: stories added to `specs/epics/provider-behavior.md` (eager creation) and `specs/epics/container-modules.md` (eager instantiation through a module), with matching acceptance scenarios in `__tests__/specs/`. Focused coverage lives in `__tests__/container/AutoResolve.spec.ts` (18 cases) and the executable README example in `__tests__/readme/autoResolve.spec.ts`.

Verified locally: `pnpm test` 397 passed / 75 files, `pnpm run type-check`, `pnpm run lint:fix` (0 errors, pre-existing `no-explicit-any` warnings only), plus `pnpm run build` → `type-check:react` / `test:react` since the react package resolves the container through the workspace link.

This is a purely additive API change, but note it does widen the `IContainer` interface (`autoResolve`, `addOnScopeCreatedHook`) — any third-party implementation of `IContainer` outside this repo would need those two members. Both in-repo implementations (`Container`, `EmptyContainer`) are updated.

Both commits are scoped `feat(ts-ioc-container)`, so they collapse into a single minor bump at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JeMahZyv9CJjqgKGHGX6we