### PR TITLE
feat(ts-ioc-container): unwrap proxies inside the library, not in consumer code

### DIFF
--- a/packages/ts-ioc-container/__tests__/container/IContainer.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/IContainer.spec.ts
@@ -95,14 +95,22 @@ describe('IContainer', function () {
       expect(root.hasInstance(new FileLogger())).toBe(false);
     });
 
-    it('should not match a proxy directly, only its unwrapped target', () => {
+    it('should match a proxy of a tracked instance - it stands for its target', () => {
       const root = new Container({ tags: ['root'] });
 
       const logger = root.resolve(FileLogger);
       const proxy = ProxyRegistry.getInstance().createProxy(logger, {});
 
-      expect(root.hasInstance(proxy)).toBe(false);
+      expect(root.hasInstance(proxy)).toBe(true);
       expect(root.hasInstance(ProxyRegistry.getInstance().unwrap(proxy))).toBe(true);
+    });
+
+    it('should match a lazy proxy once it stands for a tracked instance', () => {
+      const root = new Container({ tags: ['root'] });
+
+      const lazy = ProxyRegistry.getInstance().createLazyProxy(() => root.resolve(FileLogger));
+
+      expect(root.hasInstance(lazy)).toBe(true);
     });
   });
 });

--- a/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
+++ b/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
@@ -201,9 +201,8 @@ describe('hooks', () => {
     expect(onStartHooksRunner.hasHooks(root.resolve(MyClass))).toBe(false);
   });
 
-  // A proxy forwards `constructor` to its target, so hook metadata is found through it
-  // without unwrapping. Callers only need ProxyRegistry.unwrap where identity matters
-  // (see Container.hasInstance).
+  // Hook metadata lives on the real class, so the hook API unwraps proxies itself -
+  // a caller passes whatever the container handed it, wrapped or not.
   it('should find and run hooks through a proxy, wrapped or unwrapped', () => {
     const onStartHooksRunner = new HooksRunner('onStart');
 
@@ -223,7 +222,65 @@ describe('hooks', () => {
     expect(hasHooks(proxy, 'onStart')).toBe(true);
     expect(hasHooks(ProxyRegistry.getInstance().unwrap(proxy), 'onStart')).toBe(true);
 
-    onStartHooksRunner.execute(ProxyRegistry.getInstance().unwrap(proxy), { scope: root });
+    onStartHooksRunner.execute(proxy, { scope: root });
+
+    expect(instance.isStarted).toBe(true);
+  });
+
+  it('should run hooks on the real instance behind a lazy proxy', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+
+    class MyClass {
+      isStarted = false;
+
+      @hook('onStart', append(execute))
+      start() {
+        this.isStarted = true;
+      }
+    }
+
+    const root = new Container({ tags: ['root'] });
+    const instance = root.resolve(MyClass);
+    const lazy = ProxyRegistry.getInstance().createLazyProxy(() => instance);
+
+    expect(onStartHooksRunner.hasHooks(lazy)).toBe(true);
+
+    onStartHooksRunner.execute(lazy, {
+      scope: root,
+      // The context is built from the unwrapped instance, so hooks act on the real object.
+      mapContext: (context) => {
+        expect(context.instance).toBe(instance);
+        return context;
+      },
+    });
+
+    expect(instance.isStarted).toBe(true);
+  });
+
+  it('should run async hooks on the real instance behind a lazy proxy', async () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+
+    class MyClass {
+      isStarted = false;
+
+      @hook('onStart', append(executeAsync))
+      async start() {
+        await sleep(1);
+        this.isStarted = true;
+      }
+    }
+
+    const root = new Container({ tags: ['root'] });
+    const instance = root.resolve(MyClass);
+    const lazy = ProxyRegistry.getInstance().createLazyProxy(() => instance);
+
+    await onStartHooksRunner.executeAsync(lazy, {
+      scope: root,
+      mapContext: (context) => {
+        expect(context.instance).toBe(instance);
+        return context;
+      },
+    });
 
     expect(instance.isStarted).toBe(true);
   });

--- a/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
+++ b/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
@@ -245,14 +245,9 @@ describe('hooks', () => {
 
     expect(onStartHooksRunner.hasHooks(lazy)).toBe(true);
 
-    onStartHooksRunner.execute(lazy, {
-      scope: root,
-      // The context is built from the unwrapped instance, so hooks act on the real object.
-      mapContext: (context) => {
-        expect(context.instance).toBe(instance);
-        return context;
-      },
-    });
+    // The runner does not unwrap: the metadata lookup normalizes the target itself,
+    // and the hook reaches the real object through the proxy.
+    onStartHooksRunner.execute(lazy, { scope: root });
 
     expect(instance.isStarted).toBe(true);
   });
@@ -274,13 +269,7 @@ describe('hooks', () => {
     const instance = root.resolve(MyClass);
     const lazy = ProxyRegistry.getInstance().createLazyProxy(() => instance);
 
-    await onStartHooksRunner.executeAsync(lazy, {
-      scope: root,
-      mapContext: (context) => {
-        expect(context.instance).toBe(instance);
-        return context;
-      },
-    });
+    await onStartHooksRunner.executeAsync(lazy, { scope: root });
 
     expect(instance.isStarted).toBe(true);
   });

--- a/packages/ts-ioc-container/__tests__/injector/resolveArgs.spec.ts
+++ b/packages/ts-ioc-container/__tests__/injector/resolveArgs.spec.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata';
+import { Container, inject, ProxyRegistry, resolveArgs, Registration as R, SingleToken } from '../../lib';
+
+const GreetingToken = new SingleToken<string>('greeting');
+
+class Service {
+  constructor(@inject(GreetingToken) public greeting: string) {}
+
+  greet(@inject(GreetingToken) other?: string) {
+    return other;
+  }
+}
+
+describe('resolveArgs', () => {
+  function createContainer() {
+    return new Container().addRegistration(R.fromValue('hello').bindTo(GreetingToken));
+  }
+
+  it('accepts the constructor', () => {
+    const scope = createContainer();
+
+    expect(resolveArgs(Service)(scope, {})).toEqual(['hello']);
+  });
+
+  it('accepts an instance of that constructor', () => {
+    const scope = createContainer();
+    const instance = scope.resolve(Service);
+
+    expect(resolveArgs(instance)(scope, {})).toEqual(['hello']);
+  });
+
+  it('accepts a proxy of an instance', () => {
+    const scope = createContainer();
+    const proxy = ProxyRegistry.getInstance().createProxy(scope.resolve(Service), {});
+
+    expect(resolveArgs(proxy)(scope, {})).toEqual(['hello']);
+  });
+
+  it('accepts a lazy proxy, unwrapping it before reading metadata', () => {
+    const scope = createContainer();
+    const lazy = ProxyRegistry.getInstance().createLazyProxy(() => scope.resolve(Service));
+
+    expect(resolveArgs(lazy)(scope, {})).toEqual(['hello']);
+  });
+
+  it('reads method metadata from any of them', () => {
+    const scope = createContainer();
+    const instance = scope.resolve(Service);
+    const lazy = ProxyRegistry.getInstance().createLazyProxy(() => instance);
+
+    expect(resolveArgs(Service, 'greet')(scope, {})).toEqual(['hello']);
+    expect(resolveArgs(instance, 'greet')(scope, {})).toEqual(['hello']);
+    expect(resolveArgs(lazy, 'greet')(scope, {})).toEqual(['hello']);
+  });
+});

--- a/packages/ts-ioc-container/__tests__/injector/resolveArgs.spec.ts
+++ b/packages/ts-ioc-container/__tests__/injector/resolveArgs.spec.ts
@@ -38,6 +38,17 @@ describe('resolveArgs', () => {
     expect(resolveArgs(ProxiedService)(scope, {})).toEqual(['hello']);
   });
 
+  it('accepts an instance proxy whose handler does not forward `constructor`', () => {
+    const scope = createContainer();
+    // Reading `constructor` through a proxy only works if the handler forwards it,
+    // which a custom one need not do - so the instance is unwrapped, not read through.
+    const opaque = ProxyRegistry.getInstance().createProxy(scope.resolve(Service), {
+      get: (target, prop) => (prop === 'constructor' ? undefined : Reflect.get(target, prop)),
+    });
+
+    expect(resolveArgs(opaque)(scope, {})).toEqual(['hello']);
+  });
+
   it('accepts a proxy of an instance', () => {
     const scope = createContainer();
     const proxy = ProxyRegistry.getInstance().createProxy(scope.resolve(Service), {});

--- a/packages/ts-ioc-container/__tests__/injector/resolveArgs.spec.ts
+++ b/packages/ts-ioc-container/__tests__/injector/resolveArgs.spec.ts
@@ -29,6 +29,15 @@ describe('resolveArgs', () => {
     expect(resolveArgs(instance)(scope, {})).toEqual(['hello']);
   });
 
+  it('accepts a proxy of the constructor, unwrapping it to reach the metadata', () => {
+    const scope = createContainer();
+    // A proxied class stands in for the class itself, which is the key metadata is
+    // read from - the one case that has to be unwrapped rather than read through.
+    const ProxiedService = ProxyRegistry.getInstance().createProxy(Service, {});
+
+    expect(resolveArgs(ProxiedService)(scope, {})).toEqual(['hello']);
+  });
+
   it('accepts a proxy of an instance', () => {
     const scope = createContainer();
     const proxy = ProxyRegistry.getInstance().createProxy(scope.resolve(Service), {});

--- a/packages/ts-ioc-container/__tests__/utils.spec.ts
+++ b/packages/ts-ioc-container/__tests__/utils.spec.ts
@@ -1,5 +1,5 @@
 import { pipe } from '../lib';
-import { ProxyRegistry } from '../lib/utils/ProxyRegistry';
+import { ProxyRegistry, unwrapProxy } from '../lib/utils/ProxyRegistry';
 
 describe('fp', () => {
   it('should work with single transformation (same type)', () => {
@@ -115,6 +115,17 @@ describe('proxy', () => {
 
     // unwrapping is idempotent - the result is never itself a proxy
     expect(proxies.unwrap(proxies.unwrap(quadrupleLazyTarget))).toBe(target);
+  });
+
+  it('should expose unwrapProxy as a shortcut for the singleton', () => {
+    const target = { value: 1 };
+    const proxy = proxies.createProxy(target, {});
+    const lazyProxy = proxies.createLazyProxy(() => proxy);
+
+    expect(unwrapProxy(proxy)).toBe(target);
+    expect(unwrapProxy(lazyProxy)).toBe(target);
+    // a plain value passes through untouched
+    expect(unwrapProxy(target)).toBe(target);
   });
 
   it('should return the original target for each level of triple wrapping', () => {

--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -18,6 +18,7 @@ import { type IRegistration } from '../registration/IRegistration';
 import { ContainerDisposedError } from '../errors/ContainerDisposedError';
 import { MetadataInjector } from '../injector/MetadataInjector';
 import { AliasMap } from './AliasMap';
+import { ProxyRegistry } from '../utils/ProxyRegistry';
 import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
 import { OnDisposeHook } from '../hooks/onContainerDisposed';
 import { constructor, Instance, Is } from '../utils/basic';
@@ -239,8 +240,17 @@ export class Container implements IContainer {
     return [...this.scopes];
   }
 
+  /**
+   * Whether this scope created `instance`.
+   *
+   * A proxy stands for the object behind it, so it is unwrapped before the
+   * lookup - the container tracks real instances, and a caller asking about a
+   * proxy is asking about its target. Resolving a lazy proxy's target is what
+   * makes that answer possible, so a still-unresolved lazy proxy is resolved
+   * here.
+   */
   hasInstance(instance: Instance): boolean {
-    return this.instances.has(instance);
+    return this.instances.has(ProxyRegistry.getInstance().unwrap(instance));
   }
 
   removeScope(child: IContainer): void {

--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -18,7 +18,7 @@ import { type IRegistration } from '../registration/IRegistration';
 import { ContainerDisposedError } from '../errors/ContainerDisposedError';
 import { MetadataInjector } from '../injector/MetadataInjector';
 import { AliasMap } from './AliasMap';
-import { ProxyRegistry } from '../utils/ProxyRegistry';
+import { unwrapProxy } from '../utils/ProxyRegistry';
 import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
 import { OnDisposeHook } from '../hooks/onContainerDisposed';
 import { constructor, Instance, Is } from '../utils/basic';
@@ -250,7 +250,7 @@ export class Container implements IContainer {
    * here.
    */
   hasInstance(instance: Instance): boolean {
-    return this.instances.has(ProxyRegistry.getInstance().unwrap(instance));
+    return this.instances.has(unwrapProxy(instance));
   }
 
   removeScope(child: IContainer): void {

--- a/packages/ts-ioc-container/lib/hooks/HookContext.ts
+++ b/packages/ts-ioc-container/lib/hooks/HookContext.ts
@@ -1,7 +1,7 @@
 import type { IContainer } from '../container/IContainer';
 
 import { InjectionToken } from '../token/InjectionToken';
-import { type constructor, type Instance } from '../utils/basic';
+import { type Instance } from '../utils/basic';
 import { resolveArgs } from '../injector/MetadataInjector';
 
 export interface IHookContext {
@@ -32,7 +32,7 @@ export class HookContext implements IHookContext {
   ) {}
 
   resolveArgs(...args: unknown[]): unknown[] {
-    return resolveArgs(this.instance.constructor as constructor<unknown>, this.methodName)(this.scope, {
+    return resolveArgs(this.instance, this.methodName)(this.scope, {
       args: [...this.initialArgs, ...args],
     });
   }

--- a/packages/ts-ioc-container/lib/hooks/HooksRunner.ts
+++ b/packages/ts-ioc-container/lib/hooks/HooksRunner.ts
@@ -5,6 +5,7 @@ import { UnexpectedHookResultError } from '../errors/UnexpectedHookResultError';
 
 import { promisify } from '../utils/promise';
 import { type Instance } from '../utils/basic';
+import { ProxyRegistry } from '../utils/ProxyRegistry';
 
 export type MapHookContext = (context: IHookContext) => IHookContext;
 
@@ -15,6 +16,14 @@ export type HooksRunnerContext = {
   predicate?: (methodName: string) => boolean;
 };
 
+/**
+ * Runs the hooks a class declares under one metadata key.
+ *
+ * Every method takes the instance the container produced, which may be a proxy
+ * (a `lazy()` provider hands one out). Hook metadata lives on the real class and
+ * hooks act on the real instance, so the target is unwrapped here - callers pass
+ * whatever they hold and never unwrap it themselves.
+ */
 export class HooksRunner {
   constructor(private readonly key: string | symbol) {}
 
@@ -34,10 +43,11 @@ export class HooksRunner {
       predicate = () => true,
     }: HooksRunnerContext,
   ) {
-    const hooks = Array.from(getHooks(target, this.key).entries()).filter(([methodName]) => predicate(methodName));
+    const instance = ProxyRegistry.getInstance().unwrap(target);
+    const hooks = Array.from(getHooks(instance, this.key).entries()).filter(([methodName]) => predicate(methodName));
 
     const runMethodHooks = (methodName: string, executions: HookFn[]) => {
-      const context = mapContext(createContext(target, scope, methodName));
+      const context = mapContext(createContext(instance, scope, methodName));
       for (const execute of executions) {
         const result = execute(context);
         if (result instanceof Promise) {
@@ -60,10 +70,11 @@ export class HooksRunner {
       predicate = () => true,
     }: HooksRunnerContext,
   ) {
-    const hooks = Array.from(getHooks(target, this.key).entries()).filter(([methodName]) => predicate(methodName));
+    const instance = ProxyRegistry.getInstance().unwrap(target);
+    const hooks = Array.from(getHooks(instance, this.key).entries()).filter(([methodName]) => predicate(methodName));
 
     const runMethodHooks = async (methodName: string, executions: HookFn[]) => {
-      const context = mapContext(createContext(target, scope, methodName));
+      const context = mapContext(createContext(instance, scope, methodName));
       for (const execute of executions) {
         await promisify(execute(context));
       }

--- a/packages/ts-ioc-container/lib/hooks/HooksRunner.ts
+++ b/packages/ts-ioc-container/lib/hooks/HooksRunner.ts
@@ -15,15 +15,6 @@ export type HooksRunnerContext = {
   predicate?: (methodName: string) => boolean;
 };
 
-/**
- * Runs the hooks a class declares under one metadata key.
- *
- * Every method takes the instance the container produced, which may be a proxy
- * (a `lazy()` provider hands one out). Nothing is unwrapped here: the metadata
- * lookup normalizes the target on its own (see `resolveConstructor`), and the
- * hook context reaches the real object through the proxy. Callers pass whatever
- * they hold.
- */
 export class HooksRunner {
   constructor(private readonly key: string | symbol) {}
 

--- a/packages/ts-ioc-container/lib/hooks/HooksRunner.ts
+++ b/packages/ts-ioc-container/lib/hooks/HooksRunner.ts
@@ -5,7 +5,6 @@ import { UnexpectedHookResultError } from '../errors/UnexpectedHookResultError';
 
 import { promisify } from '../utils/promise';
 import { type Instance } from '../utils/basic';
-import { ProxyRegistry } from '../utils/ProxyRegistry';
 
 export type MapHookContext = (context: IHookContext) => IHookContext;
 
@@ -20,9 +19,10 @@ export type HooksRunnerContext = {
  * Runs the hooks a class declares under one metadata key.
  *
  * Every method takes the instance the container produced, which may be a proxy
- * (a `lazy()` provider hands one out). Hook metadata lives on the real class and
- * hooks act on the real instance, so the target is unwrapped here - callers pass
- * whatever they hold and never unwrap it themselves.
+ * (a `lazy()` provider hands one out). Nothing is unwrapped here: the metadata
+ * lookup normalizes the target on its own (see `resolveConstructor`), and the
+ * hook context reaches the real object through the proxy. Callers pass whatever
+ * they hold.
  */
 export class HooksRunner {
   constructor(private readonly key: string | symbol) {}
@@ -43,11 +43,10 @@ export class HooksRunner {
       predicate = () => true,
     }: HooksRunnerContext,
   ) {
-    const instance = ProxyRegistry.getInstance().unwrap(target);
-    const hooks = Array.from(getHooks(instance, this.key).entries()).filter(([methodName]) => predicate(methodName));
+    const hooks = Array.from(getHooks(target, this.key).entries()).filter(([methodName]) => predicate(methodName));
 
     const runMethodHooks = (methodName: string, executions: HookFn[]) => {
-      const context = mapContext(createContext(instance, scope, methodName));
+      const context = mapContext(createContext(target, scope, methodName));
       for (const execute of executions) {
         const result = execute(context);
         if (result instanceof Promise) {
@@ -70,11 +69,10 @@ export class HooksRunner {
       predicate = () => true,
     }: HooksRunnerContext,
   ) {
-    const instance = ProxyRegistry.getInstance().unwrap(target);
-    const hooks = Array.from(getHooks(instance, this.key).entries()).filter(([methodName]) => predicate(methodName));
+    const hooks = Array.from(getHooks(target, this.key).entries()).filter(([methodName]) => predicate(methodName));
 
     const runMethodHooks = async (methodName: string, executions: HookFn[]) => {
-      const context = mapContext(createContext(instance, scope, methodName));
+      const context = mapContext(createContext(target, scope, methodName));
       for (const execute of executions) {
         await promisify(execute(context));
       }

--- a/packages/ts-ioc-container/lib/hooks/hook.ts
+++ b/packages/ts-ioc-container/lib/hooks/hook.ts
@@ -1,6 +1,6 @@
 import { type IHookContext } from './HookContext';
 import type { IContainer } from '../container/IContainer';
-import { type constructor, Is, type Instance } from '../utils/basic';
+import { type constructor, Is, type Instance, resolveConstructor } from '../utils/basic';
 import { ProviderOptions } from '../provider/IProvider';
 
 export type InjectFn<T = unknown> = (s: IContainer, options: ProviderOptions) => T;
@@ -59,9 +59,12 @@ const getConstructorChain = (ctor: unknown): object[] => {
 // Get hooks metadata, merging hooks declared on parent (extended-from) classes.
 // Hooks are collected from base to derived so a derived class's hooks for the same
 // method name take precedence over (replace) the parent's.
-export function getHooks(target: Instance, key: string | symbol): HooksOfClass {
+//
+// `target` is an instance or its class, a proxy of either included - it is normalized
+// by `resolveConstructor`, so callers never have to unwrap it themselves.
+export function getHooks(target: Instance | constructor<unknown>, key: string | symbol): HooksOfClass {
   const merged: HooksOfClass = new Map();
-  for (const ctor of getConstructorChain(target.constructor).reverse()) {
+  for (const ctor of getConstructorChain(resolveConstructor(target)).reverse()) {
     const ownHooks: HooksOfClass | undefined = Reflect.getOwnMetadata(key, ctor);
     if (ownHooks) {
       for (const [methodName, fns] of ownHooks) {
@@ -72,8 +75,9 @@ export function getHooks(target: Instance, key: string | symbol): HooksOfClass {
   return merged;
 }
 
-export function hasHooks(target: Instance, key: string | symbol): boolean {
-  return getConstructorChain(target.constructor).some((ctor) => Reflect.hasOwnMetadata(key, ctor));
+// `target` is an instance or its class, a proxy of either included, see {@link getHooks}.
+export function hasHooks(target: Instance | constructor<unknown>, key: string | symbol): boolean {
+  return getConstructorChain(resolveConstructor(target)).some((ctor) => Reflect.hasOwnMetadata(key, ctor));
 }
 
 // Hook decorator

--- a/packages/ts-ioc-container/lib/hooks/hook.ts
+++ b/packages/ts-ioc-container/lib/hooks/hook.ts
@@ -1,6 +1,7 @@
 import { type IHookContext } from './HookContext';
 import type { IContainer } from '../container/IContainer';
-import { type constructor, Is, type Instance, resolveConstructor } from '../utils/basic';
+import { type constructor, Is, type Instance } from '../utils/basic';
+import { resolveConstructor } from '../metadata/target';
 import { ProviderOptions } from '../provider/IProvider';
 
 export type InjectFn<T = unknown> = (s: IContainer, options: ProviderOptions) => T;

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -112,6 +112,7 @@ export { ConstantToken } from './token/ConstantToken';
 export { type InstancePredicate, GroupInstanceToken } from './token/GroupInstanceToken';
 
 // Metadata
+export { resolveConstructor } from './metadata/target';
 export { addClassMeta, getClassMeta, addClassLabel, getClassLabels, addClassTag, getClassTags } from './metadata/class';
 export {
   addParamMeta,
@@ -142,4 +143,4 @@ export { type ExecutionContext } from './ExecutionContext';
 export { select } from './select';
 export { pipe, type MapFn } from './utils/fp';
 export { ProxyRegistry, type IProxyRegistry } from './utils/ProxyRegistry';
-export { type Branded, type constructor, type Instance, Is, resolveConstructor } from './utils/basic';
+export { type Branded, type constructor, type Instance, Is } from './utils/basic';

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -142,5 +142,5 @@ export { type ExecutionContext } from './ExecutionContext';
 // Utils
 export { select } from './select';
 export { pipe, type MapFn } from './utils/fp';
-export { ProxyRegistry, type IProxyRegistry } from './utils/ProxyRegistry';
+export { ProxyRegistry, unwrapProxy, type IProxyRegistry } from './utils/ProxyRegistry';
 export { type Branded, type constructor, type Instance, Is } from './utils/basic';

--- a/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
+++ b/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
@@ -1,6 +1,6 @@
 import { IInjector, InjectOptions, Injector } from './IInjector';
 import type { IContainer } from '../container/IContainer';
-import { type constructor, type Instance, Is } from '../utils/basic';
+import { type constructor, type Instance, resolveConstructor } from '../utils/basic';
 import { getParamMeta, addParamMeta } from '../metadata/parameter';
 import { InjectionToken } from '../token/InjectionToken';
 import { ProviderOptions } from '../provider/IProvider';
@@ -108,7 +108,7 @@ export function inject<T>(fn: Injectable<T>, ...mappers: MapFn<T>[]): ParameterD
 export function inject<T>(fn: Injectable<T>, ...mappers: MapFn<any, any>[]): ParameterDecorator {
   return (target, propertyKey, parameterIndex) => {
     addParamMeta(hookMetaKey(propertyKey as string), () => toMappedToken(fn, mappers))(
-      Is.instance(target) ? target.constructor : target,
+      resolveConstructor(target),
       propertyKey,
       parameterIndex,
     );

--- a/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
+++ b/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
@@ -1,6 +1,6 @@
 import { IInjector, InjectOptions, Injector } from './IInjector';
 import type { IContainer } from '../container/IContainer';
-import { type constructor, Is } from '../utils/basic';
+import { type constructor, type Instance, Is } from '../utils/basic';
 import { getParamMeta, addParamMeta } from '../metadata/parameter';
 import { InjectionToken } from '../token/InjectionToken';
 import { ProviderOptions } from '../provider/IProvider';
@@ -124,8 +124,15 @@ export const arg = <T = unknown>(index: number): InjectFn<T> => argsFn<T>((value
 
 export const args: InjectFn<unknown[]> = (c, { args = [] }) => args;
 
-export const resolveArgs = (Target: constructor<unknown>, methodName?: string) => {
-  const tokens = getParamMeta(hookMetaKey(methodName), Target) as InjectionToken[];
+/**
+ * Resolves the arguments annotated with `@inject` on `target`'s constructor, or on
+ * its `methodName` method.
+ *
+ * `target` is the class or any instance of it - a proxy included, since it is
+ * unwrapped on the way to the metadata (see {@link resolveConstructor}).
+ */
+export const resolveArgs = (target: constructor<unknown> | Instance, methodName?: string) => {
+  const tokens = getParamMeta(hookMetaKey(methodName), target) as InjectionToken[];
   return (scope: IContainer, { args = [], lazy }: ProviderOptions): unknown[] =>
     tokens.map((fn) => fn.resolve(scope, { args: args.map(argToToken).map((t) => t.resolve(scope)), lazy }));
 };

--- a/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
+++ b/packages/ts-ioc-container/lib/injector/MetadataInjector.ts
@@ -1,6 +1,7 @@
 import { IInjector, InjectOptions, Injector } from './IInjector';
 import type { IContainer } from '../container/IContainer';
-import { type constructor, type Instance, resolveConstructor } from '../utils/basic';
+import { type constructor, type Instance } from '../utils/basic';
+import { resolveConstructor } from '../metadata/target';
 import { getParamMeta, addParamMeta } from '../metadata/parameter';
 import { InjectionToken } from '../token/InjectionToken';
 import { ProviderOptions } from '../provider/IProvider';

--- a/packages/ts-ioc-container/lib/metadata/class.ts
+++ b/packages/ts-ioc-container/lib/metadata/class.ts
@@ -1,4 +1,4 @@
-import { resolveConstructor } from '../utils/basic';
+import { resolveConstructor } from './target';
 
 export const addClassMeta =
   <T>(key: string | symbol, mapFn: (prev: T | undefined) => T): ClassDecorator =>

--- a/packages/ts-ioc-container/lib/metadata/method.ts
+++ b/packages/ts-ioc-container/lib/metadata/method.ts
@@ -1,4 +1,4 @@
-import { resolveConstructor } from '../utils/basic';
+import { resolveConstructor } from './target';
 
 export const addMethodMeta =
   <T>(key: string, mapFn: (prev: T | undefined) => T): MethodDecorator =>

--- a/packages/ts-ioc-container/lib/metadata/parameter.ts
+++ b/packages/ts-ioc-container/lib/metadata/parameter.ts
@@ -1,4 +1,4 @@
-import { resolveConstructor } from '../utils/basic';
+import { resolveConstructor } from './target';
 
 export const addParamMeta =
   (key: string | symbol, mapFn: (prev: unknown) => unknown): ParameterDecorator =>

--- a/packages/ts-ioc-container/lib/metadata/target.ts
+++ b/packages/ts-ioc-container/lib/metadata/target.ts
@@ -1,5 +1,5 @@
 import { type constructor, Is } from '../utils/basic';
-import { ProxyRegistry } from '../utils/ProxyRegistry';
+import { unwrapProxy } from '../utils/ProxyRegistry';
 
 /**
  * The class behind `target`: `target` itself when it is already a constructor,
@@ -16,7 +16,5 @@ import { ProxyRegistry } from '../utils/ProxyRegistry';
  * class, an instance, or a proxy of either - and never unwrap by hand.
  */
 export function resolveConstructor(target: object): constructor<unknown> {
-  return Is.constructor(target)
-    ? ProxyRegistry.getInstance().unwrap(target)
-    : (target.constructor as constructor<unknown>);
+  return Is.constructor(target) ? unwrapProxy(target) : (target.constructor as constructor<unknown>);
 }

--- a/packages/ts-ioc-container/lib/metadata/target.ts
+++ b/packages/ts-ioc-container/lib/metadata/target.ts
@@ -5,13 +5,18 @@ import { ProxyRegistry } from '../utils/ProxyRegistry';
  * The class behind `target`: `target` itself when it is already a constructor,
  * otherwise the constructor of the instance.
  *
- * `target` may be a proxy (a `lazy()` provider hands one out) - it is unwrapped
- * first, because decorator metadata is defined on the real class and a proxy is
- * never that class. Every metadata read goes through here, so callers pass
- * whatever they hold - a class, an instance, or a proxy of one - and never
- * unwrap by hand.
+ * `target` may be a proxy (a `lazy()` provider hands one out), and decorator
+ * metadata is defined on the real class - a proxy is never that class. Only a
+ * proxied constructor has to be unwrapped, though: it stands in for the class
+ * itself, which is the key metadata is read from. An instance is not that key,
+ * and reading `constructor` off a proxy of one already forwards to the real
+ * class, so it needs no unwrapping.
+ *
+ * Every metadata read goes through here, so callers pass whatever they hold - a
+ * class, an instance, or a proxy of either - and never unwrap by hand.
  */
 export function resolveConstructor(target: object): constructor<unknown> {
-  const value = ProxyRegistry.getInstance().unwrap(target);
-  return Is.constructor(value) ? value : (value.constructor as constructor<unknown>);
+  return Is.constructor(target)
+    ? ProxyRegistry.getInstance().unwrap(target)
+    : (target.constructor as constructor<unknown>);
 }

--- a/packages/ts-ioc-container/lib/metadata/target.ts
+++ b/packages/ts-ioc-container/lib/metadata/target.ts
@@ -5,16 +5,17 @@ import { unwrapProxy } from '../utils/ProxyRegistry';
  * The class behind `target`: `target` itself when it is already a constructor,
  * otherwise the constructor of the instance.
  *
- * `target` may be a proxy (a `lazy()` provider hands one out), and decorator
- * metadata is defined on the real class - a proxy is never that class. Only a
- * proxied constructor has to be unwrapped, though: it stands in for the class
- * itself, which is the key metadata is read from. An instance is not that key,
- * and reading `constructor` off a proxy of one already forwards to the real
- * class, so it needs no unwrapping.
+ * `target` may be a proxy (a `lazy()` provider hands one out), and it is
+ * unwrapped before either branch, because metadata is defined on the real class
+ * and a proxy is never that class. A proxied class misses the lookup outright,
+ * standing in for the very object metadata is keyed by; a proxied instance would
+ * only answer `constructor` correctly if its handler forwards the read, which a
+ * custom one need not do.
  *
  * Every metadata read goes through here, so callers pass whatever they hold - a
  * class, an instance, or a proxy of either - and never unwrap by hand.
  */
 export function resolveConstructor(target: object): constructor<unknown> {
-  return Is.constructor(target) ? unwrapProxy(target) : (target.constructor as constructor<unknown>);
+  const value = unwrapProxy(target);
+  return Is.constructor(value) ? value : (value.constructor as constructor<unknown>);
 }

--- a/packages/ts-ioc-container/lib/metadata/target.ts
+++ b/packages/ts-ioc-container/lib/metadata/target.ts
@@ -1,4 +1,4 @@
-import { type constructor, Is } from '../utils/basic';
+import { type constructor, type Instance, Is } from '../utils/basic';
 import { unwrapProxy } from '../utils/ProxyRegistry';
 
 /**
@@ -12,10 +12,14 @@ import { unwrapProxy } from '../utils/ProxyRegistry';
  * only answer `constructor` correctly if its handler forwards the read, which a
  * custom one need not do.
  *
+ * The branch tests for a constructor rather than for an instance: `Is.instance`
+ * asks for an *own* `constructor` property, which a prototype has and an
+ * instance does not - its own `constructor` lives one level up the chain.
+ *
  * Every metadata read goes through here, so callers pass whatever they hold - a
  * class, an instance, or a proxy of either - and never unwrap by hand.
  */
-export function resolveConstructor(target: object): constructor<unknown> {
+export function resolveConstructor(target: constructor<unknown> | Instance): constructor<unknown> {
   const value = unwrapProxy(target);
   return Is.constructor(value) ? value : (value.constructor as constructor<unknown>);
 }

--- a/packages/ts-ioc-container/lib/metadata/target.ts
+++ b/packages/ts-ioc-container/lib/metadata/target.ts
@@ -1,0 +1,17 @@
+import { type constructor, Is } from '../utils/basic';
+import { ProxyRegistry } from '../utils/ProxyRegistry';
+
+/**
+ * The class behind `target`: `target` itself when it is already a constructor,
+ * otherwise the constructor of the instance.
+ *
+ * `target` may be a proxy (a `lazy()` provider hands one out) - it is unwrapped
+ * first, because decorator metadata is defined on the real class and a proxy is
+ * never that class. Every metadata read goes through here, so callers pass
+ * whatever they hold - a class, an instance, or a proxy of one - and never
+ * unwrap by hand.
+ */
+export function resolveConstructor(target: object): constructor<unknown> {
+  const value = ProxyRegistry.getInstance().unwrap(target);
+  return Is.constructor(value) ? value : (value.constructor as constructor<unknown>);
+}

--- a/packages/ts-ioc-container/lib/utils/ProxyRegistry.ts
+++ b/packages/ts-ioc-container/lib/utils/ProxyRegistry.ts
@@ -12,6 +12,13 @@ export interface IProxyRegistry {
   /**
    * Returns the real object behind `value`, unwrapping proxies stacked to any
    * depth. A value that is not a proxy is returned as is.
+   *
+   * The library calls this itself wherever a proxy would give the wrong answer -
+   * every read of class metadata (see `resolveConstructor`, `getHooks`,
+   * `resolveArgs`) and every identity check against a tracked instance (see
+   * `IContainer.hasInstance`). Pass the container's own values to those APIs as
+   * they come; unwrapping by hand is for code that needs the real object for its
+   * own reasons.
    */
   unwrap<T extends object>(value: T): T;
 

--- a/packages/ts-ioc-container/lib/utils/ProxyRegistry.ts
+++ b/packages/ts-ioc-container/lib/utils/ProxyRegistry.ts
@@ -131,3 +131,19 @@ export class ProxyRegistry implements IProxyRegistry {
     return proxy;
   }
 }
+
+/**
+ * The real object behind `value`, unwrapping proxies stacked to any depth. A
+ * value that is not a proxy is returned as is.
+ *
+ * A shortcut for `ProxyRegistry.getInstance().unwrap(value)` - the registry is a
+ * process-wide singleton, so unwrapping never needs an instance of its own. The
+ * library already unwraps wherever a proxy would give the wrong answer (reading
+ * class metadata, and `IContainer.hasInstance`), so reach for this only when
+ * your own code needs the real object - an identity check of your own, or
+ * bypassing a lazy proxy on purpose.
+ *
+ * Note that unwrapping a lazy proxy resolves its target, which is the point:
+ * there is no real object to hand back until it does.
+ */
+export const unwrapProxy = <T extends object>(value: T): T => ProxyRegistry.getInstance().unwrap(value);

--- a/packages/ts-ioc-container/lib/utils/basic.ts
+++ b/packages/ts-ioc-container/lib/utils/basic.ts
@@ -1,5 +1,3 @@
-import { ProxyRegistry } from './ProxyRegistry';
-
 export type constructor<T> = new (...args: any[]) => T;
 
 // Tags a structural type with a name, so `Instance` reads as its own type in signatures
@@ -17,17 +15,3 @@ export const Is = {
   instance: (target: unknown): target is Instance => Object.prototype.hasOwnProperty.call(target, 'constructor'),
   constructor: (target: unknown): target is constructor<unknown> => typeof target === 'function' && !!target.prototype,
 };
-
-/**
- * The class behind `target`: `target` itself when it is already a constructor,
- * otherwise the constructor of the instance.
- *
- * `target` may be a proxy (a `lazy()` provider hands one out) - it is unwrapped
- * first, because decorator metadata is defined on the real class and a proxy is
- * never that class. Every metadata read goes through here, so callers pass
- * whatever they hold - a class, an instance, or a proxy of one.
- */
-export function resolveConstructor(target: object): constructor<unknown> {
-  const value = ProxyRegistry.getInstance().unwrap(target);
-  return Is.constructor(value) ? value : (value.constructor as constructor<unknown>);
-}

--- a/packages/ts-ioc-container/lib/utils/basic.ts
+++ b/packages/ts-ioc-container/lib/utils/basic.ts
@@ -1,3 +1,5 @@
+import { ProxyRegistry } from './ProxyRegistry';
+
 export type constructor<T> = new (...args: any[]) => T;
 
 // Tags a structural type with a name, so `Instance` reads as its own type in signatures
@@ -16,6 +18,16 @@ export const Is = {
   constructor: (target: unknown): target is constructor<unknown> => typeof target === 'function' && !!target.prototype,
 };
 
-export function resolveConstructor(target: object): object {
-  return Is.constructor(target) ? target : (target as { constructor: object }).constructor;
+/**
+ * The class behind `target`: `target` itself when it is already a constructor,
+ * otherwise the constructor of the instance.
+ *
+ * `target` may be a proxy (a `lazy()` provider hands one out) - it is unwrapped
+ * first, because decorator metadata is defined on the real class and a proxy is
+ * never that class. Every metadata read goes through here, so callers pass
+ * whatever they hold - a class, an instance, or a proxy of one.
+ */
+export function resolveConstructor(target: object): constructor<unknown> {
+  const value = ProxyRegistry.getInstance().unwrap(target);
+  return Is.constructor(value) ? value : (value.constructor as constructor<unknown>);
 }

--- a/packages/ts-ioc-container/lib/utils/errorHandler.ts
+++ b/packages/ts-ioc-container/lib/utils/errorHandler.ts
@@ -1,4 +1,4 @@
-import { resolveConstructor } from './basic';
+import { resolveConstructor } from '../metadata/target';
 
 export type HandleErrorParams = (error: unknown, context: { target: string; method: string }) => void;
 

--- a/packages/ts-ioc-container/lib/utils/errorHandler.ts
+++ b/packages/ts-ioc-container/lib/utils/errorHandler.ts
@@ -1,3 +1,5 @@
+import { resolveConstructor } from './basic';
+
 export type HandleErrorParams = (error: unknown, context: { target: string; method: string }) => void;
 
 export const handleAsyncError =
@@ -8,7 +10,7 @@ export const handleAsyncError =
       try {
         return await originalMethod.apply(this, args);
       } catch (e) {
-        errorHandler(e, { target: (target as any).constructor.name, method: propertyKey as string });
+        errorHandler(e, { target: resolveConstructor(target).name, method: propertyKey as string });
       }
     };
     return descriptor;
@@ -22,7 +24,7 @@ export const handleError =
       try {
         return originalMethod.apply(this, args);
       } catch (e) {
-        errorHandler(e, { target: (target as any).constructor.name, method: propertyKey as string });
+        errorHandler(e, { target: resolveConstructor(target).name, method: propertyKey as string });
       }
     };
     return descriptor;


### PR DESCRIPTION
## Description

Reflect metadata is defined on the real class, and a proxy is never that class — so an AOP read has to look past one. Until now that was the caller's job: hold a `lazy()` instance, and you had to pass `ProxyRegistry.getInstance().unwrap(instance)` yourself or get nothing back. The same went for `hasInstance`, which compares by identity.

This moves the unwrapping into the library, at the two places that actually need it:

- **`resolveConstructor`** is the single normalization point every metadata read goes through — `getClassMeta`, `getMethodMeta`, `getParamMeta`. It unwraps before deciding what it was handed, because both shapes need it: a proxied *class* stands in for the very object metadata is keyed by, so it misses the lookup outright; a proxied *instance* would only answer `constructor` correctly while its handler forwards that read, which a custom handler need not do. One unwrap ahead of the branch covers both.
- **`Container.hasInstance`** unwraps before the identity lookup: a proxy stands for its target, so it matches when its target is tracked.

What that buys the callers:

- **`getHooks` / `hasHooks`** go through `resolveConstructor`, so they now accept an instance, its class, or a proxy of either.
- **`resolveArgs`** accepts `constructor<unknown> | Instance` — the class or any instance of it, proxies included. `HookContext.resolveArgs` now passes its instance straight through instead of reaching for `.constructor`.
- **`HooksRunner` is untouched by this branch.** Its metadata lookup normalizes the target one layer down, and the hook context reaches the real object through the proxy's own get/set traps. The lazy-proxy hook tests run end to end through the proxy, which is what shows the runner needs no change.

And for code that does need the real object for its own reasons, **`unwrapProxy(value)`** is now exported next to `ProxyRegistry` — a shortcut for `ProxyRegistry.getInstance().unwrap(value)` against what is already a process-wide singleton. It is what the library's own two unwrap sites call, so no `getInstance().unwrap(...)` remains anywhere in `lib/`.

Two supporting changes:

- `inject` and the error-handler decorators each rewrote the same class-or-instance normalization by hand; both now call `resolveConstructor`, keeping that branching in one place. Same result for every existing case — a parameter decorator's target is the class (constructor params) or the prototype (method params), and `resolveConstructor` maps both to the class exactly as before.
- `resolveConstructor` moves from `utils/basic` to `metadata/target`, next to the metadata readers that are its only reason to exist, which also keeps `utils/basic` free of a `ProxyRegistry` dependency. Same name, still exported from the package root.

Net effect: callers pass whatever the container handed them and never unwrap by hand.

## Type of change

- [x] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

Additive: the widened signatures accept everything they accepted before, `unwrapProxy` is a new export, and no existing call changes behavior. The one visible behavior change is `hasInstance(proxy)`, which now returns `true` for a proxy of a tracked instance instead of `false`.

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed — `.readme.hbs.md` untouched (the pre-commit hook regenerates regardless)
- [x] Tests added or updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes — 0 errors (37 pre-existing `no-explicit-any` warnings, two fewer than before)
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes — 79 files, 420 tests
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

- **New tests:** `__tests__/injector/resolveArgs.spec.ts` covers class / proxied-class / instance / proxied-instance / non-forwarding-proxy / lazy-proxy inputs, for both constructor and method metadata. Two of those pin the unwrap placement, each failing under a one-sided form: a proxied class fails if only instances are unwrapped, and an instance proxy whose handler returns `undefined` for `constructor` fails if only constructors are. `hook.spec.ts` gains lazy-proxy cases, sync and async, running hooks through the proxy and asserting the real instance is the one mutated. `utils.spec.ts` covers `unwrapProxy` over a plain proxy, a lazy proxy, and a non-proxy. `IContainer.spec.ts`'s proxy case flips to the new `hasInstance` contract.
- **Unwrapping a lazy proxy resolves it.** That is inherent to answering a question about the target. It is reachable via `hasInstance(lazyProxy)`, which resolves the target to answer; the hook path forces resolution too, but through the proxy rather than by unwrapping.
- **Deliberately left alone:** the metadata *write* side (`addClassMeta`, `addParamMeta`, `addMethodMeta`, the `hook` decorator). Those targets are captured at declaration time, so a proxy can never reach them. `addMethodMeta` writes via `target.constructor` while `getMethodMeta` reads via `resolveConstructor`, which disagree for a static method — a pre-existing quirk, flagged here rather than changed, since aligning it would turn inert static-method metadata into a runtime error at hook time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdwN574mD1MYhxHUv1BDmm