### PR TITLE
feat(ts-ioc-container): add the onProviderRegistered container hook

### DIFF
--- a/packages/ts-ioc-container/__tests__/container/OnProviderRegistered.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/OnProviderRegistered.spec.ts
@@ -1,0 +1,101 @@
+import {
+  Container,
+  EmptyContainer,
+  type IContainer,
+  type IProvider,
+  MethodNotImplementedError,
+  Provider,
+  Registration,
+  type DependencyKey,
+} from '../../lib';
+
+describe('onProviderRegistered', () => {
+  const record = (log: [DependencyKey, unknown][]) => (provider: IProvider, key: DependencyKey) => {
+    log.push([key, provider.resolve(new Container(), {})]);
+  };
+
+  it('should run the hook when a provider is registered', () => {
+    const log: [DependencyKey, unknown][] = [];
+
+    new Container().onProviderRegistered(record(log)).register('key', Provider.fromValue(1));
+
+    expect(log).toEqual([['key', 1]]);
+  });
+
+  it('should run every hook in the order it was added', () => {
+    const log: string[] = [];
+
+    new Container()
+      .onProviderRegistered(
+        () => log.push('first'),
+        () => log.push('second'),
+      )
+      .onProviderRegistered(() => log.push('third'))
+      .register('key', Provider.fromValue(1));
+
+    expect(log).toEqual(['first', 'second', 'third']);
+  });
+
+  it('should pass the registering scope to the hook', () => {
+    let hookScope: IContainer | undefined;
+
+    const root = new Container({ tags: ['root'] }).onProviderRegistered((_p, _k, s) => {
+      hookScope = s;
+    });
+    root.register('key', Provider.fromValue(1));
+
+    expect(hookScope).toBe(root);
+  });
+
+  it('should run the hook when a registration is added', () => {
+    const log: [DependencyKey, unknown][] = [];
+
+    new Container().onProviderRegistered(record(log)).addRegistration(Registration.fromValue(1).bindTo('key'));
+
+    expect(log).toEqual([['key', 1]]);
+  });
+
+  it('should run inherited hooks for providers cloned into a child scope', () => {
+    const log: [DependencyKey, unknown][] = [];
+
+    const root = new Container({ tags: ['root'] })
+      .onProviderRegistered(record(log))
+      .addRegistration(Registration.fromValue(1).bindTo('key'));
+    log.length = 0;
+
+    const child = root.createScope({ tags: ['child'] });
+
+    expect(log).toEqual([['key', 1]]);
+    expect(child.resolve('key')).toBe(1);
+  });
+
+  it('should not run the hook for registrations which do not match the child scope', () => {
+    const log: [DependencyKey, unknown][] = [];
+
+    const root = new Container({ tags: ['root'] }).onProviderRegistered(record(log)).addRegistration(
+      Registration.fromValue(1)
+        .bindTo('key')
+        .when((s) => s.hasTag('other')),
+    );
+    log.length = 0;
+
+    root.createScope({ tags: ['child'] });
+
+    expect(log).toEqual([]);
+  });
+
+  it('should not run hooks added to a child scope when its parent registers a provider', () => {
+    const log: [DependencyKey, unknown][] = [];
+
+    const root = new Container({ tags: ['root'] });
+    root.createScope({ tags: ['child'] }).onProviderRegistered(record(log));
+
+    root.register('key', Provider.fromValue(1));
+
+    expect(log).toEqual([]);
+  });
+
+  it('should raise an error when registering the hook on an empty container', () => {
+    expect(() => new EmptyContainer().onProviderRegistered(() => {})).toThrowError(MethodNotImplementedError);
+  });
+});

--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -5,6 +5,7 @@ import {
   type IContainer,
   type IContainerModule,
   type InstanceHook,
+  type ProviderHook,
   type RegisterOptions,
   ResolveManyOptions,
   type ResolveOneOptions,
@@ -38,6 +39,7 @@ export class Container implements IContainer {
   private readonly onConstructHookList: InstanceHook[] = [];
   private readonly onDisposeHookList: OnDisposeHook[] = [];
   private readonly onScopeCreatedHookList: ScopeHook[] = [];
+  private readonly onProviderRegisteredHookList: ProviderHook[] = [];
 
   constructor(
     options: {
@@ -58,6 +60,12 @@ export class Container implements IContainer {
     this.validateContainer();
     this.providers.set(key, provider);
     this.aliases.setAliasesByKey(key, aliases);
+
+    // Hooks run once the provider and its aliases are in place, so they observe a resolvable key.
+    for (const onProviderRegistered of this.onProviderRegisteredHookList) {
+      onProviderRegistered(provider, key, this);
+    }
+
     return this;
   }
 
@@ -133,7 +141,8 @@ export class Container implements IContainer {
     const scope = new Container({ injector: this.injector, parent: this, tags })
       .onConstruct(...this.onConstructHookList)
       .onInstanceDisposed(...this.onDisposeHookList)
-      .onScopeCreated(...this.onScopeCreatedHookList);
+      .onScopeCreated(...this.onScopeCreatedHookList)
+      .onProviderRegistered(...this.onProviderRegisteredHookList);
 
     for (const registration of this.getRegistrations()) {
       registration.applyTo(scope);
@@ -196,6 +205,7 @@ export class Container implements IContainer {
     this.onConstructHookList.length = 0;
     this.onDisposeHookList.length = 0;
     this.onScopeCreatedHookList.length = 0;
+    this.onProviderRegisteredHookList.length = 0;
   }
 
   addRegistration(registration: IRegistration): this {
@@ -224,6 +234,11 @@ export class Container implements IContainer {
 
   onScopeCreated(...hooks: ScopeHook[]): this {
     this.onScopeCreatedHookList.push(...hooks);
+    return this;
+  }
+
+  onProviderRegistered(...hooks: ProviderHook[]): this {
+    this.onProviderRegisteredHookList.push(...hooks);
     return this;
   }
 

--- a/packages/ts-ioc-container/lib/container/EmptyContainer.ts
+++ b/packages/ts-ioc-container/lib/container/EmptyContainer.ts
@@ -4,6 +4,7 @@ import {
   type IContainer,
   type IContainerModule,
   type ScopeHook,
+  type ProviderHook,
   type ResolveManyOptions,
   type ResolveOneOptions,
   type Tag,
@@ -144,6 +145,13 @@ export class EmptyContainer implements IContainer {
    * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
    */
   onScopeCreated(...hooks: ScopeHook[]): this {
+    throw new MethodNotImplementedError();
+  }
+
+  /**
+   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
+   */
+  onProviderRegistered(...hooks: ProviderHook[]): this {
     throw new MethodNotImplementedError();
   }
 }

--- a/packages/ts-ioc-container/lib/container/IContainer.ts
+++ b/packages/ts-ioc-container/lib/container/IContainer.ts
@@ -34,6 +34,7 @@ export type RegisterOptions = { aliases?: DependencyKey[] };
 export type ScopeHook = (scope: IContainer) => void;
 export type InstanceHook = (instance: Instance, scope: IContainer) => void;
 export type DependencyHook = (dependency: unknown, scope: IContainer) => void;
+export type ProviderHook = (provider: IProvider, key: DependencyKey, scope: IContainer) => void;
 
 export interface IContainer extends Tagged {
   readonly isDisposed: boolean;
@@ -43,6 +44,8 @@ export interface IContainer extends Tagged {
   onInstanceDisposed(...hooks: OnDisposeHook[]): this;
 
   onScopeCreated(...hooks: ScopeHook[]): this;
+
+  onProviderRegistered(...hooks: ProviderHook[]): this;
 
   register(key: DependencyKey, value: IProvider, options?: RegisterOptions): this;
 

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -11,6 +11,7 @@ export {
   type ScopeHook,
   type InstanceHook,
   type DependencyHook,
+  type ProviderHook,
   type AutoResolveOptions,
   isDependencyKey,
 } from './container/IContainer';


### PR DESCRIPTION
## Summary

Adds `IContainer.onProviderRegistered(...hooks: ProviderHook[]): this` — a container-level hook that observes every provider a scope takes on.

```ts
export type ProviderHook = (provider: IProvider, key: DependencyKey, scope: IContainer) => void;
```

The argument order follows the existing hook types (`InstanceHook`, `DependencyHook`): subject first, owning scope last.

## Behavior

- Fires at the end of `Container.register`, after `providers.set` and the alias write, so a listener observes an already-resolvable key.
- `addRegistration` and the registration cloning in `createScope` both funnel through `register`, so providers arriving either way are reported. Hooks are installed on a new scope *before* its registrations are applied, which is what makes the cloned providers visible.
- Inherited by child scopes, like the other container hooks; cleared in `dispose()` alongside the rest.
- `EmptyContainer.onProviderRegistered` throws `MethodNotImplementedError`, matching its other hook registrars.
- `ProviderHook` is exported from `lib/index.ts`.

## Tests

New `__tests__/container/OnProviderRegistered.spec.ts` covers: a single hook, hook ordering across calls, the scope argument's identity, `addRegistration`, cloning into a child scope, *no* fire when a registration's `when(...)` rule excludes the child scope, no leakage from a child's hooks to parent registrations, and the `EmptyContainer` error.

## Verification

`pnpm run type-check`, `pnpm run lint` (0 errors), `pnpm test` (428 passed), plus `pnpm run build` → `type-check:react` / `test:react`.

## Open question

The hook receives `(provider, key, scope)` but not the `aliases` from `RegisterOptions`. If a listener should be able to react to alias registrations, the signature needs to carry those too — happy to widen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)