### PR TITLE
feat(ts-ioc-container): add createProxy helper with recursive target unwrapping

### DIFF
--- a/packages/ts-ioc-container/__tests__/container/IContainer.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/IContainer.spec.ts
@@ -4,6 +4,7 @@ import {
   bindTo,
   Container,
   ContainerNotFoundError,
+  createProxy,
   type IContainer,
   Provider,
   register,
@@ -93,6 +94,15 @@ describe('IContainer', function () {
       const root = new Container({ tags: ['root'] });
 
       expect(root.hasInstance(new FileLogger())).toBe(false);
+    });
+
+    it('should return true for an instance wrapped in a mediator proxy', () => {
+      const root = new Container({ tags: ['root'] });
+
+      const logger = root.resolve(FileLogger);
+      const proxy = createProxy(logger, {});
+
+      expect(root.hasInstance(proxy)).toBe(true);
     });
   });
 

--- a/packages/ts-ioc-container/__tests__/utils.spec.ts
+++ b/packages/ts-ioc-container/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
 import { pipe } from '../lib';
-import { getProxyTarget, isProxy, toLazyIf } from '../lib/utils/proxy';
+import { createProxy, getProxyTarget, isProxy, toLazyIf } from '../lib/utils/proxy';
 
 describe('fp', () => {
   it('should work with single transformation (same type)', () => {
@@ -126,5 +126,66 @@ describe('proxy', () => {
     expect(getProxyTarget(firstWrap)).toBe(target);
     expect(getProxyTarget(secondWrap)).toBe(target);
     expect(getProxyTarget(thirdWrap)).toBe(target);
+  });
+
+  describe('createProxy', () => {
+    class Sender {
+      readonly sent: string[] = [];
+
+      send(message: string): string {
+        this.sent.push(message);
+        return `sent: ${message}`;
+      }
+    }
+
+    const mediator = <T extends object>(target: T, log: string[]): T =>
+      createProxy(target, {
+        get(obj, prop, receiver) {
+          const value = Reflect.get(obj, prop, receiver);
+          if (typeof value !== 'function') {
+            return value;
+          }
+          return (...args: unknown[]) => {
+            log.push(String(prop));
+            return value.apply(obj, args);
+          };
+        },
+      });
+
+    it('should mediate calls to the target class and expose it via getProxyTarget', () => {
+      const target = new Sender();
+      const log: string[] = [];
+
+      const proxy = mediator(target, log);
+
+      expect(proxy.send('hello')).toBe('sent: hello');
+      expect(log).toEqual(['send']);
+      expect(target.sent).toEqual(['hello']);
+      expect(isProxy(proxy)).toBe(true);
+      expect(getProxyTarget(proxy)).toBe(target);
+    });
+
+    it('should unwrap the deeply nested target of stacked mediators', () => {
+      const target = new Sender();
+      const log: string[] = [];
+
+      const proxy = mediator(mediator(mediator(target, log), log), log);
+
+      expect(proxy.send('hello')).toBe('sent: hello');
+      expect(log).toEqual(['send', 'send', 'send']);
+      expect(getProxyTarget(proxy)).toBe(target);
+    });
+
+    it('should unwrap the target of a mediator wrapping a lazy proxy', () => {
+      const target = new Sender();
+      const log: string[] = [];
+
+      const proxy = mediator(
+        toLazyIf(() => target, true),
+        log,
+      );
+
+      expect(getProxyTarget(proxy)).toBe(target);
+    });
   });
 });

--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -22,12 +22,13 @@ import { OnConstructHook } from '../hooks/onConstruct';
 import { OnDisposeHook } from '../hooks/onContainerDisposed';
 import { constructor, Instance, Is } from '../utils/basic';
 import { Filter as F } from '../utils/array';
+import { unwrapProxyTarget } from '../utils/proxy';
 
 export class Container implements IContainer {
   isDisposed = false;
   private parent: IContainer;
   private scopes: IContainer[] = [];
-  private instances: Instance[] = [];
+  private readonly instances = new Set<Instance>();
   private registrations: IRegistration[] = [];
   private readonly tags: Set<Tag>;
   private readonly providers = new Map<DependencyKey, IProvider>();
@@ -188,7 +189,7 @@ export class Container implements IContainer {
     }
     this.providers.clear();
     this.aliases.destroy();
-    this.instances = [];
+    this.instances.clear();
     this.registrations = [];
 
     // Clear hooks
@@ -226,7 +227,7 @@ export class Container implements IContainer {
   }
 
   addInstance(instance: Instance) {
-    this.instances.push(instance);
+    this.instances.add(instance);
 
     // Execute onConstruct hooks
     for (const onConstruct of this.onConstructHookList) {
@@ -239,7 +240,7 @@ export class Container implements IContainer {
   }
 
   hasInstance(instance: object): boolean {
-    return this.instances.includes(instance as Instance);
+    return this.instances.has(unwrapProxyTarget(instance) as Instance);
   }
 
   /**

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -147,4 +147,5 @@ export { type ExecutionContext } from './ExecutionContext';
 // Utils
 export { select } from './select';
 export { pipe, type MapFn } from './utils/fp';
+export { createProxy, getProxyTarget, isProxy } from './utils/proxy';
 export { type constructor, type Instance, Is, resolveConstructor } from './utils/basic';

--- a/packages/ts-ioc-container/lib/utils/proxy.ts
+++ b/packages/ts-ioc-container/lib/utils/proxy.ts
@@ -4,7 +4,7 @@ type ProxyState<T extends object> = {
 
 const proxyStateMap = new WeakMap<object, ProxyState<object>>();
 
-const unwrapProxyTarget = <T extends object>(value: T): T => {
+export const unwrapProxyTarget = <T extends object>(value: T): T => {
   return isProxy(value) ? getProxyTarget(value) : value;
 };
 
@@ -13,30 +13,33 @@ export function isProxy(value: object): boolean {
 }
 
 export function getProxyTarget<T extends object>(value: T): T {
-  return proxyStateMap.get(value)!.getTarget() as T;
+  const target = proxyStateMap.get(value)!.getTarget() as T;
+  return unwrapProxyTarget(target);
+}
+
+export function createProxy<T extends object>(target: T, handler: ProxyHandler<T> = {}): T {
+  const proxy = new Proxy(target, handler);
+  proxyStateMap.set(proxy, { getTarget: () => target } as ProxyState<object>);
+  return proxy;
 }
 
 export function lazyProxy<T extends object>(resolveInstance: () => T): T {
   let instance: T | undefined;
-  const state: ProxyState<T> = {
-    getTarget: () => {
-      instance = instance ?? unwrapProxyTarget(resolveInstance());
-      return instance;
-    },
+  const getTarget = (): T => {
+    instance = instance ?? resolveInstance();
+    return instance;
   };
 
-  const proxy = new Proxy(
-    {},
-    {
-      get: (_, prop) => {
-        const target = state.getTarget();
-        // @ts-ignore
-        return target[prop];
-      },
+  const proxy = createProxy({} as T, {
+    get: (_, prop) => {
+      const target = getTarget();
+      // @ts-ignore
+      return target[prop];
     },
-  ) as T;
-
-  proxyStateMap.set(proxy, state as ProxyState<object>);
+  });
+  // the {} passed to createProxy is a placeholder; override its registration so
+  // getProxyTarget resolves the real (lazily-computed) instance instead of {}
+  proxyStateMap.set(proxy, { getTarget } as ProxyState<object>);
 
   return proxy;
 }

--- a/packages/ts-ioc-container/lib/utils/proxy.ts
+++ b/packages/ts-ioc-container/lib/utils/proxy.ts
@@ -25,21 +25,25 @@ export function createProxy<T extends object>(target: T, handler: ProxyHandler<T
 
 export function lazyProxy<T extends object>(resolveInstance: () => T): T {
   let instance: T | undefined;
-  const getTarget = (): T => {
-    instance = instance ?? resolveInstance();
-    return instance;
+  const state: ProxyState<T> = {
+    getTarget: () => {
+      instance = instance ?? unwrapProxyTarget(resolveInstance());
+      return instance;
+    },
   };
 
-  const proxy = createProxy({} as T, {
-    get: (_, prop) => {
-      const target = getTarget();
-      // @ts-ignore
-      return target[prop];
+  const proxy = new Proxy(
+    {},
+    {
+      get: (_, prop) => {
+        const target = state.getTarget();
+        // @ts-ignore
+        return target[prop];
+      },
     },
-  });
-  // the {} passed to createProxy is a placeholder; override its registration so
-  // getProxyTarget resolves the real (lazily-computed) instance instead of {}
-  proxyStateMap.set(proxy, { getTarget } as ProxyState<object>);
+  ) as T;
+
+  proxyStateMap.set(proxy, state as ProxyState<object>);
 
   return proxy;
 }


### PR DESCRIPTION
## Description

Adds a `createProxy` helper that wraps `new Proxy` and registers the proxy together with its target, so the target can always be retrieved from the proxy via `getProxyTarget`.

- `createProxy(target, handler)` — creates the proxy and records `proxy → target` in the module's `WeakMap`.
- `getProxyTarget` is now recursive: it feeds the registered target back through `unwrapProxyTarget`, so stacked proxies (mediator over mediator, mediator over a lazy proxy) resolve to the original target.
- `lazyProxy` is left untouched — it keeps its own `new Proxy` call and registration, since its target is resolved lazily and `createProxy` takes an eager target.
- `Container.hasInstance` runs its argument through `unwrapProxyTarget`, so an instance wrapped in a proxy is still recognised by its owning scope (this also fixes `getScopeByInstanceOrFail` for proxied instances). `Container.instances` is now a `Set` instead of an array.
- `createProxy`, `getProxyTarget` and `isProxy` are exported from `lib/index.ts`.

## Type of change

- [x] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed (`.readme.hbs.md` unchanged)
- [x] Tests added or updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes

## Additional notes

New tests cover a target class decorated by a mediator proxy built on `createProxy`: method calls are intercepted and forwarded to the real instance, `getProxyTarget` returns that instance, stacked mediators unwrap down to the original target, and a mediator wrapping a lazy proxy unwraps through both layers. `Container.hasInstance` is covered for a proxied instance.

`@ts-ioc-container/react` was built, type-checked and tested against these changes as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013t7CoWK4zMUisUoLidKrUk