### PR TITLE
feat(ts-ioc-container)!: drop onceResolved/onceResolvedAsync in favor of oncePerInstance

### DIFF
--- a/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
+++ b/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
@@ -14,6 +14,8 @@ import {
   type HookFn,
   HooksRunner,
   inject,
+  invokeMethod,
+  onceForEachInstance,
   prepend,
   prependHooks,
   register,
@@ -640,6 +642,49 @@ describe('hooks', () => {
     onStartHooksRunner.execute(root.resolve(MyClass), { scope: root });
 
     expect(invoked).toEqual(['replacement']);
+  });
+
+  it('should run a hook wrapped in onceForEachInstance a single time per instance under any hook key', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+    const invoked: string[] = [];
+
+    class MyClass {
+      @hook('onStart', append(onceForEachInstance(invokeMethod)))
+      start() {
+        invoked.push('start');
+      }
+    }
+
+    const root = new Container({ tags: ['root'] });
+    const instance = root.resolve(MyClass);
+
+    onStartHooksRunner.execute(instance, { scope: root });
+    onStartHooksRunner.execute(instance, { scope: root });
+
+    expect(invoked).toEqual(['start']);
+  });
+
+  it('should run onceForEachInstance hooks independently for each instance', () => {
+    const onStartHooksRunner = new HooksRunner('onStart');
+
+    class MyClass {
+      startedTimes = 0;
+
+      @hook('onStart', append(onceForEachInstance(invokeMethod)))
+      start() {
+        this.startedTimes += 1;
+      }
+    }
+
+    const root = new Container({ tags: ['root'] });
+    const first = root.resolve(MyClass);
+    const second = root.resolve(MyClass);
+
+    onStartHooksRunner.execute(first, { scope: root });
+    onStartHooksRunner.execute(first, { scope: root });
+    onStartHooksRunner.execute(second, { scope: root });
+
+    expect([first.startedTimes, second.startedTimes]).toEqual([1, 1]);
   });
 
   it('should accept hook classes in appendHooks and prependHooks', () => {

--- a/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
+++ b/packages/ts-ioc-container/__tests__/hooks/hook.spec.ts
@@ -15,7 +15,7 @@ import {
   HooksRunner,
   inject,
   invokeMethod,
-  onceForEachInstance,
+  oncePerInstance,
   prepend,
   prependHooks,
   register,
@@ -644,12 +644,12 @@ describe('hooks', () => {
     expect(invoked).toEqual(['replacement']);
   });
 
-  it('should run a hook wrapped in onceForEachInstance a single time per instance under any hook key', () => {
+  it('should run a hook wrapped in oncePerInstance a single time per instance under any hook key', () => {
     const onStartHooksRunner = new HooksRunner('onStart');
     const invoked: string[] = [];
 
     class MyClass {
-      @hook('onStart', append(onceForEachInstance(invokeMethod)))
+      @hook('onStart', append(oncePerInstance(invokeMethod)))
       start() {
         invoked.push('start');
       }
@@ -664,13 +664,13 @@ describe('hooks', () => {
     expect(invoked).toEqual(['start']);
   });
 
-  it('should run onceForEachInstance hooks independently for each instance', () => {
+  it('should run oncePerInstance hooks independently for each instance', () => {
     const onStartHooksRunner = new HooksRunner('onStart');
 
     class MyClass {
       startedTimes = 0;
 
-      @hook('onStart', append(onceForEachInstance(invokeMethod)))
+      @hook('onStart', append(oncePerInstance(invokeMethod)))
       start() {
         this.startedTimes += 1;
       }

--- a/packages/ts-ioc-container/__tests__/hooks/onResolved.spec.ts
+++ b/packages/ts-ioc-container/__tests__/hooks/onResolved.spec.ts
@@ -8,7 +8,7 @@ import {
   Registration as R,
   invokeMethod,
   onResolved,
-  onceResolved,
+  onceForEachInstance,
   resolved,
   singleton,
 } from '../../lib';
@@ -22,7 +22,7 @@ class Service {
     this.resolvedTimes += 1;
   }
 
-  @onceResolved()
+  @onResolved(onceForEachInstance(invokeMethod))
   open(): void {
     this.openedTimes += 1;
   }
@@ -38,7 +38,7 @@ class AsyncService {
     this.resolvedTimes += 1;
   }
 
-  @onceResolved()
+  @onResolved(onceForEachInstance(invokeMethod))
   async open(): Promise<void> {
     await Promise.resolve();
     this.openedTimes += 1;
@@ -77,7 +77,7 @@ describe('OnResolvedModule', () => {
     expect(service.resolvedTimes).toBe(2);
   });
 
-  it('should run `onceResolved` hooks a single time however often the object is resolved', () => {
+  it('should run once-per-instance hooks a single time however often the object is resolved', () => {
     const service = new Service();
 
     const container = new Container()
@@ -90,7 +90,7 @@ describe('OnResolvedModule', () => {
     expect(service.openedTimes).toBe(1);
   });
 
-  it('should run `onceResolved` hooks a single time for an object resolved through several keys', () => {
+  it('should run once-per-instance hooks a single time for an object resolved through several keys', () => {
     const service = new Service();
 
     const container = new Container()
@@ -104,7 +104,7 @@ describe('OnResolvedModule', () => {
     expect(service.openedTimes).toBe(1);
   });
 
-  it('should run `onceResolved` hooks a single time for an object resolved from several scopes', () => {
+  it('should run once-per-instance hooks a single time for an object resolved from several scopes', () => {
     const service = new Service();
 
     const root = new Container({ tags: ['root'] })
@@ -117,7 +117,7 @@ describe('OnResolvedModule', () => {
     expect(service.openedTimes).toBe(1);
   });
 
-  it('should run `onceResolved` hooks for every distinct object of the same class', () => {
+  it('should run once-per-instance hooks for every distinct object of the same class', () => {
     const container = new Container().useModule(new OnResolvedModule()).addRegistration(R.fromClass(Service));
 
     const first = container.resolve<Service>('Service');
@@ -147,7 +147,7 @@ describe('OnResolvedModule', () => {
       };
 
     class Documented {
-      @onceResolved(record('first'), record('second'))
+      @onResolved(onceForEachInstance(record('first')), onceForEachInstance(record('second')))
       initialize(): void {
         invoked.push('method');
       }
@@ -170,7 +170,7 @@ describe('OnResolvedModule', () => {
         invoked.push('track');
       }
 
-      @onceResolved(invokeMethod)
+      @onResolved(onceForEachInstance(invokeMethod))
       open(): void {
         invoked.push('open');
       }
@@ -217,7 +217,7 @@ describe('OnResolvedModule', () => {
       @onResolved(...hooks)
       track(): void {}
 
-      @onceResolved(...hooks)
+      @onResolved(...hooks.map(onceForEachInstance))
       open(): void {}
     }
 
@@ -236,11 +236,11 @@ describe('OnResolvedModule', () => {
     expect(callsOf('open')).toEqual(['first:open', 'second:open']);
   });
 
-  it('should run `onceResolved` hooks a single time per instance', () => {
+  it('should run once-per-instance hooks a single time per instance', () => {
     const invoked: string[] = [];
 
     class Documented {
-      @onceResolved()
+      @onResolved(onceForEachInstance(invokeMethod))
       open(): void {
         invoked.push('open');
       }
@@ -310,7 +310,7 @@ describe('OnResolvedModule', () => {
     expect(() => container.resolve('Broken')).toThrowError('hook failed');
   });
 
-  it('should keep `onceResolved` hooks deduplicated across containers', () => {
+  it('should keep once-per-instance hooks deduplicated across containers', () => {
     const service = new Service();
 
     const first = new Container().useModule(new OnResolvedModule());
@@ -334,7 +334,7 @@ describe('resolved()', () => {
     expect([service.resolvedTimes, service.openedTimes]).toEqual([1, 1]);
   });
 
-  it('should run `onceResolved` hooks a single time however often the object is resolved', () => {
+  it('should run once-per-instance hooks a single time however often the object is resolved', () => {
     const service = new Service();
 
     const container = new Container().addRegistration(R.fromValue(service).bindToKey('Service').pipe(resolved()));
@@ -345,7 +345,7 @@ describe('resolved()', () => {
     expect([service.openedTimes, service.resolvedTimes]).toEqual([1, 2]);
   });
 
-  it('should run `onceResolved` hooks a single time for an object resolved from several scopes', () => {
+  it('should run once-per-instance hooks a single time for an object resolved from several scopes', () => {
     const service = new Service();
 
     const root = new Container({ tags: ['root'] }).addRegistration(
@@ -400,7 +400,7 @@ describe('OnResolvedModule with async hooks', () => {
     expect(service.resolvedTimes).toBe(2);
   });
 
-  it('should run `onceResolved` hooks a single time however often the object is resolved', async () => {
+  it('should run once-per-instance hooks a single time however often the object is resolved', async () => {
     const service = new AsyncService();
 
     const container = new Container()
@@ -414,7 +414,7 @@ describe('OnResolvedModule with async hooks', () => {
     expect(service.openedTimes).toBe(1);
   });
 
-  it('should run `onceResolved` hooks a single time for an object resolved from several scopes', async () => {
+  it('should run once-per-instance hooks a single time for an object resolved from several scopes', async () => {
     const service = new AsyncService();
 
     const root = new Container({ tags: ['root'] })
@@ -441,7 +441,7 @@ describe('OnResolvedModule with async hooks', () => {
       @onResolved(...hooks)
       track(): void {}
 
-      @onceResolved(...hooks)
+      @onResolved(...hooks.map(onceForEachInstance))
       open(): void {}
     }
 
@@ -521,7 +521,7 @@ describe('resolved() with async hooks', () => {
     expect([service.resolvedTimes, service.openedTimes]).toEqual([1, 1]);
   });
 
-  it('should run `onceResolved` hooks a single time for an object resolved from several scopes', async () => {
+  it('should run once-per-instance hooks a single time for an object resolved from several scopes', async () => {
     const service = new AsyncService();
 
     const root = new Container({ tags: ['root'] }).addRegistration(

--- a/packages/ts-ioc-container/__tests__/hooks/onResolved.spec.ts
+++ b/packages/ts-ioc-container/__tests__/hooks/onResolved.spec.ts
@@ -8,7 +8,7 @@ import {
   Registration as R,
   invokeMethod,
   onResolved,
-  onceForEachInstance,
+  oncePerInstance,
   resolved,
   singleton,
 } from '../../lib';
@@ -22,7 +22,7 @@ class Service {
     this.resolvedTimes += 1;
   }
 
-  @onResolved(onceForEachInstance(invokeMethod))
+  @onResolved(oncePerInstance(invokeMethod))
   open(): void {
     this.openedTimes += 1;
   }
@@ -38,7 +38,7 @@ class AsyncService {
     this.resolvedTimes += 1;
   }
 
-  @onResolved(onceForEachInstance(invokeMethod))
+  @onResolved(oncePerInstance(invokeMethod))
   async open(): Promise<void> {
     await Promise.resolve();
     this.openedTimes += 1;
@@ -147,7 +147,7 @@ describe('OnResolvedModule', () => {
       };
 
     class Documented {
-      @onResolved(onceForEachInstance(record('first')), onceForEachInstance(record('second')))
+      @onResolved(oncePerInstance(record('first')), oncePerInstance(record('second')))
       initialize(): void {
         invoked.push('method');
       }
@@ -170,7 +170,7 @@ describe('OnResolvedModule', () => {
         invoked.push('track');
       }
 
-      @onResolved(onceForEachInstance(invokeMethod))
+      @onResolved(oncePerInstance(invokeMethod))
       open(): void {
         invoked.push('open');
       }
@@ -217,7 +217,7 @@ describe('OnResolvedModule', () => {
       @onResolved(...hooks)
       track(): void {}
 
-      @onResolved(...hooks.map(onceForEachInstance))
+      @onResolved(...hooks.map(oncePerInstance))
       open(): void {}
     }
 
@@ -240,7 +240,7 @@ describe('OnResolvedModule', () => {
     const invoked: string[] = [];
 
     class Documented {
-      @onResolved(onceForEachInstance(invokeMethod))
+      @onResolved(oncePerInstance(invokeMethod))
       open(): void {
         invoked.push('open');
       }
@@ -441,7 +441,7 @@ describe('OnResolvedModule with async hooks', () => {
       @onResolved(...hooks)
       track(): void {}
 
-      @onResolved(...hooks.map(onceForEachInstance))
+      @onResolved(...hooks.map(oncePerInstance))
       open(): void {}
     }
 

--- a/packages/ts-ioc-container/__tests__/metadata/once.spec.ts
+++ b/packages/ts-ioc-container/__tests__/metadata/once.spec.ts
@@ -1,5 +1,6 @@
+import 'reflect-metadata';
 import { describe, it, expect, vi } from 'vitest';
-import { once } from '../../lib';
+import { append, Container, hook, HooksRunner, invokeMethod, once } from '../../lib';
 
 describe('once', () => {
   it('calls the method on first invocation', () => {
@@ -129,6 +130,101 @@ describe('once', () => {
       expect(onRepeat).toHaveBeenCalledTimes(2);
       expect(onRepeat).toHaveBeenNthCalledWith(1, { index: 1, args: ['second'] });
       expect(onRepeat).toHaveBeenNthCalledWith(2, { index: 2, args: ['third'] });
+    });
+  });
+
+  describe('combined with @hook', () => {
+    // `hook(key, ...)` only records metadata for a `HooksRunner` to read later - it never
+    // touches the method descriptor, so it composes with `@once`, which does, regardless
+    // of which decorator is declared first.
+    it('memoizes the method body even though the hook invokes it on every run', () => {
+      const onStartHooksRunner = new HooksRunner('onStart');
+      const fn = vi.fn(() => 42);
+
+      class Service {
+        @hook('onStart', append(invokeMethod))
+        @once()
+        getValue() {
+          return fn();
+        }
+      }
+
+      const root = new Container({ tags: ['root'] });
+      const instance = root.resolve(Service);
+
+      onStartHooksRunner.execute(instance, { scope: root });
+      onStartHooksRunner.execute(instance, { scope: root });
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('memoizes the same way regardless of decorator order', () => {
+      const onStartHooksRunner = new HooksRunner('onStart');
+      const fn = vi.fn(() => 42);
+
+      class Service {
+        @once()
+        @hook('onStart', append(invokeMethod))
+        getValue() {
+          return fn();
+        }
+      }
+
+      const root = new Container({ tags: ['root'] });
+      const instance = root.resolve(Service);
+
+      onStartHooksRunner.execute(instance, { scope: root });
+      onStartHooksRunner.execute(instance, { scope: root });
+
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches independently per instance when several instances share the hook', () => {
+      const onStartHooksRunner = new HooksRunner('onStart');
+      const fn = vi.fn(() => 42);
+
+      class Service {
+        @hook('onStart', append(invokeMethod))
+        @once()
+        getValue() {
+          return fn();
+        }
+      }
+
+      const root = new Container({ tags: ['root'] });
+      const first = root.resolve(Service);
+      const second = root.resolve(Service);
+
+      onStartHooksRunner.execute(first, { scope: root });
+      onStartHooksRunner.execute(second, { scope: root });
+
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns the cached result through the hook on the repeat run', () => {
+      const onStartHooksRunner = new HooksRunner('onStart');
+      let received: unknown;
+
+      class Service {
+        @hook(
+          'onStart',
+          append((context) => {
+            received = context.invokeMethod();
+          }),
+        )
+        @once()
+        getValue() {
+          return 42;
+        }
+      }
+
+      const root = new Container({ tags: ['root'] });
+      const instance = root.resolve(Service);
+
+      onStartHooksRunner.execute(instance, { scope: root });
+      onStartHooksRunner.execute(instance, { scope: root });
+
+      expect(received).toBe(42);
     });
   });
 });

--- a/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
@@ -16,7 +16,7 @@ import {
   onConstruct,
   onScopeDisposed,
   onResolved,
-  onceResolved,
+  onceForEachInstance,
   onResolve,
   Registration as R,
 } from '../../lib';
@@ -65,7 +65,7 @@ describe('Spec: lifecycle hooks', () => {
         this.usedTimes += 1;
       }
 
-      @onceResolved()
+      @onResolved(onceForEachInstance(invoke))
       open(): void {
         this.openedTimes += 1;
       }

--- a/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
@@ -16,7 +16,7 @@ import {
   onConstruct,
   onScopeDisposed,
   onResolved,
-  onceForEachInstance,
+  oncePerInstance,
   onResolve,
   Registration as R,
 } from '../../lib';
@@ -65,7 +65,7 @@ describe('Spec: lifecycle hooks', () => {
         this.usedTimes += 1;
       }
 
-      @onResolved(onceForEachInstance(invoke))
+      @onResolved(oncePerInstance(invoke))
       open(): void {
         this.openedTimes += 1;
       }

--- a/packages/ts-ioc-container/lib/hooks/onResolved.ts
+++ b/packages/ts-ioc-container/lib/hooks/onResolved.ts
@@ -26,8 +26,8 @@ export const onResolvedHooksRunner = new HooksRunner('onResolved');
  * ```
  *
  * Hooks are a rest parameter, so a prepared list spreads: `@onResolved(...hooks)`.
- * Wrap a hook with `onceForEachInstance` to run it on the first resolve of each
- * instance only, e.g. `@onResolved(onceForEachInstance(invokeMethod))`.
+ * Wrap a hook with `oncePerInstance` to run it on the first resolve of each
+ * instance only, e.g. `@onResolved(oncePerInstance(invokeMethod))`.
  *
  * Naming no hook means "invoke the decorated method". Decorators are applied
  * bottom-up, so hooks are prepended to keep them in declaration order:
@@ -45,7 +45,7 @@ const runHooks = (onException?: OnExceptionHandler): ProviderHook =>
  * resolution — including the resolves of a value the container never
  * constructs, and the repeat resolves of one it did. A singleton caches its
  * dependency, so its hooks run on the resolve that filled the cache; a hook
- * wrapped in `onceForEachInstance` runs on the first resolve of its instance
+ * wrapped in `oncePerInstance` runs on the first resolve of its instance
  * however the dependency is registered.
  *
  * Providers are hooked through `onRegistered`, so apply the module

--- a/packages/ts-ioc-container/lib/hooks/onResolved.ts
+++ b/packages/ts-ioc-container/lib/hooks/onResolved.ts
@@ -2,7 +2,7 @@ import type { IContainer, IContainerModule } from '../container/IContainer';
 import type { ProviderHook } from '../provider/IProvider';
 import { HooksRunner, type OnExceptionHandler } from './HooksRunner';
 import { registerPipe } from '../registration/IRegistration';
-import { executeHooks, forEachResolvedObject, onceResolvedHook, resolvedHook } from './resolveHooks';
+import { executeHooks, forEachResolvedObject, resolvedHook } from './resolveHooks';
 
 export const onResolvedHooksRunner = new HooksRunner('onResolved');
 
@@ -26,20 +26,14 @@ export const onResolvedHooksRunner = new HooksRunner('onResolved');
  * ```
  *
  * Hooks are a rest parameter, so a prepared list spreads: `@onResolved(...hooks)`.
- * Use `@onceResolved` to run them on the first resolve of each instance only.
+ * Wrap a hook with `onceForEachInstance` to run it on the first resolve of each
+ * instance only, e.g. `@onResolved(onceForEachInstance(invokeMethod))`.
  *
  * Naming no hook means "invoke the decorated method". Decorators are applied
  * bottom-up, so hooks are prepended to keep them in declaration order:
  * `@onX(h1) @onX(h2) method()` runs h1 before h2.
  */
 export const onResolved = resolvedHook('onResolved');
-
-/**
- * `@onResolved`, narrowed to the first resolve of each instance: the hooks run
- * once for an instance and stay silent on every later resolve of it, however
- * many keys or scopes hand it out.
- */
-export const onceResolved = onceResolvedHook('onResolved');
 
 const runHooks = (onException?: OnExceptionHandler): ProviderHook =>
   forEachResolvedObject(executeHooks(onResolvedHooksRunner, onException));
@@ -50,9 +44,9 @@ const runHooks = (onException?: OnExceptionHandler): ProviderHook =>
  * Where `OnConstructModule` observes construction, this module observes
  * resolution — including the resolves of a value the container never
  * constructs, and the repeat resolves of one it did. A singleton caches its
- * dependency, so its hooks run on the resolve that filled the cache; an
- * `@onceResolved` hook runs on the first resolve of its instance however the
- * dependency is registered.
+ * dependency, so its hooks run on the resolve that filled the cache; a hook
+ * wrapped in `onceForEachInstance` runs on the first resolve of its instance
+ * however the dependency is registered.
  *
  * Providers are hooked through `onRegistered`, so apply the module
  * before the registrations it should cover; scopes created afterwards inherit

--- a/packages/ts-ioc-container/lib/hooks/resolveHooks.ts
+++ b/packages/ts-ioc-container/lib/hooks/resolveHooks.ts
@@ -23,15 +23,15 @@ const toHooks = (hooks: HookType[]): HookType[] => (hooks.length > 0 ? hooks : [
 
 /**
  * Wraps a hook so it runs at most once per instance - compose it with
- * `@onResolved`/`@onResolvedAsync` (e.g. `@onResolved(onceForEachInstance(invokeMethod))`)
- * to run on the first resolve of each instance only.
+ * `@onResolved` (e.g. `@onResolved(oncePerInstance(invokeMethod))`) to run on
+ * the first resolve of each instance only.
  *
  * Instances are remembered in a `WeakSet`, which holds no strong reference, so
  * an instance is collectable once nothing else keeps it alive. The set belongs
  * to the wrapped hook, so every container and scope handing out the same
  * instance shares one memory of what has already run.
  */
-export const onceForEachInstance = (execute: HookType): HookFn => {
+export const oncePerInstance = (execute: HookType): HookFn => {
   const invokedInstances = new WeakSet<object>();
 
   return (context) => {

--- a/packages/ts-ioc-container/lib/hooks/resolveHooks.ts
+++ b/packages/ts-ioc-container/lib/hooks/resolveHooks.ts
@@ -22,14 +22,16 @@ export const invokeMethod: HookFn = (context) => {
 const toHooks = (hooks: HookType[]): HookType[] => (hooks.length > 0 ? hooks : [invokeMethod]);
 
 /**
- * Wraps a hook so it runs at most once per instance.
+ * Wraps a hook so it runs at most once per instance - compose it with
+ * `@onResolved`/`@onResolvedAsync` (e.g. `@onResolved(onceForEachInstance(invokeMethod))`)
+ * to run on the first resolve of each instance only.
  *
  * Instances are remembered in a `WeakSet`, which holds no strong reference, so
  * an instance is collectable once nothing else keeps it alive. The set belongs
- * to the decorated member, so every container and scope handing out the same
+ * to the wrapped hook, so every container and scope handing out the same
  * instance shares one memory of what has already run.
  */
-const onceForEachInstance = (execute: HookType): HookFn => {
+export const onceForEachInstance = (execute: HookType): HookFn => {
   const invokedInstances = new WeakSet<object>();
 
   return (context) => {
@@ -54,15 +56,6 @@ export const resolvedHook =
   (key: string) =>
   (...hooks: HookType[]) =>
     hook(key, prependHooks(...toHooks(hooks)));
-
-/**
- * `resolvedHook(key)` with every hook wrapped so it runs on the first resolve of
- * each instance only - what the `onceResolved` decorators are built from.
- */
-export const onceResolvedHook =
-  (key: string) =>
-  (...hooks: HookType[]) =>
-    hook(key, prependHooks(...toHooks(hooks).map(onceForEachInstance)));
 
 /**
  * Lifts a hook to `ProviderHook`, skipping dependencies which are not objects:

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -103,8 +103,8 @@ export { HookContext, createHookContextFactory, createHookContext, type IHookCon
 export { injectProp } from './hooks/injectProp';
 export { onConstructHooksRunner, onConstruct, OnConstructModule } from './hooks/onConstruct';
 export { onScopeDisposedHooksRunner, onScopeDisposed, OnDisposeModule } from './hooks/onScopeDisposed';
-export { onResolvedHooksRunner, onResolved, onceResolved, OnResolvedModule, resolved } from './hooks/onResolved';
-export { invokeMethod, type ResolvedObjectHook } from './hooks/resolveHooks';
+export { onResolvedHooksRunner, onResolved, OnResolvedModule, resolved } from './hooks/onResolved';
+export { invokeMethod, onceForEachInstance, type ResolvedObjectHook } from './hooks/resolveHooks';
 export {
   HooksRunner,
   runHooks,

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -104,7 +104,7 @@ export { injectProp } from './hooks/injectProp';
 export { onConstructHooksRunner, onConstruct, OnConstructModule } from './hooks/onConstruct';
 export { onScopeDisposedHooksRunner, onScopeDisposed, OnDisposeModule } from './hooks/onScopeDisposed';
 export { onResolvedHooksRunner, onResolved, OnResolvedModule, resolved } from './hooks/onResolved';
-export { invokeMethod, onceForEachInstance, type ResolvedObjectHook } from './hooks/resolveHooks';
+export { invokeMethod, oncePerInstance, type ResolvedObjectHook } from './hooks/resolveHooks';
 export {
   HooksRunner,
   runHooks,

--- a/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
+++ b/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
@@ -4,7 +4,7 @@
 - **ADR:** [ADR 0007 - Lifecycle hooks via reflect-metadata and opt-in modules](../../../adr/0007-lifecycle-hooks.md),
   [ADR 0012 - Hook registration lives with the domain which raises the event](../../../adr/0012-hook-domains.md),
   [ADR 0013 - One async-capable hook path, no `Async` variants](../../../adr/0013-one-async-capable-hook-path.md)
-- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `runHooks`, `OnExceptionHandler`, `onConstruct`, `onScopeDisposed`, `injectProp`, `onResolved`, `onceForEachInstance`, `OnConstructModule`, `OnDisposeModule`, `OnResolvedModule`, `resolved`, `ScopeHook`, `RegisteredHook`, `InjectorHook`, `ProviderHook`, `IInjectorModule`
+- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `runHooks`, `OnExceptionHandler`, `onConstruct`, `onScopeDisposed`, `injectProp`, `onResolved`, `oncePerInstance`, `OnConstructModule`, `OnDisposeModule`, `OnResolvedModule`, `resolved`, `ScopeHook`, `RegisteredHook`, `InjectorHook`, `ProviderHook`, `IInjectorModule`
 - **Executable spec:** `__tests__/specs/lifecycle-hooks.spec.ts`
 
 ## Intent
@@ -56,8 +56,8 @@ Acceptance criteria:
   rest parameter, and invokes the decorated method when no hook is named.
 - `OnResolvedModule` opts a container into resolve hook execution; the
   `resolved()` pipe opts in a single registration instead.
-- `onResolved` hooks run on every resolve; a hook wrapped in `onceForEachInstance`
-  (e.g. `onResolved(onceForEachInstance(invokeMethod))`) runs a single time per
+- `onResolved` hooks run on every resolve; a hook wrapped in `oncePerInstance`
+  (e.g. `onResolved(oncePerInstance(invokeMethod))`) runs a single time per
   instance however many keys, scopes, or resolve calls return it.
 - Distinct objects of the same class each get their own once-resolve hook run.
 - Providers registered before the module was applied are not covered.

--- a/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
+++ b/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
@@ -4,7 +4,7 @@
 - **ADR:** [ADR 0007 - Lifecycle hooks via reflect-metadata and opt-in modules](../../../adr/0007-lifecycle-hooks.md),
   [ADR 0012 - Hook registration lives with the domain which raises the event](../../../adr/0012-hook-domains.md),
   [ADR 0013 - One async-capable hook path, no `Async` variants](../../../adr/0013-one-async-capable-hook-path.md)
-- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `runHooks`, `OnExceptionHandler`, `onConstruct`, `onScopeDisposed`, `injectProp`, `onResolved`, `onceResolved`, `OnConstructModule`, `OnDisposeModule`, `OnResolvedModule`, `resolved`, `ScopeHook`, `RegisteredHook`, `InjectorHook`, `ProviderHook`, `IInjectorModule`
+- **Public API:** `hook`, `getHooks`, `hasHooks`, `HooksRunner`, `HookContext`, `createHookContext`, `createHookContextFactory`, `runHooks`, `OnExceptionHandler`, `onConstruct`, `onScopeDisposed`, `injectProp`, `onResolved`, `onceForEachInstance`, `OnConstructModule`, `OnDisposeModule`, `OnResolvedModule`, `resolved`, `ScopeHook`, `RegisteredHook`, `InjectorHook`, `ProviderHook`, `IInjectorModule`
 - **Executable spec:** `__tests__/specs/lifecycle-hooks.spec.ts`
 
 ## Intent
@@ -56,8 +56,9 @@ Acceptance criteria:
   rest parameter, and invokes the decorated method when no hook is named.
 - `OnResolvedModule` opts a container into resolve hook execution; the
   `resolved()` pipe opts in a single registration instead.
-- `onResolved` hooks run on every resolve; `onceResolved` hooks run a single time
-  per instance however many keys, scopes, or resolve calls return it.
+- `onResolved` hooks run on every resolve; a hook wrapped in `onceForEachInstance`
+  (e.g. `onResolved(onceForEachInstance(invokeMethod))`) runs a single time per
+  instance however many keys, scopes, or resolve calls return it.
 - Distinct objects of the same class each get their own once-resolve hook run.
 - Providers registered before the module was applied are not covered.
 - Rejected async hooks are reported to the module `onException` handler when one


### PR DESCRIPTION
## Description

`onceResolved` and `onceResolvedAsync` were thin sugar over `onResolved`/`onResolvedAsync` with every passed hook wrapped once-per-instance. Since the wrapper itself is already generic over any `HookType`, it's exported directly instead — as `oncePerInstance` — and composes with `onResolved` (and any custom `@hook(key, ...)` declaration) to get the exact same behavior, e.g.:

```ts
class Connection {
  @onResolved(oncePerInstance(invokeMethod))
  open(): void {}
}
```

Note: this branch also picked up a rebase onto `main` after #148 landed (which itself merged the separate sync/async hook paths into one), so `onResolvedAsync`/`onceResolvedAsync` no longer exist as separate exports independent of this change either — only `onResolved` remains, taking sync and async hooks alike.

This drops one decorator/export pair while keeping the same capability, with no change to `onResolved`'s own behavior. Added test coverage confirming `oncePerInstance` composes with any custom hook key, not just `onResolved`.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [x] `BREAKING CHANGE` — incompatible API change (major release)
- [ ] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`)
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed (no diff — `onceResolved` wasn't referenced there)
- [x] Tests added or updated under `__tests__/` to cover the change
- [x] `pnpm run lint` passes
- [x] `pnpm run type-check` passes
- [x] `pnpm test` passes (473/473)
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope

## Additional notes

`onceResolved` is no longer exported (nor is `onceResolvedAsync`/`onResolvedAsync`, both already removed by #148). Migration: replace `@onceResolved(...hooks)` with `@onResolved(...hooks.map(oncePerInstance))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MW9jjn5bMK5Q3JroEDhZ4Z