### PR TITLE
ci: extract test job from build job in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,59 @@ jobs:
       - name: Install dependencies
         run: pnpm run ci
 
+      - name: Build
+        run: pnpm run build:all
+
+      - name: Upload build artifacts
+        uses: ./.github/actions/build-artifacts
+        with:
+          mode: upload
+
+  # Lint, type-check, format and test every released package. Runs after
+  # `build` rather than beside it: @ts-ioc-container/react resolves
+  # ts-ioc-container through the workspace link, so its checks import that
+  # package's build output rather than a tarball from the registry — the
+  # artifact `build` uploaded supplies it without a second build here.
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    env:
+      NODE_ENV: test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Cache pnpm store
+        uses: ./.github/actions/cache-pnpm-store
+
+      - name: Install dependencies
+        run: pnpm run ci
+
+      - name: Download build artifacts
+        uses: ./.github/actions/build-artifacts
+        with:
+          mode: download
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Type check
+        run: pnpm run type-check
+
+      - name: Format check
+        run: pnpm run format:check
+
       - name: Test with coverage
         run: pnpm run test:coverage
 
@@ -47,22 +100,20 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ./packages/ts-ioc-container/coverage/lcov.info
 
-      # Must precede the react tests: @ts-ioc-container/react resolves
-      # ts-ioc-container through the workspace link, so it imports that
-      # package's build output rather than a tarball from the registry.
-      - name: Build
-        run: pnpm run build:all
+      - name: Lint @ts-ioc-container/react
+        run: pnpm run lint:react
+
+      - name: Type check @ts-ioc-container/react
+        run: pnpm run type-check:react
+
+      - name: Format check @ts-ioc-container/react
+        run: pnpm --filter @ts-ioc-container/react run format:check
 
       - name: Test @ts-ioc-container/react
         run: pnpm run test:react
 
-      - name: Upload build artifacts
-        uses: ./.github/actions/build-artifacts
-        with:
-          mode: upload
-
   release:
-    needs: build
+    needs: [build, test]
     environment:
       name: production
       url: https://www.npmjs.com/package/ts-ioc-container

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,8 +140,9 @@ consumers still receive an exact version. `peerDependencies` stays a range
 **Consequence for CI ordering:** react resolves the container through the
 workspace link, so it imports that package's *build output*. `pnpm run build`
 must therefore run before any react lint / type-check / test step — see the
-build steps in `pr-checks.yml` and `publish.yml`. Without it those steps fail
-to resolve `ts-ioc-container` at all.
+build step in `pr-checks.yml`, and in `publish.yml` the `test` job's
+`needs: build` plus its download of the build artifact. Without it those steps
+fail to resolve `ts-ioc-container` at all.
 
 ### Known `release-monorepo-semantically` defects
 


### PR DESCRIPTION
## Description

The `publish.yml` workflow's `build` job did three unrelated things: ran the core test suite with coverage, built every package, and ran the react tests. This splits it into two jobs:

- **`build`** — installs, runs `pnpm run build:all`, uploads the build artifact. Nothing else.
- **`test`** (new) — lint, type-check, format check and tests for both `ts-ioc-container` and `@ts-ioc-container/react`, plus the Coveralls upload.

Linting now lives in the `test` job. The publish workflow previously ran no lint, type-check or format check at all, so a lint regression could only ever be caught on the PR — now `main` gates the release on it too.

`test` declares `needs: build` and downloads the build artifact instead of rebuilding: `@ts-ioc-container/react` resolves `ts-ioc-container` through the workspace link, so its lint / type-check / test steps need that package's build output on disk. Reusing the uploaded artifact keeps that dependency satisfied without a second build.

`release` now declares `needs: [build, test]`.

Also updated the "Consequence for CI ordering" note in `CLAUDE.md` to describe the new job wiring.

## Type of change

- [ ] `feat` — new feature (minor release)
- [ ] `fix` / `perf` — bug fix or performance improvement (patch release)
- [ ] `BREAKING CHANGE` — incompatible API change (major release)
- [x] `docs` / `test` / `ci` / `chore` / `refactor` / `style` — no package release

## Checklist

- [x] Source edited only under `lib/` (not `cjm/`, `esm/`, or `typings/`) — n/a, CI config and docs only
- [x] `README.md` regenerated via `pnpm run generate:docs` if `.readme.hbs.md` changed — n/a, unchanged
- [x] Tests added or updated under `__tests__/` to cover the change — n/a, no library code changed
- [x] `pnpm run lint` passes — n/a, no source changed; the workflow YAML parses and the job graph was verified
- [x] `pnpm run type-check` passes — n/a, no source changed
- [x] `pnpm test` passes — n/a, no source changed
- [x] Commit messages follow Conventional Commits with the correct release/non-release scope (`ci:`, non-release)

## Additional notes

- Step names and commands are unchanged; only their job placement moved, plus the newly added lint / type-check / format steps.
- `pr-checks.yml` is untouched — it already runs every one of these checks in a single job, and has no separate `build` job to split.
- Trade-off: the `test` job repeats checkout / setup / `pnpm install`, so the workflow uses one more runner. In exchange the two jobs report independently and `test` no longer blocks on being in the same runner as the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhvHmuva1gvFMhkYmuqSn5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhvHmuva1gvFMhkYmuqSn5)_