### PR TITLE
feat(ts-ioc-container)!: add TypedEvent and replace container hook methods with scope events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,8 +264,7 @@ Hooks are async-capable by default, so there is no `Async`-postfixed decorator o
 
 Hooks are split by the domain that raises the event (ADR 0012) — where a hook is registered says which subsystem raises it:
 
-- **Scope** (`IContainer`): `onScopeCreated`, `onScopeDisposed` (`ScopeHook`), `onRegistered` (`RegisteredHook`)
-  — sugar over the `scopeCreated`, `scopeDisposed`, `registered` properties, which are `ITypedEvent`s (`lib/utils/TypedEvent.ts`: `subscribe` returns an unsubscribe fn; `emit` stays private to `Container`). A child scope gets a copy of the parent's listeners at `createScope` time; `dispose` disposes the events, so a disposed container rejects new hooks with `TypedEventDisposedError`.
+- **Scope** (`IContainer`): the `scopeCreated`, `scopeDisposed` (`ScopeHook` listeners) and `registered` (`RegisteredHook` listeners) properties, which are `ITypedEvent`s (`lib/utils/TypedEvent.ts`: `subscribe` returns an unsubscribe fn; `emit` stays private to `Container`). There are no `onScopeCreated(...)`-style methods on the container. A child scope gets a copy of the parent's listeners at `createScope` time; `dispose` disposes the events, so a disposed container rejects new hooks with `TypedEventDisposedError`.
 - **Injector** (`IInjector`): `onConstructed` (`InjectorHook`)
 - **Provider** (`IProvider`): `onResolved` (`ProviderHook`), or the `onResolve(...)` registration pipe
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,7 @@ Hooks are async-capable by default, so there is no `Async`-postfixed decorator o
 Hooks are split by the domain that raises the event (ADR 0012) — where a hook is registered says which subsystem raises it:
 
 - **Scope** (`IContainer`): `onScopeCreated`, `onScopeDisposed` (`ScopeHook`), `onRegistered` (`RegisteredHook`)
+  — sugar over the `scopeCreated`, `scopeDisposed`, `registered` properties, which are `ITypedEvent`s (`lib/utils/TypedEvent.ts`: `subscribe` returns an unsubscribe fn; `emit` stays private to `Container`). A child scope gets a copy of the parent's listeners at `createScope` time; `dispose` disposes the events, so a disposed container rejects new hooks with `TypedEventDisposedError`.
 - **Injector** (`IInjector`): `onConstructed` (`InjectorHook`)
 - **Provider** (`IProvider`): `onResolved` (`ProviderHook`), or the `onResolve(...)` registration pipe
 

--- a/packages/ts-ioc-container/.readme.hbs.md
+++ b/packages/ts-ioc-container/.readme.hbs.md
@@ -547,12 +547,10 @@ The decorators above declare hook *metadata* on a class. The imperative side —
 the callbacks the container machinery runs — is registered on whichever
 abstraction raises the event, one hook type per domain:
 
-| Domain       | Registered on | Type            | Methods                                                  |
+| Domain       | Registered on | Type            | Where                                                    |
 | ------------ | ------------- | --------------- | -------------------------------------------------------- |
-| **Scope**    | `IContainer`  | `ScopeHook`     | `onScopeCreated(...)`, `onScopeDisposed(...)`            |
-| **Scope**    | `IContainer`  | `RegisteredHook`| `onRegistered(...)`                                      |
-| **Scope**    | `IContainer`  | `ITypedEvent`   | `scopeCreated`, `scopeDisposed`, `registered` events     |
-| **Scope**    | `IContainer`  | `ITypedEvent`   | `scopeCreated`, `scopeDisposed`, `registered` events     |
+| **Scope**    | `IContainer`  | `ScopeHook`     | `scopeCreated.subscribe(...)`, `scopeDisposed.subscribe(...)` |
+| **Scope**    | `IContainer`  | `RegisteredHook`| `registered.subscribe(...)`                              |
 | **Injector** | `IInjector`   | `InjectorHook`  | `onConstructed(...)`                                     |
 | **Provider** | `IProvider`   | `ProviderHook`  | `onResolved(...)`, or the [`onResolve`](#on-resolve) pipe |
 
@@ -564,32 +562,30 @@ so a child inherits what its parent held then and later additions to either
 stay local.
 
 ```typescript
-const container = new Container({ tags: ['application'] })
-  .onScopeCreated((scope) => audit.scopeOpened(scope))
-  .onScopeDisposed((scope) => audit.scopeClosed(scope))
-  .onRegistered((provider, key) => audit.registered(key));
+const container = new Container({ tags: ['application'] });
+
+// Scope events are typed events on the container itself
+const stop = container.scopeCreated.subscribe((scope) => audit.scopeOpened(scope));
+container.scopeDisposed.subscribe((scope) => audit.scopeClosed(scope));
+container.registered.subscribe((provider, key) => audit.registered(key));
+
+stop(); // detached; `container.scopeCreated.unsubscribe(fn)` does the same by reference
 
 // Construction is the injector's event, not a scope's
 container.getInjector().onConstructed((instance, scope) => metrics.built(instance, scope));
 ```
 
-The built-in modules are all container modules: `OnConstructModule` reaches the
-injector through `getInjector()`, `OnDisposeModule` hooks `onScopeDisposed`, and
-`OnResolvedModule` reaches every provider through `onRegistered`.
-
-The scope methods are sugar over three typed events the container exposes —
-`scopeCreated`, `scopeDisposed` (`ITypedEvent<[IContainer]>`) and `registered`
-(`ITypedEvent<[IProvider, DependencyKey, IContainer]>`). Subscribe there when a
-hook needs to be detached again; `subscribe` returns the unsubscribe function.
-The exposed events carry no `emit` — only the container raises its own events:
-
-```typescript
-const stop = container.scopeCreated.subscribe((scope) => audit.scopeOpened(scope));
-stop(); // detached; `container.scopeCreated.unsubscribe(fn)` does the same by reference
-```
+The scope events are `scopeCreated`, `scopeDisposed` (`ITypedEvent<[IContainer]>`)
+and `registered` (`ITypedEvent<[IProvider, DependencyKey, IContainer]>`);
+`subscribe` returns the unsubscribe function. The exposed events carry no
+`emit` — only the container raises its own events.
 
 `TypedEvent` itself is exported for your own events: `subscribe` / `unsubscribe`
 / `emit` / `dispose`, with `ITypedEvent` as the subscriber-only view to hand out.
+
+The built-in modules are all container modules: `OnConstructModule` reaches the
+injector through `getInjector()`, `OnDisposeModule` subscribes to `scopeDisposed`,
+and `OnResolvedModule` reaches every provider through `registered`.
 
 ### OnConstruct
 

--- a/packages/ts-ioc-container/.readme.hbs.md
+++ b/packages/ts-ioc-container/.readme.hbs.md
@@ -551,6 +551,8 @@ abstraction raises the event, one hook type per domain:
 | ------------ | ------------- | --------------- | -------------------------------------------------------- |
 | **Scope**    | `IContainer`  | `ScopeHook`     | `onScopeCreated(...)`, `onScopeDisposed(...)`            |
 | **Scope**    | `IContainer`  | `RegisteredHook`| `onRegistered(...)`                                      |
+| **Scope**    | `IContainer`  | `ITypedEvent`   | `scopeCreated`, `scopeDisposed`, `registered` events     |
+| **Scope**    | `IContainer`  | `ITypedEvent`   | `scopeCreated`, `scopeDisposed`, `registered` events     |
 | **Injector** | `IInjector`   | `InjectorHook`  | `onConstructed(...)`                                     |
 | **Provider** | `IProvider`   | `ProviderHook`  | `onResolved(...)`, or the [`onResolve`](#on-resolve) pipe |
 
@@ -574,6 +576,20 @@ container.getInjector().onConstructed((instance, scope) => metrics.built(instanc
 The built-in modules are all container modules: `OnConstructModule` reaches the
 injector through `getInjector()`, `OnDisposeModule` hooks `onScopeDisposed`, and
 `OnResolvedModule` reaches every provider through `onRegistered`.
+
+The scope methods are sugar over three typed events the container exposes —
+`scopeCreated`, `scopeDisposed` (`ITypedEvent<[IContainer]>`) and `registered`
+(`ITypedEvent<[IProvider, DependencyKey, IContainer]>`). Subscribe there when a
+hook needs to be detached again; `subscribe` returns the unsubscribe function.
+The exposed events carry no `emit` — only the container raises its own events:
+
+```typescript
+const stop = container.scopeCreated.subscribe((scope) => audit.scopeOpened(scope));
+stop(); // detached; `container.scopeCreated.unsubscribe(fn)` does the same by reference
+```
+
+`TypedEvent` itself is exported for your own events: `subscribe` / `unsubscribe`
+/ `emit` / `dispose`, with `ITypedEvent` as the subscriber-only view to hand out.
 
 ### OnConstruct
 

--- a/packages/ts-ioc-container/README.md
+++ b/packages/ts-ioc-container/README.md
@@ -2877,6 +2877,8 @@ abstraction raises the event, one hook type per domain:
 | ------------ | ------------- | --------------- | -------------------------------------------------------- |
 | **Scope**    | `IContainer`  | `ScopeHook`     | `onScopeCreated(...)`, `onScopeDisposed(...)`            |
 | **Scope**    | `IContainer`  | `RegisteredHook`| `onRegistered(...)`                                      |
+| **Scope**    | `IContainer`  | `ITypedEvent`   | `scopeCreated`, `scopeDisposed`, `registered` events     |
+| **Scope**    | `IContainer`  | `ITypedEvent`   | `scopeCreated`, `scopeDisposed`, `registered` events     |
 | **Injector** | `IInjector`   | `InjectorHook`  | `onConstructed(...)`                                     |
 | **Provider** | `IProvider`   | `ProviderHook`  | `onResolved(...)`, or the [`onResolve`](#on-resolve) pipe |
 
@@ -2900,6 +2902,20 @@ container.getInjector().onConstructed((instance, scope) => metrics.built(instanc
 The built-in modules are all container modules: `OnConstructModule` reaches the
 injector through `getInjector()`, `OnDisposeModule` hooks `onScopeDisposed`, and
 `OnResolvedModule` reaches every provider through `onRegistered`.
+
+The scope methods are sugar over three typed events the container exposes —
+`scopeCreated`, `scopeDisposed` (`ITypedEvent<[IContainer]>`) and `registered`
+(`ITypedEvent<[IProvider, DependencyKey, IContainer]>`). Subscribe there when a
+hook needs to be detached again; `subscribe` returns the unsubscribe function.
+The exposed events carry no `emit` — only the container raises its own events:
+
+```typescript
+const stop = container.scopeCreated.subscribe((scope) => audit.scopeOpened(scope));
+stop(); // detached; `container.scopeCreated.unsubscribe(fn)` does the same by reference
+```
+
+`TypedEvent` itself is exported for your own events: `subscribe` / `unsubscribe`
+/ `emit` / `dispose`, with `ITypedEvent` as the subscriber-only view to hand out.
 
 ### OnConstruct
 

--- a/packages/ts-ioc-container/README.md
+++ b/packages/ts-ioc-container/README.md
@@ -2873,12 +2873,10 @@ The decorators above declare hook *metadata* on a class. The imperative side —
 the callbacks the container machinery runs — is registered on whichever
 abstraction raises the event, one hook type per domain:
 
-| Domain       | Registered on | Type            | Methods                                                  |
+| Domain       | Registered on | Type            | Where                                                    |
 | ------------ | ------------- | --------------- | -------------------------------------------------------- |
-| **Scope**    | `IContainer`  | `ScopeHook`     | `onScopeCreated(...)`, `onScopeDisposed(...)`            |
-| **Scope**    | `IContainer`  | `RegisteredHook`| `onRegistered(...)`                                      |
-| **Scope**    | `IContainer`  | `ITypedEvent`   | `scopeCreated`, `scopeDisposed`, `registered` events     |
-| **Scope**    | `IContainer`  | `ITypedEvent`   | `scopeCreated`, `scopeDisposed`, `registered` events     |
+| **Scope**    | `IContainer`  | `ScopeHook`     | `scopeCreated.subscribe(...)`, `scopeDisposed.subscribe(...)` |
+| **Scope**    | `IContainer`  | `RegisteredHook`| `registered.subscribe(...)`                              |
 | **Injector** | `IInjector`   | `InjectorHook`  | `onConstructed(...)`                                     |
 | **Provider** | `IProvider`   | `ProviderHook`  | `onResolved(...)`, or the [`onResolve`](#on-resolve) pipe |
 
@@ -2890,32 +2888,30 @@ so a child inherits what its parent held then and later additions to either
 stay local.
 
 ```typescript
-const container = new Container({ tags: ['application'] })
-  .onScopeCreated((scope) => audit.scopeOpened(scope))
-  .onScopeDisposed((scope) => audit.scopeClosed(scope))
-  .onRegistered((provider, key) => audit.registered(key));
+const container = new Container({ tags: ['application'] });
+
+// Scope events are typed events on the container itself
+const stop = container.scopeCreated.subscribe((scope) => audit.scopeOpened(scope));
+container.scopeDisposed.subscribe((scope) => audit.scopeClosed(scope));
+container.registered.subscribe((provider, key) => audit.registered(key));
+
+stop(); // detached; `container.scopeCreated.unsubscribe(fn)` does the same by reference
 
 // Construction is the injector's event, not a scope's
 container.getInjector().onConstructed((instance, scope) => metrics.built(instance, scope));
 ```
 
-The built-in modules are all container modules: `OnConstructModule` reaches the
-injector through `getInjector()`, `OnDisposeModule` hooks `onScopeDisposed`, and
-`OnResolvedModule` reaches every provider through `onRegistered`.
-
-The scope methods are sugar over three typed events the container exposes —
-`scopeCreated`, `scopeDisposed` (`ITypedEvent<[IContainer]>`) and `registered`
-(`ITypedEvent<[IProvider, DependencyKey, IContainer]>`). Subscribe there when a
-hook needs to be detached again; `subscribe` returns the unsubscribe function.
-The exposed events carry no `emit` — only the container raises its own events:
-
-```typescript
-const stop = container.scopeCreated.subscribe((scope) => audit.scopeOpened(scope));
-stop(); // detached; `container.scopeCreated.unsubscribe(fn)` does the same by reference
-```
+The scope events are `scopeCreated`, `scopeDisposed` (`ITypedEvent<[IContainer]>`)
+and `registered` (`ITypedEvent<[IProvider, DependencyKey, IContainer]>`);
+`subscribe` returns the unsubscribe function. The exposed events carry no
+`emit` — only the container raises its own events.
 
 `TypedEvent` itself is exported for your own events: `subscribe` / `unsubscribe`
 / `emit` / `dispose`, with `ITypedEvent` as the subscriber-only view to hand out.
+
+The built-in modules are all container modules: `OnConstructModule` reaches the
+injector through `getInjector()`, `OnDisposeModule` subscribes to `scopeDisposed`,
+and `OnResolvedModule` reaches every provider through `registered`.
 
 ### OnConstruct
 

--- a/packages/ts-ioc-container/__tests__/container/AutoResolve.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/AutoResolve.spec.ts
@@ -171,7 +171,7 @@ describe('autoResolve', function () {
 
   it('should not be supported by an empty container', function () {
     expect(() => new EmptyContainer().autoResolve()).toThrowError(MethodNotImplementedError);
-    expect(() => new EmptyContainer().onScopeCreated(() => {})).toThrowError(MethodNotImplementedError);
+    expect(() => new EmptyContainer().scopeCreated).toThrowError(MethodNotImplementedError);
   });
 
   describe('args', function () {

--- a/packages/ts-ioc-container/__tests__/container/EmptyContainer.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/EmptyContainer.spec.ts
@@ -43,7 +43,7 @@ describe('EmptyContainer', () => {
     );
   });
 
-  it('should raise an error when registering a scope disposal hook', () => {
-    expect(() => new EmptyContainer().onScopeDisposed(() => {})).toThrowError(MethodNotImplementedError);
+  it('should raise an error when accessing the scope disposal event', () => {
+    expect(() => new EmptyContainer().scopeDisposed).toThrowError(MethodNotImplementedError);
   });
 });

--- a/packages/ts-ioc-container/__tests__/container/IContainer.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/IContainer.spec.ts
@@ -23,7 +23,8 @@ describe('IContainer', function () {
       }
     };
 
-    const container = new Container({ tags: ['root'] }).onScopeDisposed(onDispose);
+    const container = new Container({ tags: ['root'] });
+    container.scopeDisposed.subscribe(onDispose);
 
     container.dispose();
 

--- a/packages/ts-ioc-container/__tests__/container/OnRegistered.spec.ts
+++ b/packages/ts-ioc-container/__tests__/container/OnRegistered.spec.ts
@@ -17,7 +17,9 @@ describe('onRegistered', () => {
   it('should run the hook when a provider is registered', () => {
     const log: [DependencyKey, unknown][] = [];
 
-    new Container().onRegistered(record(log)).register('key', Provider.fromValue(1));
+    const container = new Container();
+    container.registered.subscribe(record(log));
+    container.register('key', Provider.fromValue(1));
 
     expect(log).toEqual([['key', 1]]);
   });
@@ -25,13 +27,11 @@ describe('onRegistered', () => {
   it('should run every hook in the order it was added', () => {
     const log: string[] = [];
 
-    new Container()
-      .onRegistered(
-        () => log.push('first'),
-        () => log.push('second'),
-      )
-      .onRegistered(() => log.push('third'))
-      .register('key', Provider.fromValue(1));
+    const container = new Container();
+    container.registered.subscribe(() => log.push('first'));
+    container.registered.subscribe(() => log.push('second'));
+    container.registered.subscribe(() => log.push('third'));
+    container.register('key', Provider.fromValue(1));
 
     expect(log).toEqual(['first', 'second', 'third']);
   });
@@ -39,7 +39,8 @@ describe('onRegistered', () => {
   it('should pass the registering scope to the hook', () => {
     let hookScope: IContainer | undefined;
 
-    const root = new Container({ tags: ['root'] }).onRegistered((_p, _k, s) => {
+    const root = new Container({ tags: ['root'] });
+    root.registered.subscribe((_p, _k, s) => {
       hookScope = s;
     });
     root.register('key', Provider.fromValue(1));
@@ -50,7 +51,9 @@ describe('onRegistered', () => {
   it('should run the hook when a registration is added', () => {
     const log: [DependencyKey, unknown][] = [];
 
-    new Container().onRegistered(record(log)).addRegistration(Registration.fromValue(1).bindTo('key'));
+    const container = new Container();
+    container.registered.subscribe(record(log));
+    container.addRegistration(Registration.fromValue(1).bindTo('key'));
 
     expect(log).toEqual([['key', 1]]);
   });
@@ -58,9 +61,9 @@ describe('onRegistered', () => {
   it('should run inherited hooks for providers cloned into a child scope', () => {
     const log: [DependencyKey, unknown][] = [];
 
-    const root = new Container({ tags: ['root'] })
-      .onRegistered(record(log))
-      .addRegistration(Registration.fromValue(1).bindTo('key'));
+    const root = new Container({ tags: ['root'] });
+    root.registered.subscribe(record(log));
+    root.addRegistration(Registration.fromValue(1).bindTo('key'));
     log.length = 0;
 
     const child = root.createScope({ tags: ['child'] });
@@ -72,7 +75,9 @@ describe('onRegistered', () => {
   it('should not run the hook for registrations which do not match the child scope', () => {
     const log: [DependencyKey, unknown][] = [];
 
-    const root = new Container({ tags: ['root'] }).onRegistered(record(log)).addRegistration(
+    const root = new Container({ tags: ['root'] });
+    root.registered.subscribe(record(log));
+    root.addRegistration(
       Registration.fromValue(1)
         .bindTo('key')
         .when((s) => s.hasTag('other')),
@@ -88,14 +93,14 @@ describe('onRegistered', () => {
     const log: [DependencyKey, unknown][] = [];
 
     const root = new Container({ tags: ['root'] });
-    root.createScope({ tags: ['child'] }).onRegistered(record(log));
+    root.createScope({ tags: ['child'] }).registered.subscribe(record(log));
 
     root.register('key', Provider.fromValue(1));
 
     expect(log).toEqual([]);
   });
 
-  it('should raise an error when registering the hook on an empty container', () => {
-    expect(() => new EmptyContainer().onRegistered(() => {})).toThrowError(MethodNotImplementedError);
+  it('should raise an error when accessing the event on an empty container', () => {
+    expect(() => new EmptyContainer().registered).toThrowError(MethodNotImplementedError);
   });
 });

--- a/packages/ts-ioc-container/__tests__/specs/errors-and-boundaries.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/errors-and-boundaries.spec.ts
@@ -13,6 +13,8 @@ import {
   ProviderDisposedError,
   Registration as R,
   UnsupportedTokenTypeError,
+  TypedEvent,
+  TypedEventDisposedError,
   ContainerError,
   hook,
   SequentialSync,
@@ -54,6 +56,16 @@ describe('Spec: errors and boundaries', () => {
     expect(() => provider.hasAccess({ invocationScope: container, providerScope: container, args: [] })).toThrowError(
       ProviderDisposedError,
     );
+  });
+
+  it('rejects disposed typed event usage', () => {
+    const event = new TypedEvent<[string]>();
+
+    event.dispose();
+
+    expect(() => event.subscribe(() => {})).toThrowError(TypedEventDisposedError);
+    expect(() => event.emit('late')).toThrowError(TypedEventDisposedError);
+    expect(new TypedEventDisposedError('x')).toBeInstanceOf(ContainerError);
   });
 
   it('rejects unsupported token operations', () => {

--- a/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { expectTypeOf } from 'vitest';
 import {
   MetadataInjector,
   OnConstructModule,
@@ -6,6 +7,9 @@ import {
   OnResolvedModule,
   append,
   Container,
+  EmptyContainer,
+  MethodNotImplementedError,
+  Provider,
   hasHooks,
   hook,
   HookContext,
@@ -348,6 +352,53 @@ describe('Spec: lifecycle hooks', () => {
       'resolved:Service',
       'scopeDisposed',
     ]);
+  });
+
+  it('exposes scope events as typed events which a hook can be detached from', () => {
+    const log: string[] = [];
+    const container = new Container({ tags: ['app'] });
+
+    const stopCreated = container.scopeCreated.subscribe((scope) => log.push(`created:${scope.hasTag('request')}`));
+    const onRegistered = (_provider: unknown, key: unknown) => log.push(`registered:${String(key)}`);
+    container.registered.subscribe(onRegistered);
+    container.scopeDisposed.subscribe(() => log.push('disposed'));
+
+    container.register('a', Provider.fromValue(1));
+    container.createScope({ tags: ['request'] }).dispose();
+
+    stopCreated();
+    container.registered.unsubscribe(onRegistered);
+
+    container.register('b', Provider.fromValue(2));
+    container.createScope({ tags: ['request'] }).dispose();
+
+    // The container's own scopeDisposed event fires for the container itself, not for its children.
+    expect(log).toEqual(['registered:a', 'created:true', 'disposed', 'disposed']);
+    // The exposed event is the subscriber's side only - it carries no emit.
+    expectTypeOf(container.scopeCreated).not.toHaveProperty('emit');
+    expectTypeOf(container.registered).not.toHaveProperty('emit');
+  });
+
+  it('gives a child scope a copy of the parent listeners, so later detaching on either stays local', () => {
+    const log: string[] = [];
+    const container = new Container({ tags: ['app'] });
+    const stop = container.scopeCreated.subscribe((scope) => log.push(`created:${scope.hasTag('child')}`));
+
+    const child = container.createScope({ tags: ['child'] });
+    stop();
+
+    child.createScope({ tags: ['grandchild'] });
+    container.createScope({ tags: ['child'] });
+
+    expect(log).toEqual(['created:true', 'created:false']);
+  });
+
+  it('rejects scope events on the empty container', () => {
+    const empty = new EmptyContainer();
+
+    expect(() => empty.scopeCreated).toThrowError(MethodNotImplementedError);
+    expect(() => empty.scopeDisposed).toThrowError(MethodNotImplementedError);
+    expect(() => empty.registered).toThrowError(MethodNotImplementedError);
   });
 
   it('shares injector hooks with every scope built on the same injector', () => {

--- a/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/lifecycle-hooks.spec.ts
@@ -305,10 +305,11 @@ describe('Spec: lifecycle hooks', () => {
     expect(worker.calls).toEqual(['start']);
   });
 
-  it('runs direct disposal callbacks registered with onScopeDisposed', () => {
+  it('runs direct disposal callbacks subscribed to scopeDisposed', () => {
     const disposed: string[] = [];
 
-    const container = new Container({ tags: ['app'] }).onScopeDisposed((c) => {
+    const container = new Container({ tags: ['app'] });
+    container.scopeDisposed.subscribe((c) => {
       if (c.hasTag('app')) disposed.push('app');
     });
 
@@ -327,11 +328,11 @@ describe('Spec: lifecycle hooks', () => {
       log.push(`constructed:${instance.constructor.name}`),
     );
 
-    const container = new Container({ injector, tags: ['app'] })
-      // Scope domain — the container's own events.
-      .onScopeCreated((scope) => log.push(`scopeCreated:${scope.hasTag('request')}`))
-      .onScopeDisposed(() => log.push('scopeDisposed'))
-      .onRegistered((_provider, key) => log.push(`registered:${String(key)}`));
+    const container = new Container({ injector, tags: ['app'] });
+    // Scope domain — the container's own events.
+    container.scopeCreated.subscribe((scope) => log.push(`scopeCreated:${scope.hasTag('request')}`));
+    container.scopeDisposed.subscribe(() => log.push('scopeDisposed'));
+    container.registered.subscribe((_provider, key) => log.push(`registered:${String(key)}`));
 
     container.addRegistration(
       // Provider domain — resolution.

--- a/packages/ts-ioc-container/__tests__/specs/metadata-utilities.spec.ts
+++ b/packages/ts-ioc-container/__tests__/specs/metadata-utilities.spec.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import { afterEach, beforeEach, vi } from 'vitest';
+import { Mock, Times } from 'moq.ts';
 import {
   addClassLabel,
   addClassTag,
@@ -19,6 +20,9 @@ import {
   addParamTag,
   shallowCache,
   throttle,
+  TypedEvent,
+  type TypedEventListener,
+  TypedEventDisposedError,
 } from '../../lib';
 
 describe('Spec: metadata utilities', () => {
@@ -107,6 +111,55 @@ describe('Spec: metadata utilities', () => {
     vi.advanceTimersByTime(100);
 
     expect(calls).toEqual(['first', 'second', 'latest']);
+  });
+
+  it('publishes typed events to subscribers until they unsubscribe or the event is disposed', () => {
+    const event = new TypedEvent<[string]>();
+    const first = new Mock<TypedEventListener<[string]>>();
+    const second = new Mock<TypedEventListener<[string]>>();
+
+    const unsubscribeFirst = event.subscribe(first.object());
+    event.subscribe(second.object());
+    event.subscribe(second.object()); // a repeated subscription does not double-deliver
+
+    event.emit('one');
+    unsubscribeFirst();
+    unsubscribeFirst(); // harmless when already detached
+    event.emit('two');
+    event.unsubscribe(second.object());
+    event.unsubscribe(second.object()); // harmless when already detached
+    event.emit('three');
+
+    first.verify((l) => l('one'), Times.Once());
+    first.verify((l) => l('two'), Times.Never());
+    second.verify((l) => l('one'), Times.Once());
+    second.verify((l) => l('two'), Times.Once());
+    second.verify((l) => l('three'), Times.Never());
+
+    event.dispose();
+
+    expect(() => event.subscribe(first.object())).toThrowError(TypedEventDisposedError);
+    expect(() => event.emit('four')).toThrowError(TypedEventDisposedError);
+    expect(() => event.unsubscribe(first.object())).not.toThrow();
+  });
+
+  it('delivers an emission in subscription order and settles subscription changes made mid-emission', () => {
+    const event = new TypedEvent<[number]>();
+    const log: string[] = [];
+    const late: TypedEventListener<[number]> = (n) => log.push(`late:${n}`);
+    const second: TypedEventListener<[number]> = (n) => log.push(`second:${n}`);
+
+    event.subscribe((n) => {
+      log.push(`first:${n}`);
+      event.unsubscribe(second);
+      event.subscribe(late);
+    });
+    event.subscribe(second);
+
+    event.emit(1);
+    event.emit(2);
+
+    expect(log).toEqual(['first:1', 'first:2', 'late:2']);
   });
 
   it('handles synchronous and asynchronous method errors with context', async () => {

--- a/packages/ts-ioc-container/lib/container/AutoResolveModule.ts
+++ b/packages/ts-ioc-container/lib/container/AutoResolveModule.ts
@@ -19,6 +19,6 @@ export class AutoResolveModule implements IContainerModule {
   constructor(private readonly options: AutoResolveOptions = {}) {}
 
   applyTo(container: IContainer): void {
-    container.onScopeCreated((scope) => scope.autoResolve(this.options));
+    container.scopeCreated.subscribe((scope) => scope.autoResolve(this.options));
   }
 }

--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -4,11 +4,9 @@ import {
   type DependencyKey,
   type IContainer,
   type IContainerModule,
-  type RegisteredHook,
   type RegisterOptions,
   ResolveManyOptions,
   type ResolveOneOptions,
-  type ScopeHook,
   type Tag,
 } from './IContainer';
 import { type IInjector } from '../injector/IInjector';
@@ -140,10 +138,10 @@ export class Container implements IContainer {
     this.validateContainer();
 
     // Injector hooks need no copying - the child shares this scope's injector, so it shares its hooks.
-    const scope = new Container({ injector: this.injector, parent: this, tags })
-      .onScopeCreated(...this.scopeCreatedEvent.getListeners())
-      .onScopeDisposed(...this.scopeDisposedEvent.getListeners())
-      .onRegistered(...this.registeredEvent.getListeners());
+    const scope = new Container({ injector: this.injector, parent: this, tags });
+    this.scopeCreatedEvent.getListeners().forEach((hook) => scope.scopeCreatedEvent.subscribe(hook));
+    this.scopeDisposedEvent.getListeners().forEach((hook) => scope.scopeDisposedEvent.subscribe(hook));
+    this.registeredEvent.getListeners().forEach((hook) => scope.registeredEvent.subscribe(hook));
 
     for (const registration of this.getRegistrations()) {
       registration.applyTo(scope);
@@ -219,30 +217,6 @@ export class Container implements IContainer {
 
   hasRegistration(key: DependencyKey): boolean {
     return this.registrations.some((r) => r.getKeyOrFail() === key) || this.parent.hasRegistration(key);
-  }
-
-  /**
-   * @throws {TypedEventDisposedError} when the container has already been disposed.
-   */
-  onScopeCreated(...hooks: ScopeHook[]): this {
-    hooks.forEach((hook) => this.scopeCreatedEvent.subscribe(hook));
-    return this;
-  }
-
-  /**
-   * @throws {TypedEventDisposedError} when the container has already been disposed.
-   */
-  onScopeDisposed(...hooks: ScopeHook[]): this {
-    hooks.forEach((hook) => this.scopeDisposedEvent.subscribe(hook));
-    return this;
-  }
-
-  /**
-   * @throws {TypedEventDisposedError} when the container has already been disposed.
-   */
-  onRegistered(...hooks: RegisteredHook[]): this {
-    hooks.forEach((hook) => this.registeredEvent.subscribe(hook));
-    return this;
   }
 
   addInstance(instance: Instance) {

--- a/packages/ts-ioc-container/lib/container/Container.ts
+++ b/packages/ts-ioc-container/lib/container/Container.ts
@@ -22,6 +22,7 @@ import { unwrapProxy } from '../utils/ProxyRegistry';
 import { DependencyNotFoundError } from '../errors/DependencyNotFoundError';
 import { constructor, Instance, Is } from '../utils/basic';
 import { Filter as F } from '../utils/array';
+import { type ITypedEvent, TypedEvent } from '../utils/TypedEvent';
 
 export class Container implements IContainer {
   isDisposed = false;
@@ -34,9 +35,14 @@ export class Container implements IContainer {
   private readonly aliases = new AliasMap();
   private readonly injector: IInjector;
 
-  private readonly onScopeCreatedHookList: ScopeHook[] = [];
-  private readonly onScopeDisposedHookList: ScopeHook[] = [];
-  private readonly onRegisteredHookList: RegisteredHook[] = [];
+  // The concrete events stay private so `emit` is this container's alone; the
+  // public properties expose the subscriber's side only.
+  private readonly scopeCreatedEvent = new TypedEvent<[IContainer]>();
+  private readonly scopeDisposedEvent = new TypedEvent<[IContainer]>();
+  private readonly registeredEvent = new TypedEvent<[IProvider, DependencyKey, IContainer]>();
+  readonly scopeCreated: ITypedEvent<[IContainer]> = this.scopeCreatedEvent;
+  readonly scopeDisposed: ITypedEvent<[IContainer]> = this.scopeDisposedEvent;
+  readonly registered: ITypedEvent<[IProvider, DependencyKey, IContainer]> = this.registeredEvent;
 
   constructor(
     options: {
@@ -59,9 +65,7 @@ export class Container implements IContainer {
     this.aliases.setAliasesByKey(key, aliases);
 
     // Hooks run once the provider and its aliases are in place, so they observe a resolvable key.
-    for (const onRegistered of this.onRegisteredHookList) {
-      onRegistered(provider, key, this);
-    }
+    this.registeredEvent.emit(provider, key, this);
 
     return this;
   }
@@ -137,9 +141,9 @@ export class Container implements IContainer {
 
     // Injector hooks need no copying - the child shares this scope's injector, so it shares its hooks.
     const scope = new Container({ injector: this.injector, parent: this, tags })
-      .onScopeCreated(...this.onScopeCreatedHookList)
-      .onScopeDisposed(...this.onScopeDisposedHookList)
-      .onRegistered(...this.onRegisteredHookList);
+      .onScopeCreated(...this.scopeCreatedEvent.getListeners())
+      .onScopeDisposed(...this.scopeDisposedEvent.getListeners())
+      .onRegistered(...this.registeredEvent.getListeners());
 
     for (const registration of this.getRegistrations()) {
       registration.applyTo(scope);
@@ -147,9 +151,7 @@ export class Container implements IContainer {
     this.scopes.push(scope);
 
     // Hooks run once the scope is fully registered and attached, so they observe a usable scope.
-    for (const onScopeCreated of this.onScopeCreatedHookList) {
-      onScopeCreated(scope);
-    }
+    this.scopeCreatedEvent.emit(scope);
 
     return scope;
   }
@@ -180,10 +182,7 @@ export class Container implements IContainer {
     this.validateContainer();
     this.isDisposed = true;
 
-    // Execute onScopeDisposed hooks
-    for (const onScopeDisposed of this.onScopeDisposedHookList) {
-      onScopeDisposed(this);
-    }
+    this.scopeDisposedEvent.emit(this);
 
     // Detach from parent
     this.parent.removeScope(this);
@@ -198,10 +197,10 @@ export class Container implements IContainer {
     this.instances.clear();
     this.registrations = [];
 
-    // Clear hooks. Injector hooks are not this scope's to clear - the injector outlives it.
-    this.onScopeCreatedHookList.length = 0;
-    this.onScopeDisposedHookList.length = 0;
-    this.onRegisteredHookList.length = 0;
+    // Dispose scope events. Injector hooks are not this scope's to clear - the injector outlives it.
+    this.scopeCreatedEvent.dispose();
+    this.scopeDisposedEvent.dispose();
+    this.registeredEvent.dispose();
   }
 
   addRegistration(registration: IRegistration): this {
@@ -222,18 +221,27 @@ export class Container implements IContainer {
     return this.registrations.some((r) => r.getKeyOrFail() === key) || this.parent.hasRegistration(key);
   }
 
+  /**
+   * @throws {TypedEventDisposedError} when the container has already been disposed.
+   */
   onScopeCreated(...hooks: ScopeHook[]): this {
-    this.onScopeCreatedHookList.push(...hooks);
+    hooks.forEach((hook) => this.scopeCreatedEvent.subscribe(hook));
     return this;
   }
 
+  /**
+   * @throws {TypedEventDisposedError} when the container has already been disposed.
+   */
   onScopeDisposed(...hooks: ScopeHook[]): this {
-    this.onScopeDisposedHookList.push(...hooks);
+    hooks.forEach((hook) => this.scopeDisposedEvent.subscribe(hook));
     return this;
   }
 
+  /**
+   * @throws {TypedEventDisposedError} when the container has already been disposed.
+   */
   onRegistered(...hooks: RegisteredHook[]): this {
-    this.onRegisteredHookList.push(...hooks);
+    hooks.forEach((hook) => this.registeredEvent.subscribe(hook));
     return this;
   }
 

--- a/packages/ts-ioc-container/lib/container/EmptyContainer.ts
+++ b/packages/ts-ioc-container/lib/container/EmptyContainer.ts
@@ -15,6 +15,7 @@ import { type IProvider } from '../provider/IProvider';
 import { type IRegistration } from '../registration/IRegistration';
 import { type constructor, type Instance } from '../utils/basic';
 import { type IInjector } from '../injector/IInjector';
+import { type ITypedEvent } from '../utils/TypedEvent';
 
 export class EmptyContainer implements IContainer {
   /**
@@ -131,6 +132,27 @@ export class EmptyContainer implements IContainer {
    */
   resolveOneByAlias<T>(alias: DependencyKey, options?: ResolveOneOptions): T {
     throw new DependencyNotFoundError(`Cannot find alias ${alias.toString()}`);
+  }
+
+  /**
+   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
+   */
+  get scopeCreated(): ITypedEvent<[IContainer]> {
+    throw new MethodNotImplementedError();
+  }
+
+  /**
+   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
+   */
+  get scopeDisposed(): ITypedEvent<[IContainer]> {
+    throw new MethodNotImplementedError();
+  }
+
+  /**
+   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
+   */
+  get registered(): ITypedEvent<[IProvider, DependencyKey, IContainer]> {
+    throw new MethodNotImplementedError();
   }
 
   /**

--- a/packages/ts-ioc-container/lib/container/EmptyContainer.ts
+++ b/packages/ts-ioc-container/lib/container/EmptyContainer.ts
@@ -3,8 +3,6 @@ import {
   type DependencyKey,
   type IContainer,
   type IContainerModule,
-  type ScopeHook,
-  type RegisteredHook,
   type ResolveManyOptions,
   type ResolveOneOptions,
   type Tag,
@@ -152,27 +150,6 @@ export class EmptyContainer implements IContainer {
    * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
    */
   get registered(): ITypedEvent<[IProvider, DependencyKey, IContainer]> {
-    throw new MethodNotImplementedError();
-  }
-
-  /**
-   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
-   */
-  onScopeCreated(...hooks: ScopeHook[]): this {
-    throw new MethodNotImplementedError();
-  }
-
-  /**
-   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
-   */
-  onScopeDisposed(...hooks: ScopeHook[]): this {
-    throw new MethodNotImplementedError();
-  }
-
-  /**
-   * @throws {MethodNotImplementedError} always — the empty container cannot hold hooks.
-   */
-  onRegistered(...hooks: RegisteredHook[]): this {
     throw new MethodNotImplementedError();
   }
 }

--- a/packages/ts-ioc-container/lib/container/IContainer.ts
+++ b/packages/ts-ioc-container/lib/container/IContainer.ts
@@ -2,6 +2,7 @@ import { type IProvider, ProviderOptions } from '../provider/IProvider';
 import { type IRegistration } from '../registration/IRegistration';
 import { IInjector, type WithArgs } from '../injector/IInjector';
 import { type constructor, Instance } from '../utils/basic';
+import { type ITypedEvent } from '../utils/TypedEvent';
 
 export type DependencyKey = string | symbol;
 export function isDependencyKey(target: unknown): target is DependencyKey {
@@ -52,10 +53,35 @@ export type RegisteredHook = (provider: IProvider, key: DependencyKey, scope: IC
 export interface IContainer extends Tagged {
   readonly isDisposed: boolean;
 
+  /**
+   * Raised once a scope this container created is fully registered and attached.
+   * The subscriber's side only - a container raises its own scope events.
+   */
+  readonly scopeCreated: ITypedEvent<[IContainer]>;
+
+  /**
+   * Raised by this container as it disposes, before its providers and instances go.
+   */
+  readonly scopeDisposed: ITypedEvent<[IContainer]>;
+
+  /**
+   * Raised once a provider is registered here under a resolvable key.
+   */
+  readonly registered: ITypedEvent<[IProvider, DependencyKey, IContainer]>;
+
+  /**
+   * Sugar over `scopeCreated.subscribe(...)` for fluent setup.
+   */
   onScopeCreated(...hooks: ScopeHook[]): this;
 
+  /**
+   * Sugar over `scopeDisposed.subscribe(...)` for fluent setup.
+   */
   onScopeDisposed(...hooks: ScopeHook[]): this;
 
+  /**
+   * Sugar over `registered.subscribe(...)` for fluent setup.
+   */
   onRegistered(...hooks: RegisteredHook[]): this;
 
   register(key: DependencyKey, value: IProvider, options?: RegisterOptions): this;

--- a/packages/ts-ioc-container/lib/container/IContainer.ts
+++ b/packages/ts-ioc-container/lib/container/IContainer.ts
@@ -33,7 +33,7 @@ export type RegisterOptions = { aliases?: DependencyKey[] };
 
 /**
  * Scope event hooks - the container's own domain: a scope was created, a scope
- * was disposed.
+ * was disposed. The listener type of `IContainer.scopeCreated` / `scopeDisposed`.
  *
  * The other two hook domains live with the abstraction which raises them:
  * injector hooks on `IInjector` (`InjectorHook`), provider hooks on
@@ -46,7 +46,7 @@ export type ScopeHook = (scope: IContainer) => void;
 /**
  * Scope event hook for a registration landing in a scope: a provider entered
  * the provider map under `key`. Registration is always of a provider, so the
- * name says only what varies.
+ * name says only what varies. The listener type of `IContainer.registered`.
  */
 export type RegisteredHook = (provider: IProvider, key: DependencyKey, scope: IContainer) => void;
 
@@ -68,21 +68,6 @@ export interface IContainer extends Tagged {
    * Raised once a provider is registered here under a resolvable key.
    */
   readonly registered: ITypedEvent<[IProvider, DependencyKey, IContainer]>;
-
-  /**
-   * Sugar over `scopeCreated.subscribe(...)` for fluent setup.
-   */
-  onScopeCreated(...hooks: ScopeHook[]): this;
-
-  /**
-   * Sugar over `scopeDisposed.subscribe(...)` for fluent setup.
-   */
-  onScopeDisposed(...hooks: ScopeHook[]): this;
-
-  /**
-   * Sugar over `registered.subscribe(...)` for fluent setup.
-   */
-  onRegistered(...hooks: RegisteredHook[]): this;
 
   register(key: DependencyKey, value: IProvider, options?: RegisterOptions): this;
 

--- a/packages/ts-ioc-container/lib/errors/TypedEventDisposedError.ts
+++ b/packages/ts-ioc-container/lib/errors/TypedEventDisposedError.ts
@@ -1,0 +1,20 @@
+import { ContainerError } from './ContainerError';
+
+export class TypedEventDisposedError extends ContainerError {
+  name = 'TypedEventDisposedError';
+
+  /**
+   * @throws {TypedEventDisposedError} when `isTrue` is falsy.
+   */
+  static assert(isTrue: boolean, failMessage: string) {
+    if (!isTrue) {
+      throw new TypedEventDisposedError(failMessage);
+    }
+  }
+
+  constructor(message: string) {
+    super(message);
+
+    Object.setPrototypeOf(this, TypedEventDisposedError.prototype);
+  }
+}

--- a/packages/ts-ioc-container/lib/hooks/onResolved.ts
+++ b/packages/ts-ioc-container/lib/hooks/onResolved.ts
@@ -21,8 +21,8 @@ const runHooks =
 /**
  * Runs `onResolved` hooks every time a dependency object leaves a provider, the
  * way `strategy` defines (key it to `onResolved`).
- * Providers are hooked through `onRegistered`, so apply the module before the
- * registrations it should cover; scopes created afterwards inherit it.
+ * Providers are hooked through the `registered` event, so apply the module before
+ * the registrations it should cover; scopes created afterwards inherit it.
  */
 export class OnResolvedModule implements IContainerModule {
   private readonly runHooks: ProviderHook;
@@ -32,7 +32,7 @@ export class OnResolvedModule implements IContainerModule {
   }
 
   applyTo(container: IContainer) {
-    container.onRegistered((provider) => {
+    container.registered.subscribe((provider) => {
       provider.onResolved(this.runHooks);
     });
   }

--- a/packages/ts-ioc-container/lib/hooks/onScopeDisposed.ts
+++ b/packages/ts-ioc-container/lib/hooks/onScopeDisposed.ts
@@ -10,14 +10,14 @@ export const onScopeDisposed = (...fns: HookType[]) => hook('onScopeDisposed', p
  * Runs the `@onScopeDisposed` hooks of every instance of a scope being disposed,
  * the way `strategy` defines (key it to `onScopeDisposed`).
  *
- * Disposal is a scope event, so the module hangs off `IContainer.onScopeDisposed`.
+ * Disposal is a scope event, so the module hangs off `IContainer.scopeDisposed`.
  * Disposal is local: disposing a parent runs no child-scope hooks.
  */
 export class OnDisposeModule implements IContainerModule {
   constructor(private readonly strategy: HookExecutionStrategy) {}
 
   applyTo(container: IContainer) {
-    container.onScopeDisposed((scope) => {
+    container.scopeDisposed.subscribe((scope) => {
       for (const instance of scope.getInstances()) {
         this.strategy.execute(instance, { scope });
       }

--- a/packages/ts-ioc-container/lib/index.ts
+++ b/packages/ts-ioc-container/lib/index.ts
@@ -82,6 +82,7 @@ export { ContainerDisposedError } from './errors/ContainerDisposedError';
 export { ProviderDisposedError } from './errors/ProviderDisposedError';
 export { CannonSingletonApplyTwiceError } from './errors/CannonSingletonApplyTwiceError';
 export { UnsupportedTokenTypeError } from './errors/UnsupportedTokenTypeError';
+export { TypedEventDisposedError } from './errors/TypedEventDisposedError';
 
 // Hooks
 export {
@@ -164,6 +165,7 @@ export { throttle } from './utils/throttle';
 export { debounce } from './utils/debounce';
 export { shallowCache } from './utils/shallowCache';
 export { once } from './utils/once';
+export { TypedEvent, type ITypedEvent, type TypedEventListener, type Unsubscribe } from './utils/TypedEvent';
 
 // Execution
 export { type ExecutionContext } from './ExecutionContext';

--- a/packages/ts-ioc-container/lib/utils/TypedEvent.ts
+++ b/packages/ts-ioc-container/lib/utils/TypedEvent.ts
@@ -1,0 +1,93 @@
+import { TypedEventDisposedError } from '../errors/TypedEventDisposedError';
+
+export type TypedEventListener<TArgs extends unknown[]> = (...args: TArgs) => void;
+
+export type Unsubscribe = () => void;
+
+/**
+ * The subscriber's side of a {@link TypedEvent}: attach, detach, tear down.
+ * Hand this out instead of the event itself so that only the owner can `emit`.
+ */
+export interface ITypedEvent<TArgs extends unknown[]> {
+  /**
+   * Attaches `listener` and returns a function which detaches it again. A
+   * listener subscribed more than once is still delivered each emission once.
+   *
+   * @throws {TypedEventDisposedError} when the event has already been disposed.
+   */
+  subscribe(listener: TypedEventListener<TArgs>): Unsubscribe;
+
+  /**
+   * Detaches `listener`. Harmless when it is not subscribed, or after `dispose`.
+   */
+  unsubscribe(listener: TypedEventListener<TArgs>): void;
+
+  /**
+   * Detaches every listener and rejects further `subscribe` / `emit` calls.
+   */
+  dispose(): void;
+}
+
+/**
+ * A typed, multi-listener event. `TArgs` is the argument list a listener
+ * receives, so a `TypedEvent<[IContainer]>` accepts `(scope: IContainer) => void`
+ * listeners unchanged.
+ *
+ * Emission delivers to the listeners subscribed at the moment `emit` is called,
+ * in subscription order. A listener detached mid-emission is skipped for the
+ * rest of that emission; one attached mid-emission receives only later ones.
+ */
+export class TypedEvent<TArgs extends unknown[] = []> implements ITypedEvent<TArgs> {
+  private readonly listeners = new Set<TypedEventListener<TArgs>>();
+  private isDisposed = false;
+
+  /**
+   * @throws {TypedEventDisposedError} when the event has already been disposed.
+   */
+  subscribe(listener: TypedEventListener<TArgs>): Unsubscribe {
+    this.validate();
+    this.listeners.add(listener);
+    return () => this.unsubscribe(listener);
+  }
+
+  unsubscribe(listener: TypedEventListener<TArgs>): void {
+    this.listeners.delete(listener);
+  }
+
+  /**
+   * Calls every current listener with `args`. What a listener throws surfaces
+   * out of `emit` and stops delivery to the listeners after it.
+   *
+   * @throws {TypedEventDisposedError} when the event has already been disposed.
+   * @throws {unknown} rethrows whatever a listener threw.
+   */
+  emit(...args: TArgs): void {
+    this.validate();
+    // Iterate a snapshot so a listener can (un)subscribe without disturbing this emission;
+    // a listener detached mid-emission is still skipped for the rest of it.
+    for (const listener of [...this.listeners]) {
+      if (this.listeners.has(listener)) {
+        listener(...args);
+      }
+    }
+  }
+
+  /**
+   * A copy of the current listeners, in subscription order.
+   */
+  getListeners(): TypedEventListener<TArgs>[] {
+    return [...this.listeners];
+  }
+
+  dispose(): void {
+    this.listeners.clear();
+    this.isDisposed = true;
+  }
+
+  /**
+   * @throws {TypedEventDisposedError} when the event has already been disposed.
+   */
+  private validate(): void {
+    TypedEventDisposedError.assert(!this.isDisposed, 'TypedEvent is already disposed');
+  }
+}

--- a/packages/ts-ioc-container/specs/epics/errors-and-boundaries.md
+++ b/packages/ts-ioc-container/specs/epics/errors-and-boundaries.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0001 - Container as a linked list of scopes](../../docs/adr/0001-container-as-linked-list.md)
-- **Public API:** `DependencyNotFoundError`, `DependencyMissingKeyError`, `ContainerDisposedError`, `MethodNotImplementedError`, `UnsupportedTokenTypeError`, `ContainerNotFoundError`, `EmptyContainer`
+- **Public API:** `DependencyNotFoundError`, `DependencyMissingKeyError`, `ContainerDisposedError`, `MethodNotImplementedError`, `UnsupportedTokenTypeError`, `ContainerNotFoundError`, `TypedEventDisposedError`, `EmptyContainer`
 - **Executable spec:** `__tests__/specs/errors-and-boundaries.spec.ts`
 
 ## Intent
@@ -48,6 +48,8 @@ Acceptance criteria:
 - Registering in a disposed container fails with `ContainerDisposedError`.
 - Creating a scope from a disposed container fails with
   `ContainerDisposedError`.
+- Subscribing to or emitting on a disposed `TypedEvent` fails with
+  `TypedEventDisposedError`.
 
 ### Story: Reject unsupported token operations
 

--- a/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
+++ b/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
@@ -121,6 +121,13 @@ Acceptance criteria:
   ScopeHook[])`, `onScopeDisposed(...hooks: ScopeHook[])` and
   `onRegistered(...hooks: RegisteredHook[])`, each returning the
   container for fluent chaining.
+- The same scope events are exposed on `IContainer` as typed events —
+  `scopeCreated`, `scopeDisposed` (`ITypedEvent<[IContainer]>`) and
+  `registered` (`ITypedEvent<[IProvider, DependencyKey, IContainer]>`) — so a
+  hook can be detached with the function `subscribe` returns, or with
+  `unsubscribe`. The fluent `onX(...hooks)` methods are sugar over `subscribe`.
+- The exposed events carry no `emit`: only the container raises its own scope
+  events.
 - Construction is registered on `IInjector`: `onConstructed(...hooks:
   InjectorHook[])`, reached through `container.getInjector()` or configured
   before the injector is passed to `new Container({ injector })`.
@@ -136,7 +143,7 @@ Acceptance criteria:
   whenever it was added.
 - Disposing a scope clears its own scope hooks and leaves the shared injector's
   hooks intact.
-- `EmptyContainer` rejects every scope hook method with
+- `EmptyContainer` rejects every scope hook method and scope event with
   `MethodNotImplementedError`.
 
 ### Story: Choose how hooks run

--- a/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
+++ b/packages/ts-ioc-container/specs/epics/lifecycle-hooks.md
@@ -117,15 +117,11 @@ hook is registered says which domain owns it.
 
 Acceptance criteria:
 
-- Scope events are registered on `IContainer`: `onScopeCreated(...hooks:
-  ScopeHook[])`, `onScopeDisposed(...hooks: ScopeHook[])` and
-  `onRegistered(...hooks: RegisteredHook[])`, each returning the
-  container for fluent chaining.
-- The same scope events are exposed on `IContainer` as typed events —
-  `scopeCreated`, `scopeDisposed` (`ITypedEvent<[IContainer]>`) and
-  `registered` (`ITypedEvent<[IProvider, DependencyKey, IContainer]>`) — so a
-  hook can be detached with the function `subscribe` returns, or with
-  `unsubscribe`. The fluent `onX(...hooks)` methods are sugar over `subscribe`.
+- Scope events are exposed on `IContainer` as typed events — `scopeCreated`,
+  `scopeDisposed` (`ITypedEvent<[IContainer]>`) and `registered`
+  (`ITypedEvent<[IProvider, DependencyKey, IContainer]>`). A hook is attached
+  with `subscribe` and detached with the function it returns, or with
+  `unsubscribe`. There are no fluent `onX(...hooks)` methods on the container.
 - The exposed events carry no `emit`: only the container raises its own scope
   events.
 - Construction is registered on `IInjector`: `onConstructed(...hooks:
@@ -143,8 +139,7 @@ Acceptance criteria:
   whenever it was added.
 - Disposing a scope clears its own scope hooks and leaves the shared injector's
   hooks intact.
-- `EmptyContainer` rejects every scope hook method and scope event with
-  `MethodNotImplementedError`.
+- `EmptyContainer` rejects every scope event with `MethodNotImplementedError`.
 
 ### Story: Choose how hooks run
 

--- a/packages/ts-ioc-container/specs/epics/metadata-utilities.md
+++ b/packages/ts-ioc-container/specs/epics/metadata-utilities.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **ADR:** [ADR 0008 - Zero runtime dependencies](../../docs/adr/0008-zero-runtime-dependencies.md)
-- **Public API:** `addClassMeta`, `getClassMeta`, `addClassLabel`, `getClassLabels`, `addClassTag`, `getClassTags`, `addParamMeta`, `getParamMeta`, `addParamLabel`, `getParamLabels`, `addParamTag`, `getParamTags`, `addMethodMeta`, `getMethodMeta`, `addMethodLabel`, `getMethodLabels`, `addMethodTag`, `getMethodTags`, `once`, `debounce`, `throttle`, `shallowCache`, `handleError`, `handleAsyncError`
+- **Public API:** `addClassMeta`, `getClassMeta`, `addClassLabel`, `getClassLabels`, `addClassTag`, `getClassTags`, `addParamMeta`, `getParamMeta`, `addParamLabel`, `getParamLabels`, `addParamTag`, `getParamTags`, `addMethodMeta`, `getMethodMeta`, `addMethodLabel`, `getMethodLabels`, `addMethodTag`, `getMethodTags`, `once`, `debounce`, `throttle`, `shallowCache`, `handleError`, `handleAsyncError`, `TypedEvent`, `ITypedEvent`
 - **Executable spec:** `__tests__/specs/metadata-utilities.spec.ts`
 
 ## Intent
@@ -62,6 +62,28 @@ Acceptance criteria:
 - `shallowCache` caches results per instance and computed argument key.
 - `throttle` blocks calls inside the configured time window per instance.
 - `debounce` delays execution and keeps the latest call in the debounce window.
+
+### Story: Publish typed events
+
+As an application developer, I can expose a typed event so that subscribers
+receive strongly typed payloads and can detach without holding a reference to
+the emitter's internals.
+
+Acceptance criteria:
+
+- `subscribe` registers a listener and returns a function that unsubscribes
+  it; calling that function more than once is harmless.
+- `emit` delivers the payload to every current listener in subscription order.
+- `unsubscribe` detaches a listener by reference; unsubscribing a listener that
+  was never subscribed is harmless.
+- Subscribing the same listener twice delivers each emission to it once.
+- A listener detached while an emission is in progress does not receive that
+  emission after it has been detached, and a listener attached during an
+  emission receives only later emissions.
+- `dispose` detaches every listener; subscribing to or emitting on a disposed
+  event fails with `TypedEventDisposedError`, and unsubscribing stays harmless.
+- `ITypedEvent` exposes `subscribe`, `unsubscribe`, and `dispose` only, so an
+  owner can hand out the event without handing out `emit`.
 
 ### Story: Handle method errors
 


### PR DESCRIPTION
## Summary

- **`TypedEvent<TArgs>`** (`lib/utils/TypedEvent.ts`) — a small typed multi-listener event. `ITypedEvent` is the subscriber-only view: `subscribe(listener)` returns the unsubscribe function, plus `unsubscribe` and `dispose`. The class adds `emit(...args)` and `getListeners()`. It is variadic (`TypedEvent<[IContainer]>`) so the existing `ScopeHook` / `RegisteredHook` listener signatures fit unchanged.
- **`TypedEventDisposedError`** — `subscribe`/`emit` on a disposed event throw it; `unsubscribe` stays harmless. Follows the `ContainerDisposedError` / `ProviderDisposedError` convention.
- **`IContainer` exposes its scope events**: `scopeCreated`, `scopeDisposed` (`ITypedEvent<[IContainer]>`) and `registered` (`ITypedEvent<[IProvider, DependencyKey, IContainer]>`). They are typed as `ITypedEvent`, so consumers can attach and detach hooks but only the container can `emit` (the concrete events are private fields; an `expectTypeOf(...).not.toHaveProperty('emit')` assertion pins that).
- **BREAKING:** the fluent `onScopeCreated(...)`, `onScopeDisposed(...)` and `onRegistered(...)` methods are **removed** from `IContainer`, `Container` and `EmptyContainer`. Migrate with `container.scopeCreated.subscribe(hook)` etc. `EmptyContainer` throws `MethodNotImplementedError` from the three getters, as it did from the methods.
- `AutoResolveModule`, `OnDisposeModule`, `OnResolvedModule` and `createScope`'s listener copy go through the events directly. Child scopes still receive a copy of the parent's listeners at `createScope` time; `dispose` disposes the events.

## Migration

```ts
// before
new Container().onScopeCreated(a).onScopeDisposed(b).onRegistered(c);

// after
const container = new Container();
container.scopeCreated.subscribe(a);
const stop = container.scopeDisposed.subscribe(b); // stop() detaches
container.registered.subscribe(c);
```

## Why

There was no way to remove a scope hook once added — the hook lists were private arrays. Exposing them as typed events gives unsubscription, and having one way to attach (the event) rather than two keeps the API small. `TypedEvent` is generally useful on its own, so it is exported.

## Reviewer notes

- Calling `subscribe` on a *disposed* container's event throws `TypedEventDisposedError`; before, the removed methods silently pushed into a dead list.
- Spec-driven (ADR 0011): stories updated in `metadata-utilities.md`, `lifecycle-hooks.md`, `errors-and-boundaries.md` with matching scenarios in `__tests__/specs/`; listeners are mocked with moq.ts.
- `emit` iterates a snapshot of the listener set, so a listener can (un)subscribe mid-emission; a listener detached mid-emission is skipped for the rest of it.
- README hook-domains section and `CLAUDE.md` updated; `README.md` regenerated. The stale root `README.md` copy that the pre-commit hook keeps trying to regenerate is deliberately left out of this PR.

## Verification

- `pnpm run type-check`, `pnpm test` (483/483), `pnpm run lint` (0 errors) for the core package
- `pnpm run build` then `type-check:react`, `test:react` (14/14), `lint:react` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)