### PR TITLE
feat(ts-ioc-container): strip stray encoding artifacts from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@ node_modules
 typings
 lerna-debug.log
 yarn-error.log
-precompiledƒ
-.generatedƒ
+precompiled
+.generated
 .vscode
-.yarn/cacheƒƒƒ
+.yarn/cache
 .yarn/install-state.gz
 yarn.log
 prev-coverage-result.json


### PR DESCRIPTION
## Description

Small cleanup: a few `.gitignore` entries (`precompiled`, `.generated`, `.yarn/cache`) had a stray mangled character appended, likely from a copy/paste encoding mishap. This strips them so the patterns actually match as intended.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [x] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`) — N/A, only `.gitignore` touched
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed — N/A, no README changes
- [x] Tests added or updated under `__tests__/` to cover the change — N/A, no source behavior change
- [x] `pnpm run lint` passes — N/A, no source changes
- [x] `pnpm run type-check` passes — N/A, no source changes
- [x] `pnpm test` passes — N/A, no source changes
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope (`chore(config)` — does not trigger a release)

## Additional notes

Intentionally typed `chore` (not `feat`/`fix`/`perf`) so it does not trigger a release for either `ts-ioc-container` or `@ts-ioc-container/react`; scoped `config` per this repo's `commitlint.config.mjs` scope-enum, matching the existing `config` scope for configuration file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyW8uuxGkgU5g7LhmUqQzw