### PR TITLE
feat(ts-ioc-container)!: split lifecycle hooks by the domain that raises them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,17 @@ EntityManagerToken.args(UserRepositoryToken).resolve(container);
 
 ### Hooks
 
-`@onConstruct` and `@onContainerDisposed` decorators trigger after construction / on disposal. Requires adding `OnConstructModule` / `OnDisposeModule` to the container. `@hook` is the generic base. `injectProp` enables property injection within hooks.
+`@onConstruct` and `@onContainerDisposed` decorators trigger after construction / on disposal. `@hook` is the generic base. `injectProp` enables property injection within hooks.
+
+Hooks are split by the domain that raises the event (ADR 0012) — where a hook is registered says which subsystem raises it:
+
+- **Scope** (`IContainer`): `onScopeCreated`, `onScopeDisposed` (`ScopeHook`), `onRegistered` (`RegisteredHook`)
+- **Injector** (`IInjector`): `onConstructed` (`InjectorHook`)
+- **Provider** (`IProvider`): `onResolved` (`ProviderHook`), or the `onResolve(...)` registration pipe
+
+`IContainer` has no `getInjector()` — an injector is configured and then passed in:
+`new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) })`.
+`OnConstructModule` / `OnConstructAsyncModule` are `IInjectorModule`s; `OnDisposeModule`, `OnResolvedModule` and `OnResolvedAsyncModule` are `IContainerModule`s.
 
 ### `@throws` JSDoc Convention
 

--- a/adr/0007-lifecycle-hooks.md
+++ b/adr/0007-lifecycle-hooks.md
@@ -66,8 +66,14 @@ optional exception handler instead of failing `resolve`.
 - Async construct hooks cannot block resolution, so instances that must be
   initialized before use have to expose readiness themselves.
 
+> [!NOTE]
+> This ADR covers hook *declaration*. Where the imperative hook lists live — and
+> the renames that moved them — is
+> [ADR 0012](0012-hook-domains.md).
+
 ## References
 
+- [ADR 0012 — Hook registration lives with the domain which raises the event](0012-hook-domains.md)
 - `lib/hooks/hook.ts`
 - `lib/hooks/HooksRunner.ts`
 - `lib/hooks/onConstruct.ts`

--- a/adr/0012-hook-domains.md
+++ b/adr/0012-hook-domains.md
@@ -1,0 +1,157 @@
+# ADR 0012 — Hook registration lives with the domain which raises the event
+
+- **Status:** Accepted
+- **Date:** 2026-09-08
+- **Deciders:** core maintainers
+- **Tags:** hooks, lifecycle, api-design
+
+## Context
+
+[ADR 0007](0007-lifecycle-hooks.md) established hook *declaration* — metadata on
+a class, executed by `HooksRunner`, activated by opt-in modules. It said nothing
+about where the imperative side lives: the callback lists the container
+machinery actually walks.
+
+Those lists all accumulated on `IContainer`:
+
+```typescript
+container
+  .onConstruct(...)          // an instance was constructed
+  .onInstanceDisposed(...)   // actually: this scope was disposed
+  .onScopeCreated(...)       // a child scope was created
+  .onProviderRegistered(...) // a provider entered the provider map
+```
+
+Only two of those four are the container's own events. Construction belongs to
+the injector, which is the abstraction that calls `new Target(...)`; the
+container merely forwarded to it and then fanned out hooks from `addInstance`.
+Resolution belongs to the provider, and indeed already had
+`IProvider.onResolve` — so resolve hooks were registered in a different place
+from every other hook, for no reason a reader could see from the API.
+
+The type names hid the same confusion. `InstanceHook` and `DependencyHook` were
+distinguished by the shape of their payload rather than by the domain that
+raised them, and `ProviderHook` named the *provider-registered* event, which is
+a scope event about a provider — not a hook the provider itself raises.
+`onInstanceDisposed` took a scope and ran on scope disposal, so its name
+described neither its argument nor its trigger.
+
+## Decision
+
+Register each hook on the abstraction which raises its event, and name the hook
+type after that domain. Three domains, three owners:
+
+| Domain   | Owner        | Type             | Methods                             |
+| -------- | ------------ | ---------------- | ----------------------------------- |
+| Scope    | `IContainer` | `ScopeHook`      | `onScopeCreated`, `onScopeDisposed` |
+| Scope    | `IContainer` | `RegisteredHook` | `onRegistered`                      |
+| Injector | `IInjector`  | `InjectorHook`   | `onConstructed`                     |
+| Provider | `IProvider`  | `ProviderHook`   | `onResolved`                        |
+
+Each hook type is declared in the file of the abstraction that owns it, rather
+than collected in `IContainer.ts`.
+
+### The injector is configured before the container receives it
+
+`IContainer` gets **no** `getInjector()`. A container does not expose its
+collaborators, and an injector is not something a container hands out — it is
+something a container is given. Injector hooks are therefore registered on the
+injector at construction time, before it is passed in:
+
+```typescript
+const injector = new MetadataInjector().onConstructed(runMetrics);
+const container = new Container({ injector });
+```
+
+`Container.addInstance` goes back to only tracking an instance; the abstract
+`Injector` base runs the construct hooks itself, right after handing the
+instance to the scope.
+
+### Construct modules are injector modules
+
+`OnConstructModule` and `OnConstructAsyncModule` are no longer
+`IContainerModule`s. They implement a new `IInjectorModule`
+(`applyTo(injector: IInjector)`), the exact mirror of `IContainerModule`, and
+the `Injector` base gets `useModule` for the same fluent shape the container
+has:
+
+```typescript
+const injector = new MetadataInjector().useModule(new OnConstructModule());
+const container = new Container({ injector });
+```
+
+`OnDisposeModule` stays a container module (`onScopeDisposed`), as do
+`OnResolvedModule` and `OnResolvedAsyncModule`, which reach every provider
+through `onRegistered`.
+
+`IInjector` therefore requires `onConstructed`. Injectors extending the
+`Injector` base inherit it and `useModule`; an injector implementing the
+interface from scratch owns its own hook list, or returns `this` to decline the
+domain.
+
+### Renames
+
+A clean break, with no deprecated aliases:
+
+| Before                         | After                       |
+| ------------------------------ | --------------------------- |
+| `container.onConstruct`        | `injector.onConstructed`    |
+| `container.onInstanceDisposed` | `container.onScopeDisposed` |
+| `container.onProviderRegistered` | `container.onRegistered`  |
+| `provider.onResolve`           | `provider.onResolved`       |
+| `InstanceHook`                 | `InjectorHook`              |
+| `DependencyHook`               | `ProviderHook`              |
+| `ProviderHook`                 | `RegisteredHook`            |
+| `OnDisposeHook`                | `ScopeHook` (folded in)     |
+| `ResolvedDependencyHook`       | `ResolvedObjectHook`        |
+
+`onRegistered` drops the `Provider` qualifier because registration is always of
+a provider — the name keeps only what varies, the key it registered under.
+
+The `@onConstruct`, `@onContainerDisposed` and `@onResolved` decorators, the
+hook keys they write, and the `onResolve(...)` registration pipe keep their
+names: they are declarations on a class or a registration, not domain event
+registration.
+
+## Consequences
+
+**Positive**
+
+- Where a hook is registered now tells you which subsystem raises it, and the
+  hook's type names that same subsystem.
+- `onScopeDisposed` describes both its argument and its trigger.
+- `Container` sheds a hook list, the fan-out in `addInstance`, and any accessor
+  for its injector; construct hooks live next to the code that constructs.
+- `createScope` no longer copies construct hooks into the child — the child gets
+  the same injector, so it gets the hooks by construction.
+- A custom injector can participate in the construct domain, which was
+  previously reachable only through the container.
+- Injector configuration is complete before the container exists, so there is no
+  window in which a container is live but its construct hooks are not.
+
+**Negative / trade-offs**
+
+- Breaking change for anyone calling the imperative hook API or naming the hook
+  types. A major version bump, and no alias shim to soften it.
+- Enabling construct hooks is now two statements instead of one chained
+  `useModule`, and needs the injector named explicitly — including the
+  `MetadataInjector` that used to be an invisible default.
+- Code holding only an `IContainer` cannot register construct hooks at all. That
+  is the point, but it means a container module can no longer enable them; such
+  a module has to be split into a container half and an injector half.
+- One injector backs a container and every scope created from it, so
+  `onConstructed` is tree-wide. A per-scope construct hook needs a scope check
+  inside the hook, or a separate injector for that subtree.
+- `IInjector` is no longer a single-method interface, so a from-scratch injector
+  has one more member to implement.
+
+## References
+
+- `lib/container/IContainer.ts` — `ScopeHook`, `RegisteredHook`
+- `lib/injector/IInjector.ts` — `InjectorHook`, `IInjectorModule`, `Injector.onConstructed`
+- `lib/provider/IProvider.ts` — `ProviderHook`, `IProvider.onResolved`
+- `lib/hooks/onConstruct.ts`, `lib/hooks/onConstructAsync.ts`
+- `lib/hooks/onContainerDisposed.ts`
+- `__tests__/specs/lifecycle-hooks.spec.ts`
+- [ADR 0007 — Lifecycle hooks via reflect-metadata and opt-in modules](0007-lifecycle-hooks.md)
+- [ADR 0002 — Pluggable injector strategies](0002-pluggable-injectors.md)

--- a/adr/README.md
+++ b/adr/README.md
@@ -22,6 +22,7 @@ is left intact so the historical reasoning remains discoverable.
 | 0009 | [Token taxonomy — Single / Group / Alias / Class / Function / Constant](0009-token-taxonomy.md) | Accepted |
 | 0010 | [Generated README from Handlebars source](0010-generated-readme.md)                             | Accepted |
 | 0011 | [Specs-driven development workflow](0011-spec-driven-development.md)                            | Accepted |
+| 0012 | [Hook registration lives with the domain which raises the event](0012-hook-domains.md)          | Accepted |
 
 ## Adding a new ADR
 

--- a/packages/ts-ioc-container/.readme.hbs.md
+++ b/packages/ts-ioc-container/.readme.hbs.md
@@ -54,6 +54,7 @@ provider pipelines, aliases, and custom injector strategies.
   - [Scope](#scope) `scope`
 - [Module](#module)
 - [Hook](#hook) `@hook`
+  - [Hook domains](#hook-domains) `ScopeHook` `InjectorHook` `ProviderHook`
   - [OnConstruct](#onconstruct) `@onConstruct`
   - [OnConstructAsync](#onconstructasync) `@onConstructAsync`
   - [OnContainerDisposed](#oncontainerdisposed) `@onContainerDisposed`
@@ -427,7 +428,7 @@ Sometimes you want to decorate you class with some logic. Use the `decorate(...)
 
 ### On resolve
 
-Sometimes you don't want to change the dependency, only to react to it. Use the `onResolve(...)` pipe — it appends a `DependencyHook` that receives the resolved dependency and the resolving scope.
+Sometimes you don't want to change the dependency, only to react to it. Use the `onResolve(...)` pipe — it appends a `ProviderHook` that receives the resolved dependency and the resolving scope.
 
 - `provider(onResolve((instance, scope) => tracker.track(instance)))`
 
@@ -506,6 +507,51 @@ replace the accumulated hooks.
 variadic signature and compensate for the bottom-up application order, so
 stacked decorators run in declaration order: `@onConstruct(h1) @onConstruct(h2)`
 runs `h1` before `h2`.
+
+### Hook domains
+
+The decorators above declare hook *metadata* on a class. The imperative side —
+the callbacks the container machinery runs — is registered on whichever
+abstraction raises the event, one hook type per domain:
+
+| Domain       | Registered on | Type            | Methods                                                  |
+| ------------ | ------------- | --------------- | -------------------------------------------------------- |
+| **Scope**    | `IContainer`  | `ScopeHook`     | `onScopeCreated(...)`, `onScopeDisposed(...)`            |
+| **Scope**    | `IContainer`  | `RegisteredHook`| `onRegistered(...)`                                      |
+| **Injector** | `IInjector`   | `InjectorHook`  | `onConstructed(...)`                                     |
+| **Provider** | `IProvider`   | `ProviderHook`  | `onResolved(...)`, or the [`onResolve`](#on-resolve) pipe |
+
+A container never hands its injector out — the injector is configured first and
+passed in at construction:
+
+```typescript
+// Construction is the injector's event, not a scope's
+const injector = new MetadataInjector().onConstructed((instance, scope) => metrics.built(instance, scope));
+
+const container = new Container({ injector, tags: ['application'] })
+  .onScopeCreated((scope) => audit.scopeOpened(scope))
+  .onScopeDisposed((scope) => audit.scopeClosed(scope))
+  .onRegistered((provider, key) => audit.registered(key));
+```
+
+A container passes its injector to every scope it creates, so **one injector**
+backs the whole scope tree and an `onConstructed` hook covers all of it, whenever
+it was added. Scope hooks, by contrast, are copied into a child at `createScope`
+time, so a child inherits what its parent held then and later additions to either
+stay local.
+
+The built-in modules follow the same split. `OnConstructModule` and
+`OnConstructAsyncModule` are **injector** modules (`IInjectorModule`), applied
+with `injector.useModule(...)`:
+
+```typescript
+const injector = new MetadataInjector().useModule(new OnConstructModule());
+const container = new Container({ injector });
+```
+
+`OnDisposeModule` is a container module hooking `onScopeDisposed`, and
+`OnResolvedModule` / `OnResolvedAsyncModule` are container modules reaching every
+provider through `onRegistered`.
 
 ### OnConstruct
 

--- a/packages/ts-ioc-container/README.md
+++ b/packages/ts-ioc-container/README.md
@@ -54,6 +54,7 @@ provider pipelines, aliases, and custom injector strategies.
   - [Scope](#scope) `scope`
 - [Module](#module)
 - [Hook](#hook) `@hook`
+  - [Hook domains](#hook-domains) `ScopeHook` `InjectorHook` `ProviderHook`
   - [OnConstruct](#onconstruct) `@onConstruct`
   - [OnConstructAsync](#onconstructasync) `@onConstructAsync`
   - [OnContainerDisposed](#oncontainerdisposed) `@onContainerDisposed`
@@ -2379,7 +2380,7 @@ describe('Decorator Pattern', () => {
 
 ### On resolve
 
-Sometimes you don't want to change the dependency, only to react to it. Use the `onResolve(...)` pipe — it appends a `DependencyHook` that receives the resolved dependency and the resolving scope.
+Sometimes you don't want to change the dependency, only to react to it. Use the `onResolve(...)` pipe — it appends a `ProviderHook` that receives the resolved dependency and the resolving scope.
 
 - `provider(onResolve((instance, scope) => tracker.track(instance)))`
 
@@ -2833,11 +2834,57 @@ variadic signature and compensate for the bottom-up application order, so
 stacked decorators run in declaration order: `@onConstruct(h1) @onConstruct(h2)`
 runs `h1` before `h2`.
 
+### Hook domains
+
+The decorators above declare hook *metadata* on a class. The imperative side —
+the callbacks the container machinery runs — is registered on whichever
+abstraction raises the event, one hook type per domain:
+
+| Domain       | Registered on | Type            | Methods                                                  |
+| ------------ | ------------- | --------------- | -------------------------------------------------------- |
+| **Scope**    | `IContainer`  | `ScopeHook`     | `onScopeCreated(...)`, `onScopeDisposed(...)`            |
+| **Scope**    | `IContainer`  | `RegisteredHook`| `onRegistered(...)`                                      |
+| **Injector** | `IInjector`   | `InjectorHook`  | `onConstructed(...)`                                     |
+| **Provider** | `IProvider`   | `ProviderHook`  | `onResolved(...)`, or the [`onResolve`](#on-resolve) pipe |
+
+A container never hands its injector out — the injector is configured first and
+passed in at construction:
+
+```typescript
+// Construction is the injector's event, not a scope's
+const injector = new MetadataInjector().onConstructed((instance, scope) => metrics.built(instance, scope));
+
+const container = new Container({ injector, tags: ['application'] })
+  .onScopeCreated((scope) => audit.scopeOpened(scope))
+  .onScopeDisposed((scope) => audit.scopeClosed(scope))
+  .onRegistered((provider, key) => audit.registered(key));
+```
+
+A container passes its injector to every scope it creates, so **one injector**
+backs the whole scope tree and an `onConstructed` hook covers all of it, whenever
+it was added. Scope hooks, by contrast, are copied into a child at `createScope`
+time, so a child inherits what its parent held then and later additions to either
+stay local.
+
+The built-in modules follow the same split. `OnConstructModule` and
+`OnConstructAsyncModule` are **injector** modules (`IInjectorModule`), applied
+with `injector.useModule(...)`:
+
+```typescript
+const injector = new MetadataInjector().useModule(new OnConstructModule());
+const container = new Container({ injector });
+```
+
+`OnDisposeModule` is a container module hooking `onScopeDisposed`, and
+`OnResolvedModule` / `OnResolvedAsyncModule` are container modules reaching every
+provider through `onRegistered`.
+
 ### OnConstruct
 
 ```typescript
 import 'reflect-metadata';
 import {
+  MetadataInjector,
   OnConstructModule,
   Container,
   type ExecutionContext,
@@ -2865,9 +2912,9 @@ describe('onConstruct', function () {
       }
     }
 
-    const container = new Container()
-      .useModule(new OnConstructModule())
-      .addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructModule()),
+    }).addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
 
     const db = container.resolve(DatabaseConnection);
 
@@ -2886,11 +2933,13 @@ describe('onConstruct', function () {
     }
 
     let captured: { ex: unknown; context: ExecutionContext } | undefined;
-    const container = new Container().useModule(
-      new OnConstructModule((ex, context) => {
-        captured = { ex, context };
-      }),
-    );
+    const container = new Container({
+      injector: new MetadataInjector().useModule(
+        new OnConstructModule((ex, context) => {
+          captured = { ex, context };
+        }),
+      ),
+    });
 
     expect(() => container.resolve(BrokenService)).not.toThrow();
     expect(captured?.ex).toBe(failure);
@@ -2907,7 +2956,7 @@ describe('onConstruct', function () {
       init() {}
     }
 
-    const container = new Container().useModule(new OnConstructModule());
+    const container = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) });
 
     expect(() => container.resolve(BrokenService)).toThrow(failure);
   });
@@ -2921,11 +2970,13 @@ describe('onConstruct', function () {
     }
 
     let scope: IContainer | undefined;
-    const container = new Container().useModule(
-      new OnConstructModule((_ex, context) => {
-        scope = context.scope;
-      }),
-    );
+    const container = new Container({
+      injector: new MetadataInjector().useModule(
+        new OnConstructModule((_ex, context) => {
+          scope = context.scope;
+        }),
+      ),
+    });
     const child = container.createScope();
 
     child.resolve(BrokenService);
@@ -2945,6 +2996,7 @@ is created and they settle afterwards, so `resolve` returns before they finish.
 ```typescript
 import 'reflect-metadata';
 import {
+  MetadataInjector,
   OnConstructAsyncModule,
   Container,
   type ExecutionContext,
@@ -2982,9 +3034,9 @@ describe('onConstructAsync', function () {
       }
     }
 
-    const container = new Container()
-      .useModule(new OnConstructAsyncModule())
-      .addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructAsyncModule()),
+    }).addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
 
     const db = container.resolve(DatabaseConnection);
 
@@ -3006,11 +3058,13 @@ describe('onConstructAsync', function () {
     }
 
     let captured: { ex: unknown; context: ExecutionContext } | undefined;
-    const container = new Container().useModule(
-      new OnConstructAsyncModule((ex, context) => {
-        captured = { ex, context };
-      }),
-    );
+    const container = new Container({
+      injector: new MetadataInjector().useModule(
+        new OnConstructAsyncModule((ex, context) => {
+          captured = { ex, context };
+        }),
+      ),
+    });
 
     const child = container.createScope();
     child.resolve(BrokenService);

--- a/packages/ts-ioc-container/__tests__/container/EmptyContainer.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/EmptyContainer.spec.ts
@@ -42,4 +42,8 @@ describe('EmptyContainer', () => {
       MethodNotImplementedError,
     );
   });
+
+  it('should raise an error when registering a scope disposal hook', () => {
+    expect(() => new EmptyContainer().onScopeDisposed(() => {})).toThrowError(MethodNotImplementedError);
+  });
 });

--- a/packages/ts-ioc-container/__tests__/container/IContainer.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/IContainer.spec.ts
@@ -23,7 +23,7 @@ describe('IContainer', function () {
       }
     };
 
-    const container = new Container({ tags: ['root'] }).onInstanceDisposed(onDispose);
+    const container = new Container({ tags: ['root'] }).onScopeDisposed(onDispose);
 
     container.dispose();
 

--- a/packages/ts-ioc-container/__tests__/container/OnRegistered.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/OnRegistered.spec.ts
@@ -9,7 +9,7 @@ import {
   type DependencyKey,
 } from '../../lib';
 
-describe('onProviderRegistered', () => {
+describe('onRegistered', () => {
   const record = (log: [DependencyKey, unknown][]) => (provider: IProvider, key: DependencyKey) => {
     log.push([key, provider.resolve(new Container(), {})]);
   };
@@ -17,7 +17,7 @@ describe('onProviderRegistered', () => {
   it('should run the hook when a provider is registered', () => {
     const log: [DependencyKey, unknown][] = [];
 
-    new Container().onProviderRegistered(record(log)).register('key', Provider.fromValue(1));
+    new Container().onRegistered(record(log)).register('key', Provider.fromValue(1));
 
     expect(log).toEqual([['key', 1]]);
   });
@@ -26,11 +26,11 @@ describe('onProviderRegistered', () => {
     const log: string[] = [];
 
     new Container()
-      .onProviderRegistered(
+      .onRegistered(
         () => log.push('first'),
         () => log.push('second'),
       )
-      .onProviderRegistered(() => log.push('third'))
+      .onRegistered(() => log.push('third'))
       .register('key', Provider.fromValue(1));
 
     expect(log).toEqual(['first', 'second', 'third']);
@@ -39,7 +39,7 @@ describe('onProviderRegistered', () => {
   it('should pass the registering scope to the hook', () => {
     let hookScope: IContainer | undefined;
 
-    const root = new Container({ tags: ['root'] }).onProviderRegistered((_p, _k, s) => {
+    const root = new Container({ tags: ['root'] }).onRegistered((_p, _k, s) => {
       hookScope = s;
     });
     root.register('key', Provider.fromValue(1));
@@ -50,7 +50,7 @@ describe('onProviderRegistered', () => {
   it('should run the hook when a registration is added', () => {
     const log: [DependencyKey, unknown][] = [];
 
-    new Container().onProviderRegistered(record(log)).addRegistration(Registration.fromValue(1).bindTo('key'));
+    new Container().onRegistered(record(log)).addRegistration(Registration.fromValue(1).bindTo('key'));
 
     expect(log).toEqual([['key', 1]]);
   });
@@ -59,7 +59,7 @@ describe('onProviderRegistered', () => {
     const log: [DependencyKey, unknown][] = [];
 
     const root = new Container({ tags: ['root'] })
-      .onProviderRegistered(record(log))
+      .onRegistered(record(log))
       .addRegistration(Registration.fromValue(1).bindTo('key'));
     log.length = 0;
 
@@ -72,7 +72,7 @@ describe('onProviderRegistered', () => {
   it('should not run the hook for registrations which do not match the child scope', () => {
     const log: [DependencyKey, unknown][] = [];
 
-    const root = new Container({ tags: ['root'] }).onProviderRegistered(record(log)).addRegistration(
+    const root = new Container({ tags: ['root'] }).onRegistered(record(log)).addRegistration(
       Registration.fromValue(1)
         .bindTo('key')
         .when((s) => s.hasTag('other')),
@@ -88,7 +88,7 @@ describe('onProviderRegistered', () => {
     const log: [DependencyKey, unknown][] = [];
 
     const root = new Container({ tags: ['root'] });
-    root.createScope({ tags: ['child'] }).onProviderRegistered(record(log));
+    root.createScope({ tags: ['child'] }).onRegistered(record(log));
 
     root.register('key', Provider.fromValue(1));
 
@@ -96,6 +96,6 @@ describe('onProviderRegistered', () => {
   });
 
   it('should raise an error when registering the hook on an empty container', () => {
-    expect(() => new EmptyContainer().onProviderRegistered(() => {})).toThrowError(MethodNotImplementedError);
+    expect(() => new EmptyContainer().onRegistered(() => {})).toThrowError(MethodNotImplementedError);
   });
 });

--- a/packages/ts-ioc-container/__tests__/metadata/combined.spec.ts
+++ b/packages/ts-ioc-container/__tests__/metadata/combined.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
 import {
+  MetadataInjector,
   once,
   throttle,
   shallowCache,
@@ -34,7 +35,7 @@ describe('@onConstruct + method decorators', () => {
       }
     }
 
-    const container = new Container().useModule(new OnConstructModule());
+    const container = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) });
     const s = container.resolve(Service);
 
     expect(s.initialized).toBe(true);
@@ -59,7 +60,7 @@ describe('@onConstruct + method decorators', () => {
       }
     }
 
-    const container = new Container().useModule(new OnConstructModule());
+    const container = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) });
     container.resolve(Service);
 
     expect(calls).toEqual(['ran']); // hook fired, throttle allowed it
@@ -85,7 +86,7 @@ describe('@onConstruct + method decorators', () => {
       }
     }
 
-    const container = new Container().useModule(new OnConstructModule());
+    const container = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) });
     // onConstruct calls compute() with no args (x = undefined)
     const s = container.resolve(Service);
 
@@ -112,7 +113,7 @@ describe('@onConstruct + method decorators', () => {
       }
     }
 
-    const container = new Container().useModule(new OnConstructModule());
+    const container = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) });
 
     // Resolving should not propagate the error because @handleError catches it
     expect(() => container.resolve(Service)).not.toThrow();
@@ -133,7 +134,7 @@ describe('@onConstruct + method decorators', () => {
       }
     }
 
-    const container = new Container().useModule(new OnConstructModule());
+    const container = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) });
     container.resolve(Service);
 
     expect(fn).not.toHaveBeenCalled(); // debounce deferred it

--- a/packages/ts-ioc-container/__tests__/readme/customHooks.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/customHooks.spec.ts
@@ -1,4 +1,4 @@
-import { append, Container, hook, HooksRunner, type HookFn } from '../../lib';
+import { append, Container, hook, HooksRunner, MetadataInjector, type HookFn } from '../../lib';
 
 /**
  * User Management Domain - Custom Lifecycle Hooks
@@ -15,7 +15,7 @@ import { append, Container, hook, HooksRunner, type HookFn } from '../../lib';
  * How it works:
  * 1. Define a HooksRunner with a unique hook name
  * 2. Create methods decorated with @hook('hookName', append(executor))
- * 3. Register the hook runner via onConstruct
+ * 3. Register the hook runner on an injector via onConstructed, then pass it to the container
  * 4. Methods are automatically called when instances are created
  */
 
@@ -39,10 +39,13 @@ describe('Custom Hooks', () => {
       }
     }
 
-    const container = new Container({ tags: ['application'] }).onConstruct((instance, scope) => {
+    // Construction is the injector's event, so custom construct hooks go on the injector
+    const injector = new MetadataInjector().onConstructed((instance, scope) => {
       // Run all 'initialize' hooks on newly created instances
       initializeHookRunner.execute(instance, { scope });
     });
+
+    const container = new Container({ injector, tags: ['application'] });
 
     const cacheService = container.resolve(CacheService);
 

--- a/packages/ts-ioc-container/__tests__/readme/onConstruct.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/onConstruct.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {
+  MetadataInjector,
   OnConstructModule,
   Container,
   type ExecutionContext,
@@ -27,9 +28,9 @@ describe('onConstruct', function () {
       }
     }
 
-    const container = new Container()
-      .useModule(new OnConstructModule())
-      .addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructModule()),
+    }).addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
 
     const db = container.resolve(DatabaseConnection);
 
@@ -48,11 +49,13 @@ describe('onConstruct', function () {
     }
 
     let captured: { ex: unknown; context: ExecutionContext } | undefined;
-    const container = new Container().useModule(
-      new OnConstructModule((ex, context) => {
-        captured = { ex, context };
-      }),
-    );
+    const container = new Container({
+      injector: new MetadataInjector().useModule(
+        new OnConstructModule((ex, context) => {
+          captured = { ex, context };
+        }),
+      ),
+    });
 
     expect(() => container.resolve(BrokenService)).not.toThrow();
     expect(captured?.ex).toBe(failure);
@@ -69,7 +72,7 @@ describe('onConstruct', function () {
       init() {}
     }
 
-    const container = new Container().useModule(new OnConstructModule());
+    const container = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) });
 
     expect(() => container.resolve(BrokenService)).toThrow(failure);
   });
@@ -83,11 +86,13 @@ describe('onConstruct', function () {
     }
 
     let scope: IContainer | undefined;
-    const container = new Container().useModule(
-      new OnConstructModule((_ex, context) => {
-        scope = context.scope;
-      }),
-    );
+    const container = new Container({
+      injector: new MetadataInjector().useModule(
+        new OnConstructModule((_ex, context) => {
+          scope = context.scope;
+        }),
+      ),
+    });
     const child = container.createScope();
 
     child.resolve(BrokenService);

--- a/packages/ts-ioc-container/__tests__/readme/onConstructAsync.spec.ts
+++ b/packages/ts-ioc-container/__tests__/readme/onConstructAsync.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {
+  MetadataInjector,
   OnConstructAsyncModule,
   Container,
   type ExecutionContext,
@@ -37,9 +38,9 @@ describe('onConstructAsync', function () {
       }
     }
 
-    const container = new Container()
-      .useModule(new OnConstructAsyncModule())
-      .addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructAsyncModule()),
+    }).addRegistration(R.fromValue('postgres://localhost:5432').bindTo('ConnectionString'));
 
     const db = container.resolve(DatabaseConnection);
 
@@ -61,11 +62,13 @@ describe('onConstructAsync', function () {
     }
 
     let captured: { ex: unknown; context: ExecutionContext } | undefined;
-    const container = new Container().useModule(
-      new OnConstructAsyncModule((ex, context) => {
-        captured = { ex, context };
-      }),
-    );
+    const container = new Container({
+      injector: new MetadataInjector().useModule(
+        new OnConstructAsyncModule((ex, context) => {
+          captured = { ex, context };
+        }),
+      ),
+    });
 
     const child = container.createScope();
     child.resolve(BrokenService);

--- a/packages/ts-ioc-container/__tests__/specs/container-modules.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/container-modules.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {
+  MetadataInjector,
   OnConstructModule,
   autoResolve,
   AutoResolveModule,
@@ -73,7 +74,9 @@ describe('Spec: container modules', () => {
       }
     }
 
-    const app = new Container().useModule(new OnConstructModule()).addRegistration(R.fromClass(FeatureService));
+    const app = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) }).addRegistration(
+      R.fromClass(FeatureService),
+    );
     const request = app.createScope({ tags: ['request'] });
 
     expect(request.resolve<FeatureService>('FeatureService').started).toBe(true);

--- a/packages/ts-ioc-container/__tests__/specs/injector-strategies.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/injector-strategies.spec.ts
@@ -135,6 +135,12 @@ describe('Spec: injector strategies', () => {
         container.addInstance(instance as never);
         return instance;
       }
+
+      // Construct hooks are the injector's domain, so a from-scratch injector
+      // either keeps its own list or, as here, declines to raise them.
+      onConstructed(): this {
+        return this;
+      }
     }
 
     const container = new Container({ injector: new StaticFactoryInjector() }).addRegistration(R.fromClass(Service));

--- a/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import {
+  MetadataInjector,
   OnConstructAsyncModule,
   OnConstructModule,
   OnDisposeModule,
@@ -18,6 +19,7 @@ import {
   onContainerDisposed,
   onResolved,
   onceResolved,
+  onResolve,
   Registration as R,
   UnexpectedHookResultError,
 } from '../../lib';
@@ -43,8 +45,7 @@ describe('Spec: lifecycle hooks', () => {
       }
     }
 
-    const container = new Container()
-      .useModule(new OnConstructModule())
+    const container = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) })
       .useModule(new OnDisposeModule())
       .addRegistration(R.fromClass(Resource));
 
@@ -100,7 +101,9 @@ describe('Spec: lifecycle hooks', () => {
       initialize(): void {}
     }
 
-    const container = new Container().useModule(new OnConstructModule()).addRegistration(R.fromClass(Resource));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructModule()),
+    }).addRegistration(R.fromClass(Resource));
 
     container.resolve<Resource>('Resource');
 
@@ -122,7 +125,9 @@ describe('Spec: lifecycle hooks', () => {
       initialize(): void {}
     }
 
-    const container = new Container().useModule(new OnConstructModule()).addRegistration(R.fromClass(Resource));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructModule()),
+    }).addRegistration(R.fromClass(Resource));
 
     container.resolve<Resource>('Resource');
 
@@ -143,7 +148,9 @@ describe('Spec: lifecycle hooks', () => {
       initialize(): void {}
     }
 
-    const container = new Container().useModule(new OnConstructModule()).addRegistration(R.fromClass(Resource));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructModule()),
+    }).addRegistration(R.fromClass(Resource));
 
     container.resolve<Resource>('Resource');
 
@@ -184,7 +191,9 @@ describe('Spec: lifecycle hooks', () => {
       async initialize(): Promise<void> {}
     }
 
-    const container = new Container().useModule(new OnConstructAsyncModule()).addRegistration(R.fromClass(Resource));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructAsyncModule()),
+    }).addRegistration(R.fromClass(Resource));
 
     container.resolve<Resource>('Resource');
 
@@ -204,7 +213,9 @@ describe('Spec: lifecycle hooks', () => {
       }
     }
 
-    const container = new Container().useModule(new OnConstructAsyncModule()).addRegistration(R.fromClass(Resource));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructAsyncModule()),
+    }).addRegistration(R.fromClass(Resource));
 
     const resource = container.resolve<Resource>('Resource');
 
@@ -222,9 +233,9 @@ describe('Spec: lifecycle hooks', () => {
     }
 
     let captured: unknown;
-    const container = new Container()
-      .useModule(new OnConstructAsyncModule((ex) => (captured = ex)))
-      .addRegistration(R.fromClass(BrokenResource));
+    const container = new Container({
+      injector: new MetadataInjector().useModule(new OnConstructAsyncModule((ex) => (captured = ex))),
+    }).addRegistration(R.fromClass(BrokenResource));
 
     container.resolve<BrokenResource>('BrokenResource');
 
@@ -241,8 +252,7 @@ describe('Spec: lifecycle hooks', () => {
       logger!: Logger;
     }
 
-    const container = new Container()
-      .useModule(new OnConstructModule())
+    const container = new Container({ injector: new MetadataInjector().useModule(new OnConstructModule()) })
       .addRegistration(R.fromClass(Logger))
       .addRegistration(R.fromClass(Service));
 
@@ -283,16 +293,72 @@ describe('Spec: lifecycle hooks', () => {
     expect(worker.calls).toEqual(['start']);
   });
 
-  it('runs direct disposal callbacks registered with onDispose', () => {
+  it('runs direct disposal callbacks registered with onScopeDisposed', () => {
     const disposed: string[] = [];
 
-    const container = new Container({ tags: ['app'] }).onInstanceDisposed((c) => {
+    const container = new Container({ tags: ['app'] }).onScopeDisposed((c) => {
       if (c.hasTag('app')) disposed.push('app');
     });
 
     container.dispose();
 
     expect(disposed).toEqual(['app']);
+  });
+
+  it('registers each hook with the domain which raises it', () => {
+    const log: string[] = [];
+
+    class Service {}
+
+    // Injector domain — construction. Configured before the container owns it.
+    const injector = new MetadataInjector().onConstructed((instance) =>
+      log.push(`constructed:${instance.constructor.name}`),
+    );
+
+    const container = new Container({ injector, tags: ['app'] })
+      // Scope domain — the container's own events.
+      .onScopeCreated((scope) => log.push(`scopeCreated:${scope.hasTag('request')}`))
+      .onScopeDisposed(() => log.push('scopeDisposed'))
+      .onRegistered((_provider, key) => log.push(`registered:${String(key)}`));
+
+    container.addRegistration(
+      // Provider domain — resolution.
+      R.fromClass(Service).pipe(
+        onResolve((dependency) => log.push(`resolved:${(dependency as object).constructor.name}`)),
+      ),
+    );
+
+    const scope = container.createScope({ tags: ['request'] });
+    scope.resolve<Service>('Service');
+    scope.dispose();
+
+    expect(log).toEqual([
+      'registered:Service',
+      'registered:Service',
+      'scopeCreated:true',
+      'constructed:Service',
+      'resolved:Service',
+      'scopeDisposed',
+    ]);
+  });
+
+  it('shares injector hooks with every scope built on the same injector', () => {
+    const constructed: string[] = [];
+
+    class Service {}
+
+    const injector = new MetadataInjector();
+    const container = new Container({ injector, tags: ['app'] }).addRegistration(R.fromClass(Service));
+    const scope = container.createScope({ tags: ['request'] });
+
+    // Registered after both scopes exist: one injector backs the whole tree, so
+    // the hook covers every scope in it, whenever it was added.
+    injector.onConstructed((_instance, s) => constructed.push(s.hasTag('request') ? 'request' : 'app'));
+
+    container.resolve<Service>('Service');
+    scope.resolve<Service>('Service');
+
+    expect(constructed).toEqual(['app', 'request']);
   });
 
   it('resolves hook method arguments and separates sync from async execution', async () => {

--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -4,8 +4,7 @@ import {
   type DependencyKey,
   type IContainer,
   type IContainerModule,
-  type InstanceHook,
-  type ProviderHook,
+  type RegisteredHook,
   type RegisterOptions,
   ResolveManyOptions,
   type ResolveOneOptions,
@@ -21,7 +20,6 @@ import { MetadataInjector } from '../injector/MetadataInjector';
 import { AliasMap } from './AliasMap';
 import { unwrapProxy } from '../utils/ProxyRegistry';
 import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
-import { OnDisposeHook } from '../hooks/onContainerDisposed';
 import { constructor, Instance, Is } from '../utils/basic';
 import { Filter as F } from '../utils/array';
 
@@ -36,10 +34,9 @@ export class Container implements IContainer {
   private readonly aliases = new AliasMap();
   private readonly injector: IInjector;
 
-  private readonly onConstructHookList: InstanceHook[] = [];
-  private readonly onDisposeHookList: OnDisposeHook[] = [];
   private readonly onScopeCreatedHookList: ScopeHook[] = [];
-  private readonly onProviderRegisteredHookList: ProviderHook[] = [];
+  private readonly onScopeDisposedHookList: ScopeHook[] = [];
+  private readonly onRegisteredHookList: RegisteredHook[] = [];
 
   constructor(
     options: {
@@ -62,8 +59,8 @@ export class Container implements IContainer {
     this.aliases.setAliasesByKey(key, aliases);
 
     // Hooks run once the provider and its aliases are in place, so they observe a resolvable key.
-    for (const onProviderRegistered of this.onProviderRegisteredHookList) {
-      onProviderRegistered(provider, key, this);
+    for (const onRegistered of this.onRegisteredHookList) {
+      onRegistered(provider, key, this);
     }
 
     return this;
@@ -138,11 +135,11 @@ export class Container implements IContainer {
   createScope({ tags }: CreateScopeOptions = {}): IContainer {
     this.validateContainer();
 
+    // Injector hooks need no copying - the child shares this scope's injector, so it shares its hooks.
     const scope = new Container({ injector: this.injector, parent: this, tags })
-      .onConstruct(...this.onConstructHookList)
-      .onInstanceDisposed(...this.onDisposeHookList)
       .onScopeCreated(...this.onScopeCreatedHookList)
-      .onProviderRegistered(...this.onProviderRegisteredHookList);
+      .onScopeDisposed(...this.onScopeDisposedHookList)
+      .onRegistered(...this.onRegisteredHookList);
 
     for (const registration of this.getRegistrations()) {
       registration.applyTo(scope);
@@ -183,9 +180,9 @@ export class Container implements IContainer {
     this.validateContainer();
     this.isDisposed = true;
 
-    // Execute onDispose hooks
-    for (const hook of this.onDisposeHookList) {
-      hook(this);
+    // Execute onScopeDisposed hooks
+    for (const onScopeDisposed of this.onScopeDisposedHookList) {
+      onScopeDisposed(this);
     }
 
     // Detach from parent
@@ -201,11 +198,10 @@ export class Container implements IContainer {
     this.instances.clear();
     this.registrations = [];
 
-    // Clear hooks
-    this.onConstructHookList.length = 0;
-    this.onDisposeHookList.length = 0;
+    // Clear hooks. Injector hooks are not this scope's to clear - the injector outlives it.
     this.onScopeCreatedHookList.length = 0;
-    this.onProviderRegisteredHookList.length = 0;
+    this.onScopeDisposedHookList.length = 0;
+    this.onRegisteredHookList.length = 0;
   }
 
   addRegistration(registration: IRegistration): this {
@@ -222,33 +218,23 @@ export class Container implements IContainer {
     return this.registrations.some((r) => r.getKeyOrFail() === key) || this.parent.hasRegistration(key);
   }
 
-  onConstruct(...hooks: InstanceHook[]): this {
-    this.onConstructHookList.push(...hooks);
-    return this;
-  }
-
-  onInstanceDisposed(...hooks: OnDisposeHook[]): this {
-    this.onDisposeHookList.push(...hooks);
-    return this;
-  }
-
   onScopeCreated(...hooks: ScopeHook[]): this {
     this.onScopeCreatedHookList.push(...hooks);
     return this;
   }
 
-  onProviderRegistered(...hooks: ProviderHook[]): this {
-    this.onProviderRegisteredHookList.push(...hooks);
+  onScopeDisposed(...hooks: ScopeHook[]): this {
+    this.onScopeDisposedHookList.push(...hooks);
+    return this;
+  }
+
+  onRegistered(...hooks: RegisteredHook[]): this {
+    this.onRegisteredHookList.push(...hooks);
     return this;
   }
 
   addInstance(instance: Instance) {
     this.instances.add(instance);
-
-    // Execute onConstruct hooks
-    for (const onConstruct of this.onConstructHookList) {
-      onConstruct(instance, this);
-    }
   }
 
   getScopes() {

--- a/packages/ts-ioc-container/lib/container/EmptyContainer.ts
+++ b/packages/ts-ioc-container/lib/container/EmptyContainer.ts
@@ -4,17 +4,15 @@ import {
   type IContainer,
   type IContainerModule,
   type ScopeHook,
-  type ProviderHook,
+  type RegisteredHook,
   type ResolveManyOptions,
   type ResolveOneOptions,
   type Tag,
-  type InstanceHook,
 } from './IContainer';
 import { MethodNotImplementedError } from '../errors/MethodNotImplementedError';
 import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
 import { type IProvider } from '../provider/IProvider';
 import { type IRegistration } from '../registration/IRegistration';
-import { OnDisposeHook } from '../hooks/onContainerDisposed';
 import { type constructor, type Instance } from '../utils/basic';
 
 export class EmptyContainer implements IContainer {
@@ -130,20 +128,6 @@ export class EmptyContainer implements IContainer {
   /**
    * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
    */
-  onInstanceDisposed(...hooks: OnDisposeHook[]): this {
-    throw new MethodNotImplementedError();
-  }
-
-  /**
-   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
-   */
-  onConstruct(...hooks: InstanceHook[]): this {
-    throw new MethodNotImplementedError();
-  }
-
-  /**
-   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
-   */
   onScopeCreated(...hooks: ScopeHook[]): this {
     throw new MethodNotImplementedError();
   }
@@ -151,7 +135,14 @@ export class EmptyContainer implements IContainer {
   /**
    * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
    */
-  onProviderRegistered(...hooks: ProviderHook[]): this {
+  onScopeDisposed(...hooks: ScopeHook[]): this {
+    throw new MethodNotImplementedError();
+  }
+
+  /**
+   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
+   */
+  onRegistered(...hooks: RegisteredHook[]): this {
     throw new MethodNotImplementedError();
   }
 }

--- a/packages/ts-ioc-container/lib/container/IContainer.ts
+++ b/packages/ts-ioc-container/lib/container/IContainer.ts
@@ -1,6 +1,5 @@
 import { type IProvider, ProviderOptions } from '../provider/IProvider';
 import { type IRegistration } from '../registration/IRegistration';
-import { OnDisposeHook } from '../hooks/onContainerDisposed';
 import { type WithArgs } from '../injector/IInjector';
 import { type constructor, Instance } from '../utils/basic';
 
@@ -31,21 +30,33 @@ export type CreateScopeOptions = Partial<WithTags>;
 export type AutoResolveOptions = Partial<WithArgs>;
 export type RegisterOptions = { aliases?: DependencyKey[] };
 
+/**
+ * Scope event hooks - the container's own domain: a scope was created, a scope
+ * was disposed.
+ *
+ * The other two hook domains live with the abstraction which raises them:
+ * injector hooks on `IInjector` (`InjectorHook`), provider hooks on
+ * {@link IProvider} (`ProviderHook`). An injector is configured before it is
+ * passed to a container's constructor, so a container never hands its injector
+ * out.
+ */
 export type ScopeHook = (scope: IContainer) => void;
-export type InstanceHook = (instance: Instance, scope: IContainer) => void;
-export type DependencyHook = (dependency: unknown, scope: IContainer) => void;
-export type ProviderHook = (provider: IProvider, key: DependencyKey, scope: IContainer) => void;
+
+/**
+ * Scope event hook for a registration landing in a scope: a provider entered
+ * the provider map under `key`. Registration is always of a provider, so the
+ * name says only what varies.
+ */
+export type RegisteredHook = (provider: IProvider, key: DependencyKey, scope: IContainer) => void;
 
 export interface IContainer extends Tagged {
   readonly isDisposed: boolean;
 
-  onConstruct(...hooks: InstanceHook[]): this;
-
-  onInstanceDisposed(...hooks: OnDisposeHook[]): this;
-
   onScopeCreated(...hooks: ScopeHook[]): this;
 
-  onProviderRegistered(...hooks: ProviderHook[]): this;
+  onScopeDisposed(...hooks: ScopeHook[]): this;
+
+  onRegistered(...hooks: RegisteredHook[]): this;
 
   register(key: DependencyKey, value: IProvider, options?: RegisterOptions): this;
 

--- a/packages/ts-ioc-container/lib/hooks/onConstruct.ts
+++ b/packages/ts-ioc-container/lib/hooks/onConstruct.ts
@@ -1,5 +1,5 @@
 import { hook, HookType, prependHooks } from './hook';
-import type { IContainer, IContainerModule } from '../container/IContainer';
+import type { IInjector, IInjectorModule } from '../injector/IInjector';
 import { HooksRunner } from './HooksRunner';
 import type { ExecutionContext } from '../ExecutionContext';
 
@@ -10,14 +10,28 @@ export const onConstruct = (...fns: HookType[]) => hook('onConstruct', prependHo
 
 export type OnExceptionHandler = (ex: unknown, context: ExecutionContext) => void;
 
-export class OnConstructModule implements IContainerModule {
+/**
+ * Runs `onConstruct` hooks when an instance is constructed.
+ *
+ * Construction is the injector's event, so this is an injector module: apply it
+ * to the injector, then pass that injector to the container.
+ *
+ * ```typescript
+ * const injector = new MetadataInjector().useModule(new OnConstructModule());
+ * const container = new Container({ injector });
+ * ```
+ *
+ * A container passes its injector to every scope it creates, so one injector
+ * covers a whole scope tree.
+ */
+export class OnConstructModule implements IInjectorModule {
   constructor(private readonly onException?: OnExceptionHandler) {}
 
-  applyTo(container: IContainer) {
+  applyTo(injector: IInjector) {
     /**
      * @throws {unknown} rethrows whatever the `onConstruct` hooks threw, when no `onException` handler was supplied.
      */
-    container.onConstruct((instance, scope) => {
+    injector.onConstructed((instance, scope) => {
       try {
         onConstructHooksRunner.execute(instance, { scope });
       } catch (ex) {

--- a/packages/ts-ioc-container/lib/hooks/onConstructAsync.ts
+++ b/packages/ts-ioc-container/lib/hooks/onConstructAsync.ts
@@ -1,5 +1,5 @@
 import { hook, HookType, prependHooks } from './hook';
-import type { IContainer, IContainerModule } from '../container/IContainer';
+import type { IInjector, IInjectorModule } from '../injector/IInjector';
 import { HooksRunner } from './HooksRunner';
 import type { OnExceptionHandler } from './onConstruct';
 
@@ -8,15 +8,22 @@ export const onConstructAsyncHooksRunner = new HooksRunner('onConstructAsync');
 // `@onX(h1) @onX(h2) method()` runs h1 before h2.
 export const onConstructAsync = (...fns: HookType[]) => hook('onConstructAsync', prependHooks(...fns));
 
-// Resolution stays synchronous, so async construct hooks are started when the
-// instance is tracked and settle afterwards: `resolve` returns before they
-// finish. Instances that must expose readiness should publish it themselves,
-// for example by storing the pending promise on the instance.
-export class OnConstructAsyncModule implements IContainerModule {
+/**
+ * Runs `onConstructAsync` hooks when an instance is constructed.
+ *
+ * Resolution stays synchronous, so async construct hooks are started when the
+ * instance is tracked and settle afterwards: `resolve` returns before they
+ * finish. Instances that must expose readiness should publish it themselves,
+ * for example by storing the pending promise on the instance.
+ *
+ * Like `OnConstructModule`, this is an injector module — see there for how to
+ * apply one.
+ */
+export class OnConstructAsyncModule implements IInjectorModule {
   constructor(private readonly onException?: OnExceptionHandler) {}
 
-  applyTo(container: IContainer) {
-    container.onConstruct((instance, scope) => {
+  applyTo(injector: IInjector) {
+    injector.onConstructed((instance, scope) => {
       if (!onConstructAsyncHooksRunner.hasHooks(instance)) {
         return;
       }

--- a/packages/ts-ioc-container/lib/hooks/onContainerDisposed.ts
+++ b/packages/ts-ioc-container/lib/hooks/onContainerDisposed.ts
@@ -7,11 +7,16 @@ export const onContainerDisposedHooksRunner = new HooksRunner('onContainerDispos
 // `@onX(h1) @onX(h2) method()` runs h1 before h2.
 export const onContainerDisposed = (...fns: HookType[]) => hook('onContainerDisposed', prependHooks(...fns));
 
-export type OnDisposeHook = (scope: IContainer) => void;
-
+/**
+ * Runs `onContainerDisposed` hooks on every instance of a scope being disposed.
+ *
+ * A scope's disposal is a scope event, so the module hangs off
+ * `onScopeDisposed`. Disposal is local: disposing a parent runs no child-scope
+ * hooks.
+ */
 export class OnDisposeModule implements IContainerModule {
   applyTo(container: IContainer) {
-    container.onInstanceDisposed((scope) => {
+    container.onScopeDisposed((scope) => {
       for (const instance of scope.getInstances()) {
         onContainerDisposedHooksRunner.execute(instance, { scope });
       }

--- a/packages/ts-ioc-container/lib/hooks/onResolved.ts
+++ b/packages/ts-ioc-container/lib/hooks/onResolved.ts
@@ -1,4 +1,5 @@
-import type { DependencyHook, IContainer, IContainerModule } from '../container/IContainer';
+import type { IContainer, IContainerModule } from '../container/IContainer';
+import type { ProviderHook } from '../provider/IProvider';
 import { HooksRunner } from './HooksRunner';
 import { registerPipe } from '../registration/IRegistration';
 import { executeHooks, forEachResolvedObject, onceResolvedHook, resolvedHook } from './resolveHooks';
@@ -37,7 +38,7 @@ export const onResolved = resolvedHook('onResolved');
  */
 export const onceResolved = onceResolvedHook('onResolved');
 
-const runHooks: DependencyHook = forEachResolvedObject(executeHooks(onResolvedHooksRunner));
+const runHooks: ProviderHook = forEachResolvedObject(executeHooks(onResolvedHooksRunner));
 
 /**
  * Runs `onResolved` hooks every time a dependency object leaves a provider.
@@ -49,15 +50,15 @@ const runHooks: DependencyHook = forEachResolvedObject(executeHooks(onResolvedHo
  * `@onceResolved` hook runs on the first resolve of its instance however the
  * dependency is registered.
  *
- * Providers are hooked through `onProviderRegistered`, so apply the module
+ * Providers are hooked through `onRegistered`, so apply the module
  * before the registrations it should cover; scopes created afterwards inherit
  * it. To opt in one registration instead of the whole container, use the
  * {@link resolved} pipe.
  */
 export class OnResolvedModule implements IContainerModule {
   applyTo(container: IContainer) {
-    container.onProviderRegistered((provider) => {
-      provider.onResolve(runHooks);
+    container.onRegistered((provider) => {
+      provider.onResolved(runHooks);
     });
   }
 }
@@ -67,4 +68,4 @@ export class OnResolvedModule implements IContainerModule {
  * its `onResolved` hooks on resolve, without the container opting every other
  * registration in.
  */
-export const resolved = <T = unknown>() => registerPipe<T>((p) => p.onResolve(runHooks));
+export const resolved = <T = unknown>() => registerPipe<T>((p) => p.onResolved(runHooks));

--- a/packages/ts-ioc-container/lib/hooks/onResolvedAsync.ts
+++ b/packages/ts-ioc-container/lib/hooks/onResolvedAsync.ts
@@ -48,8 +48,8 @@ export class OnResolvedAsyncModule implements IContainerModule {
   }
 
   applyTo(container: IContainer) {
-    container.onProviderRegistered((provider) => {
-      provider.onResolve(this.runHooks);
+    container.onRegistered((provider) => {
+      provider.onResolved(this.runHooks);
     });
   }
 }
@@ -58,4 +58,4 @@ export class OnResolvedAsyncModule implements IContainerModule {
  * Per-registration form of {@link OnResolvedAsyncModule}, mirroring `resolved()`.
  */
 export const resolvedAsync = <T = unknown>(onException?: OnExceptionHandler) =>
-  registerPipe<T>((p) => p.onResolve(runHooks(onException)));
+  registerPipe<T>((p) => p.onResolved(runHooks(onException)));

--- a/packages/ts-ioc-container/lib/hooks/resolveHooks.ts
+++ b/packages/ts-ioc-container/lib/hooks/resolveHooks.ts
@@ -1,13 +1,14 @@
-import type { DependencyHook, IContainer } from '../container/IContainer';
+import type { IContainer } from '../container/IContainer';
+import type { ProviderHook } from '../provider/IProvider';
 import type { HooksRunner } from './HooksRunner';
 import { hook, type HookFn, type HookType, prependHooks, toHookFn } from './hook';
 import type { OnExceptionHandler } from './onConstruct';
 import { Is } from '../utils/basic';
 
 /**
- * A resolve hook narrowed to the dependencies that can carry hook metadata.
+ * A {@link ProviderHook} narrowed to the dependencies that can carry hook metadata.
  */
-export type ResolvedDependencyHook = (dependency: object, scope: IContainer) => void;
+export type ResolvedObjectHook = (dependency: object, scope: IContainer) => void;
 
 /**
  * Invokes the decorated method with its resolved arguments - what every resolve
@@ -65,11 +66,11 @@ export const onceResolvedHook =
     hook(key, prependHooks(...toHooks(hooks).map(onceForEachInstance)));
 
 /**
- * Lifts a hook to `DependencyHook`, skipping dependencies which are not objects:
+ * Lifts a hook to `ProviderHook`, skipping dependencies which are not objects:
  * hook metadata lives on classes, and a primitive can carry none.
  */
 export const forEachResolvedObject =
-  (run: ResolvedDependencyHook): DependencyHook =>
+  (run: ResolvedObjectHook): ProviderHook =>
   (dependency, scope) => {
     if (Is.object(dependency)) {
       run(dependency, scope);
@@ -80,7 +81,7 @@ export const forEachResolvedObject =
  * @throws {unknown} rethrows whatever the hooks threw.
  */
 export const executeHooks =
-  (runner: HooksRunner): ResolvedDependencyHook =>
+  (runner: HooksRunner): ResolvedObjectHook =>
   (dependency, scope) =>
     runner.execute(dependency, { scope });
 
@@ -89,7 +90,7 @@ export const executeHooks =
  * afterwards: `resolve` returns before they finish.
  */
 export const executeHooksAsync =
-  (runner: HooksRunner, onException?: OnExceptionHandler): ResolvedDependencyHook =>
+  (runner: HooksRunner, onException?: OnExceptionHandler): ResolvedObjectHook =>
   (dependency, scope) => {
     if (!runner.hasHooks(dependency)) {
       return;

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -9,9 +9,7 @@ export {
   type ResolveOneOptions,
   type ResolveManyOptions,
   type ScopeHook,
-  type InstanceHook,
-  type DependencyHook,
-  type ProviderHook,
+  type RegisteredHook,
   type AutoResolveOptions,
   isDependencyKey,
 } from './container/IContainer';
@@ -20,7 +18,14 @@ export { AutoResolveModule } from './container/AutoResolveModule';
 export { EmptyContainer } from './container/EmptyContainer';
 
 // Injectors
-export { type IInjector, type InjectOptions, type IInjectFnResolver, Injector } from './injector/IInjector';
+export {
+  type IInjector,
+  type InjectOptions,
+  type IInjectFnResolver,
+  type IInjectorModule,
+  type InjectorHook,
+  Injector,
+} from './injector/IInjector';
 export { MetadataInjector, inject, arg, args, argsFn, resolveArgs } from './injector/MetadataInjector';
 export { SimpleInjector } from './injector/SimpleInjector';
 export { ProxyInjector } from './injector/ProxyInjector';
@@ -35,6 +40,7 @@ export {
   type GetCacheKey,
   type ScopeAccessOptions,
   type ScopeAccessRule,
+  type ProviderHook,
 } from './provider/IProvider';
 export { Provider } from './provider/Provider';
 
@@ -107,7 +113,7 @@ export {
   OnResolvedAsyncModule,
   resolvedAsync,
 } from './hooks/onResolvedAsync';
-export { invokeMethod, type ResolvedDependencyHook } from './hooks/resolveHooks';
+export { invokeMethod, type ResolvedObjectHook } from './hooks/resolveHooks';
 export { HooksRunner, type HooksRunnerContext, type MapHookContext } from './hooks/HooksRunner';
 
 // Tokens

--- a/packages/ts-ioc-container/lib/injector/IInjector.ts
+++ b/packages/ts-ioc-container/lib/injector/IInjector.ts
@@ -6,8 +6,28 @@ import { type constructor, Instance } from '../utils/basic';
 export type WithArgs = { args: unknown[] };
 export type InjectOptions = Partial<WithArgs>;
 
+/**
+ * Injector hooks - the injector's own domain: an instance was constructed.
+ *
+ * Construction is the injector's business, so the hook list belongs to the
+ * injector rather than to a scope. One injector is shared by a container and
+ * every scope created from it, so a hook added here observes construction in
+ * all of them.
+ */
+export type InjectorHook = (instance: Instance, scope: IContainer) => void;
+
 export interface IInjector {
   resolve<T>(container: IContainer, value: constructor<T>, options?: ProviderOptions): T;
+
+  onConstructed(...hooks: InjectorHook[]): this;
+}
+
+/**
+ * The injector counterpart of `IContainerModule`: an opt-in bundle of injector
+ * hooks, applied to the injector before it is handed to a container.
+ */
+export interface IInjectorModule {
+  applyTo(injector: IInjector): void;
 }
 
 export interface IInjectFnResolver<T> {
@@ -15,15 +35,38 @@ export interface IInjectFnResolver<T> {
 }
 
 export abstract class Injector {
+  private readonly onConstructedHookList: InjectorHook[] = [];
+
   constructor(private readonly proxyRegistry: IProxyRegistry = ProxyRegistry.getInstance()) {}
 
   resolve<T>(scope: IContainer, Target: constructor<T>, { args, lazy }: ProviderOptions = {}): T {
     // @ts-ignore
     return this.proxyRegistry.toLazyIf(() => {
-      const instance = this.createInstance(scope, Target, { args });
-      scope.addInstance(instance as Instance);
+      const instance = this.createInstance(scope, Target, { args }) as Instance;
+      scope.addInstance(instance);
+
+      // Hooks run once the scope tracks the instance, so they observe a scope which owns it.
+      for (const onConstructed of this.onConstructedHookList) {
+        onConstructed(instance, scope);
+      }
+
       return instance;
     }, lazy);
+  }
+
+  /**
+   * Hooks run after the constructed instance is handed to the scope, and before
+   * it reaches the caller. A `lazy` resolve returns a proxy first, so its hooks
+   * run when the proxy is first touched.
+   */
+  onConstructed(...hooks: InjectorHook[]): this {
+    this.onConstructedHookList.push(...hooks);
+    return this;
+  }
+
+  useModule(module: IInjectorModule): this {
+    module.applyTo(this);
+    return this;
   }
 
   protected abstract createInstance<T>(scope: IContainer, Target: constructor<T>, options?: InjectOptions): T;

--- a/packages/ts-ioc-container/lib/provider/IProvider.ts
+++ b/packages/ts-ioc-container/lib/provider/IProvider.ts
@@ -1,4 +1,4 @@
-import { type DependencyHook, IContainer, Tagged } from '../container/IContainer';
+import { IContainer, Tagged } from '../container/IContainer';
 import { InjectOptions } from '../injector/IInjector';
 
 export type WithLazy = { lazy: boolean };
@@ -11,6 +11,15 @@ export type ArgsFn = (l: IContainer, options?: InjectOptions) => unknown[];
 
 export type GetCacheKey = (...args: unknown[]) => string | symbol;
 export type DecorateFn<Instance = any> = (dep: Instance, scope: IContainer) => Instance;
+
+/**
+ * Provider hooks - the provider's own domain: a dependency was resolved.
+ *
+ * Resolution is the provider's business, so the hook list belongs to the
+ * provider. A dependency is not necessarily a constructed instance - a provider
+ * can hand out a value the container never built - so the hook takes `unknown`.
+ */
+export type ProviderHook = (dependency: unknown, scope: IContainer) => void;
 
 export interface IProvider<T = any> {
   resolve(container: IContainer, options: ProviderOptions): T;
@@ -33,5 +42,5 @@ export interface IProvider<T = any> {
 
   dispose(): void;
 
-  onResolve(...hooks: DependencyHook[]): this;
+  onResolved(...hooks: ProviderHook[]): this;
 }

--- a/packages/ts-ioc-container/lib/provider/Provider.ts
+++ b/packages/ts-ioc-container/lib/provider/Provider.ts
@@ -7,8 +7,9 @@ import {
   type ResolveDependency,
   type ScopeAccessOptions,
   type ScopeAccessRule,
+  type ProviderHook,
 } from './IProvider';
-import type { DependencyHook, DependencyKey, IContainer } from '../container/IContainer';
+import type { DependencyKey, IContainer } from '../container/IContainer';
 import { type constructor } from '../utils/basic';
 import { CannonSingletonApplyTwiceError } from '../errors/CannonSingletonApplyTwiceError';
 import { ProviderDisposedError } from '../errors/ProviderDisposedError';
@@ -34,13 +35,13 @@ export class Provider<T = any> implements IProvider<T> {
   private cache = new Map<string | symbol, unknown>();
   private getKey: GetCacheKey | undefined;
   private isDisposed: boolean = false;
-  private readonly onResolveHookList: DependencyHook[] = [];
+  private readonly onResolvedHookList: ProviderHook[] = [];
 
   constructor(private readonly resolveDependency: ResolveDependency<T>) {}
 
   /**
    * @throws {ProviderDisposedError} when the provider has already been disposed.
-   * @throws {unknown} rethrows whatever an `onResolve` hook threw.
+   * @throws {unknown} rethrows whatever an `onResolved` hook threw.
    */
   resolve(scope: IContainer, options: ProviderOptions): T {
     ProviderDisposedError.assert(!this.isDisposed, 'Provider is already disposed');
@@ -59,7 +60,7 @@ export class Provider<T = any> implements IProvider<T> {
   }
 
   /**
-   * @throws {unknown} rethrows whatever an `onResolve` hook threw.
+   * @throws {unknown} rethrows whatever an `onResolved` hook threw.
    */
   private resolveDep(scope: IContainer, { args = [], lazy }: ProviderOptions = {}): T {
     let dependency = this.resolveDependency(scope, {
@@ -67,8 +68,8 @@ export class Provider<T = any> implements IProvider<T> {
       lazy: lazy ?? this.isLazy,
     });
     dependency = this.mappers.reduce((acc, current) => current(acc, scope), dependency);
-    for (const onResolve of this.onResolveHookList) {
-      onResolve(dependency, scope);
+    for (const onResolved of this.onResolvedHookList) {
+      onResolved(dependency, scope);
     }
     return dependency;
   }
@@ -129,8 +130,8 @@ export class Provider<T = any> implements IProvider<T> {
    * Hooks run after every mapper, on each resolved dependency. A singleton provider
    * caches the dependency, so its hooks run once — on the resolve that filled the cache.
    */
-  onResolve(...hooks: DependencyHook[]): this {
-    this.onResolveHookList.push(...hooks);
+  onResolved(...hooks: ProviderHook[]): this {
+    this.onResolvedHookList.push(...hooks);
     return this;
   }
 
@@ -146,6 +147,6 @@ export class Provider<T = any> implements IProvider<T> {
     this.accessRules.splice(0, this.accessRules.length);
     this.mappers.splice(0, this.mappers.length);
     this.argsFnList.splice(0, this.argsFnList.length);
-    this.onResolveHookList.splice(0, this.onResolveHookList.length);
+    this.onResolvedHookList.splice(0, this.onResolvedHookList.length);
   }
 }

--- a/packages/ts-ioc-container/lib/registration/IRegistration.ts
+++ b/packages/ts-ioc-container/lib/registration/IRegistration.ts
@@ -1,11 +1,5 @@
-import {
-  type DependencyHook,
-  type DependencyKey,
-  type IContainer,
-  type IContainerModule,
-  isDependencyKey,
-} from '../container/IContainer';
-import type { ArgsFn, DecorateFn, GetCacheKey, IProvider, ScopeAccessRule } from '../provider/IProvider';
+import { type DependencyKey, type IContainer, type IContainerModule, isDependencyKey } from '../container/IContainer';
+import type { ArgsFn, DecorateFn, GetCacheKey, IProvider, ProviderHook, ScopeAccessRule } from '../provider/IProvider';
 import { SingleToken } from '../token/SingleToken';
 import { BindToken } from '../token/BindToken';
 import { MapFn } from '../utils/fp';
@@ -111,4 +105,8 @@ export const decorate = (...fns: DecorateFn[]) => registerPipe((p) => p.map(...f
 
 export const singleton = <T = unknown>(getCacheKey?: GetCacheKey) => registerPipe<T>((p) => p.singleton(getCacheKey));
 
-export const onResolve = <T = unknown>(...hooks: DependencyHook[]) => registerPipe<T>((p) => p.onResolve(...hooks));
+/**
+ * Registration-level form of `IProvider.onResolved`: attaches provider hooks to
+ * the piped registration's provider.
+ */
+export const onResolve = <T = unknown>(...hooks: ProviderHook[]) => registerPipe<T>((p) => p.onResolved(...hooks));

--- a/packages/ts-ioc-container/specs/epics/container-modules.md
+++ b/packages/ts-ioc-container/specs/epics/container-modules.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0007 - Lifecycle hooks via reflect-metadata and opt-in modules](../../docs/adr/0007-lifecycle-hooks.md)
-- **Public API:** `IContainerModule`, `Container.useModule`, `OnConstructModule`, `OnDisposeModule`, `AutoResolveModule`, `Container.autoResolve`
+- **Public API:** `IContainerModule`, `Container.useModule`, `OnDisposeModule`, `OnResolvedModule`, `AutoResolveModule`, `Container.autoResolve`
 - **Executable spec:** `__tests__/specs/container-modules.spec.ts`
 
 ## Intent
@@ -44,12 +44,15 @@ that projects that need hooks can enable them explicitly.
 
 Acceptance criteria:
 
-- `OnConstructModule` enables construct hook execution for future
-  instances in the container.
 - `OnDisposeModule` enables dispose hook execution for instances tracked
   by the disposed scope.
+- `OnResolvedModule` enables resolve hook execution for every provider
+  registered after it is applied.
 - Child scopes created after module setup inherit the lifecycle hooks configured
   on the parent.
+- Construct hooks are not a container concern: `OnConstructModule` and
+  `OnConstructAsyncModule` are `IInjectorModule`s, applied to the injector
+  before it reaches the container. See the lifecycle-hooks epic.
 
 ### Story: Eagerly instantiate scope services through a module
 

--- a/packages/ts-ioc-container/specs/epics/injector-strategies.md
+++ b/packages/ts-ioc-container/specs/epics/injector-strategies.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0002 - Pluggable injector strategies](../../docs/adr/0002-pluggable-injectors.md)
-- **Public API:** `IInjector`, `Injector`, `MetadataInjector`, `SimpleInjector`, `ProxyInjector`, `inject`, `resolveArgs`, `arg`, `args`, `argsFn`
+- **Public API:** `IInjector`, `IInjectorModule`, `InjectorHook`, `Injector`, `MetadataInjector`, `SimpleInjector`, `ProxyInjector`, `inject`, `resolveArgs`, `arg`, `args`, `argsFn`
 - **Executable spec:** `__tests__/specs/injector-strategies.spec.ts`
 
 ## Intent
@@ -10,6 +10,12 @@
 As a developer in different TypeScript environments, I want multiple injection
 strategies so that I can use decorator metadata, direct container access,
 proxy-style access, or a custom construction strategy.
+
+The injector also owns the construct hook domain: `onConstructed(...hooks:
+InjectorHook[])` and `IInjectorModule` are registered on the injector, which is
+configured before being passed to `new Container({ injector })`. An injector
+written from scratch against `IInjector` supplies `onConstructed` itself, or
+returns `this` to decline the domain.
 
 ## Stories
 

--- a/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
+++ b/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
@@ -1,8 +1,9 @@
 # Epic: Lifecycle hooks
 
 - **Status:** Accepted
-- **ADR:** [ADR 0007 - Lifecycle hooks via reflect-metadata and opt-in modules](../../docs/adr/0007-lifecycle-hooks.md)
-- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `onConstruct`, `onConstructAsync`, `onContainerDisposed`, `injectProp`, `onResolved`, `onceResolved`, `onResolvedAsync`, `onceResolvedAsync`, `OnConstructModule`, `OnConstructAsyncModule`, `OnDisposeModule`, `OnResolvedModule`, `OnResolvedAsyncModule`, `resolved`, `resolvedAsync`
+- **ADR:** [ADR 0007 - Lifecycle hooks via reflect-metadata and opt-in modules](../../../adr/0007-lifecycle-hooks.md),
+  [ADR 0012 - Hook registration lives with the domain which raises the event](../../../adr/0012-hook-domains.md)
+- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `onConstruct`, `onConstructAsync`, `onContainerDisposed`, `injectProp`, `onResolved`, `onceResolved`, `onResolvedAsync`, `onceResolvedAsync`, `OnConstructModule`, `OnConstructAsyncModule`, `OnDisposeModule`, `OnResolvedModule`, `OnResolvedAsyncModule`, `resolved`, `resolvedAsync`, `ScopeHook`, `RegisteredHook`, `InjectorHook`, `ProviderHook`, `IInjectorModule`
 - **Executable spec:** `__tests__/specs/lifecycle-hooks.spec.ts`
 
 ## Intent
@@ -22,7 +23,8 @@ used.
 Acceptance criteria:
 
 - `onConstruct` stores hook metadata on a method.
-- `OnConstructModule` opts a container into construct hook execution.
+- `OnConstructModule` is an injector module: it opts an injector into construct
+  hook execution, and that injector is then passed to the container.
 - Construct hooks run after the instance is created and tracked.
 - Hook classes are resolved through the container before execution.
 
@@ -35,8 +37,8 @@ synchronous construct path.
 Acceptance criteria:
 
 - `onConstructAsync` stores hook metadata on a method under its own hook key.
-- `OnConstructAsyncModule` opts a container into async construct hook
-  execution.
+- `OnConstructAsyncModule` is an injector module opting an injector into async
+  construct hook execution.
 - Async construct hooks start when the instance is created and settle after
   resolution returns.
 - Rejected hooks are reported to the module `onException` handler when one is
@@ -99,21 +101,36 @@ Acceptance criteria:
 - `hasHooks` identifies whether hook metadata exists.
 - `HooksRunner` can execute only methods accepted by a predicate.
 
-### Story: Register direct disposal callbacks on a container
+### Story: Register imperative hooks with the domain which raises them
 
-As an application developer, I can attach disposal callbacks directly to a
-container so that cleanup logic runs when the container is disposed without
-needing a class decorated with `@onContainerDisposed`.
+As an application developer, I can attach callbacks directly to the abstraction
+which raises an event — scope, injector, or provider — so that cleanup, metrics,
+and custom extension points do not need a decorated class, and so the place a
+hook is registered says which domain owns it.
 
 Acceptance criteria:
 
-- `onDispose` registers a callback that receives the disposing container.
-- The callback is invoked when the container is disposed.
-- `onDispose` returns the container for fluent chaining.
-- `onConstruct` and `onScopeCreated` are the matching container-level hooks, for
-  newly created instances and newly created scopes, and chain the same way.
-- A child scope inherits the hooks its parent held at `createScope` time.
-- `EmptyContainer` rejects all three with `MethodNotImplementedError`.
+- Scope events are registered on `IContainer`: `onScopeCreated(...hooks:
+  ScopeHook[])`, `onScopeDisposed(...hooks: ScopeHook[])` and
+  `onRegistered(...hooks: RegisteredHook[])`, each returning the
+  container for fluent chaining.
+- Construction is registered on `IInjector`: `onConstructed(...hooks:
+  InjectorHook[])`. The injector is configured before it is passed to
+  `new Container({ injector })`; a container never hands its injector out.
+- `IInjectorModule` bundles injector hooks, applied with `injector.useModule(...)`
+  or `module.applyTo(injector)`.
+- Resolution is registered on `IProvider`: `onResolved(...hooks:
+  ProviderHook[])`, or on a registration through the `onResolve(...)` pipe.
+- `onScopeDisposed` callbacks receive the disposing scope.
+- A child scope inherits the scope hooks its parent held at `createScope` time;
+  later additions to either stay local to it.
+- A container passes its injector to every scope it creates, so an
+  `onConstructed` hook observes construction anywhere in that scope tree,
+  whenever it was added.
+- Disposing a scope clears its own scope hooks and leaves the shared injector's
+  hooks intact.
+- `EmptyContainer` rejects every scope hook method with
+  `MethodNotImplementedError`.
 
 ### Story: Handle sync and async hook execution
 

--- a/packages/ts-ioc-container/specs/epics/provider-behavior.md
+++ b/packages/ts-ioc-container/specs/epics/provider-behavior.md
@@ -119,7 +119,7 @@ dependency elsewhere run on resolution without changing the resolved value.
 
 Acceptance criteria:
 
-- `onResolve` receives the resolved dependency and the resolving scope.
+- `IProvider.onResolved` takes `ProviderHook`s, which receive the resolved dependency and the resolving scope; the `onResolve(...)` pipe is its registration-level form.
 - Unlike `decorate`, an `onResolve` hook cannot replace the dependency — its
   return value is ignored and the caller receives the value the pipes produced.
 - Hooks run after every `decorate` mapper, so they observe the fully decorated


### PR DESCRIPTION
## Why

Hook registration was all collected on `IContainer`, even for events the container doesn't raise:

```typescript
container
  .onConstruct(...)          // an instance was constructed — the injector's event
  .onInstanceDisposed(...)   // actually: this scope was disposed
  .onScopeCreated(...)       // a child scope was created
  .onProviderRegistered(...) // a provider entered the provider map
```

Only two of those four are the container's own. Construction belongs to the injector — the thing that calls `new Target(...)`. Resolution belongs to the provider, and already had `IProvider.onResolve`, so resolve hooks were registered somewhere different from every other hook for no reason visible in the API.

The type names hid the same confusion: `InstanceHook` / `DependencyHook` were named for their payload shape rather than their domain, and `ProviderHook` named the *provider-registered* event — a scope event *about* a provider, not a hook the provider raises. `onInstanceDisposed` took a scope and fired on scope disposal, so its name matched neither its argument nor its trigger.

## What

Each hook now lives with the abstraction that raises it, and each hook type is named for that domain:

| Domain       | Owner        | Type             | Methods                             |
| ------------ | ------------ | ---------------- | ----------------------------------- |
| **Scope**    | `IContainer` | `ScopeHook`      | `onScopeCreated`, `onScopeDisposed` |
| **Scope**    | `IContainer` | `RegisteredHook` | `onRegistered`                      |
| **Injector** | `IInjector`  | `InjectorHook`   | `onConstructed`                     |
| **Provider** | `IProvider`  | `ProviderHook`   | `onResolved`                        |

Each hook type is declared in its owner's file rather than gathered in `IContainer.ts`.

**The injector is configured before the container receives it.** `IContainer` gets *no* `getInjector()` — an injector isn't something a container hands out, it's something a container is given:

```typescript
const injector = new MetadataInjector().onConstructed(runMetrics);
const container = new Container({ injector });
```

**Construct modules are injector modules.** `OnConstructModule` / `OnConstructAsyncModule` implement a new `IInjectorModule` (`applyTo(injector: IInjector)`), the mirror of `IContainerModule`, with `useModule` on the `Injector` base for the same fluent shape:

```typescript
const injector = new MetadataInjector().useModule(new OnConstructModule());
const container = new Container({ injector });
```

`OnDisposeModule` stays a container module (`onScopeDisposed`), as do `OnResolvedModule` / `OnResolvedAsyncModule`, which reach every provider via `onRegistered`.

`Container.addInstance` is back to only tracking an instance — the `Injector` base runs construct hooks itself, right after handing the instance to the scope — and `createScope` no longer copies construct hooks into the child, since the child gets the same injector.

`onRegistered` drops the `Provider` qualifier because registration is always of a provider; the name keeps only what varies, the key.

## Breaking changes

No deprecated aliases — clean break, major bump.

| Before                             | After                       |
| ---------------------------------- | --------------------------- |
| `container.onConstruct`            | `injector.onConstructed`    |
| `container.onInstanceDisposed`     | `container.onScopeDisposed` |
| `container.onProviderRegistered`   | `container.onRegistered`    |
| `provider.onResolve`               | `provider.onResolved`       |
| `InstanceHook`                     | `InjectorHook`              |
| `DependencyHook`                   | `ProviderHook`              |
| `ProviderHook`                     | `RegisteredHook`            |
| `OnDisposeHook`                    | `ScopeHook` (folded in)     |
| `ResolvedDependencyHook`           | `ResolvedObjectHook`        |

Also: `IInjector` now requires `onConstructed`, so an injector written from scratch against the interface supplies its own hook list or returns `this` to decline the domain. Code holding only an `IContainer` can no longer register construct hooks — that's the point, but it means a container module that used to enable them has to split into a container half and an injector half.

Unchanged: the `@onConstruct`, `@onContainerDisposed` and `@onResolved` decorators, the hook keys they write, and the `onResolve(...)` registration pipe. Those are declarations on a class or a registration, not domain event registration.

## Docs

- **ADR 0012** (new) — the decision, the trade-offs, and the full rename table; ADR 0007 cross-links to it and keeps its original scope (hook *declaration*).
- README gains a **Hook domains** section (`.readme.hbs.md` + regenerated `README.md`).
- Spec epics updated: `lifecycle-hooks` (new story: "Register imperative hooks with the domain which raises them"), `container-modules`, `injector-strategies`, `provider-behavior`.
- `CLAUDE.md` hooks section rewritten around the three domains.

## Verification

- `pnpm test` — 467 passed (82 files), including 2 new acceptance tests: one asserting the full cross-domain event order, one asserting an `onConstructed` hook covers a whole scope tree however late it's added.
- `pnpm run type-check`, `pnpm run lint` — clean (0 errors).
- `pnpm run build`, then `type-check:react` / `lint:react` / `test:react` — clean, 14 passed. The react package needed no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
